### PR TITLE
[AssetMapper] Document how to use local npm packages

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -306,6 +306,51 @@ that your ``assets/vendor/`` directory is in sync with the updated import map:
     references to it in your JavaScript files. Make sure to update your code and
     remove any ``import`` statements that reference the removed package.
 
+Using Local npm Packages
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, ``importmap:require`` downloads packages from a CDN. If you prefer
+to install packages locally via npm (e.g. to use a specific build or a package
+not available on the CDN), you can point AssetMapper to your ``node_modules/``
+directory.
+
+First, install the package with npm and register the directory containing its
+browser-compatible files in your AssetMapper paths:
+
+.. code-block:: yaml
+
+    # config/packages/asset_mapper.yaml
+    framework:
+        asset_mapper:
+            paths:
+                assets/: ''
+                node_modules/@hpcc-js/wasm/dist/: 'hpcc'
+
+Using a namespace (like ``hpcc``) for registered folders is highly recommended
+to avoid collisions in logical paths. For example, if both ``assets/`` and
+``node_modules/@hpcc-js/wasm/dist/`` contain an ``index.js`` file, only one
+of them would be mapped without namespaces.
+
+Then, require the package in the importmap using the ``--path`` option to point
+to the local file using its logical path:
+
+.. code-block:: terminal
+
+    $ php bin/console importmap:require @hpcc-js/wasm --path=hpcc/index.js
+
+Now you can import the package as usual:
+
+.. code-block:: javascript
+
+    import { Graphviz } from '@hpcc-js/wasm';
+
+.. note::
+
+    Only the registered directories are served by AssetMapper. All relative
+    imports inside those directories are resolved automatically. Make sure
+    the registered directory includes every file the package needs for its
+    browser imports.
+
 How does the importmap Work?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes #22000

Documents how to use AssetMapper with local npm packages from `node_modules/` instead of the CDN, by:

- Registering the package's browser-compatible directory in `asset_mapper.paths`
- Using `importmap:require --path` to point to the local file