### PR TITLE
[Form] Document the uid_format option of EntityType

### DIFF
--- a/reference/forms/types/entity.rst
+++ b/reference/forms/types/entity.rst
@@ -191,6 +191,35 @@ loading all entities.
     one used in your ``FROM`` clause (for instance if you return an entity
     from a joined table), it will break validation.
 
+``uid_format``
+~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``null``
+
+When the entity identifier is a :doc:`UID </components/uid>` (ULID or UUID),
+this option controls how the UID is rendered as a choice value. By default
+(``null``), ULIDs are rendered in Base32 and UUIDs in RFC 4122 format (via
+``__toString()``).
+
+Set this option to use a different format:
+
+* ``base32`` - renders the UID in Base32 format (e.g. ``01ARZ3NDEKTSV4RRFFQ69G5FAV``)
+* ``base58`` - renders the UID in Base58 format (e.g. ``1BKocMc5BnhMpSSENfEptz``)
+* ``rfc4122`` - renders the UID in RFC 4122 format (e.g. ``550e8400-e29b-41d4-a716-446655440000``)
+
+Example::
+
+    use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+
+    $builder->add('category', EntityType::class, [
+        'class' => Category::class,
+        'uid_format' => 'base58',
+    ]);
+
+.. versionadded:: 8.1
+
+    The ``uid_format`` option was introduced in Symfony 8.1.
+
 Overridden Options
 ------------------
 


### PR DESCRIPTION
Fixes #22003

Documents the new `uid_format` option added to `EntityType` in Symfony 8.1 (symfony/symfony#63371).

This option controls how UID identifiers (ULID/UUID) are rendered as choice values, supporting `base32`, `base58` and `rfc4122` formats.