### PR TITLE
 Document the form_flow_* Twig helper functions

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -649,6 +649,18 @@ explained in the article about :doc:`customizing form rendering </form/form_cust
 * :ref:`field_help() <reference-forms-twig-field-helpers>`
 * :ref:`field_errors() <reference-forms-twig-field-helpers>`
 * :ref:`field_choices() <reference-forms-twig-field-helpers>`
+* :ref:`form_flow_current_step() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_total_steps() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_steps() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_step_index() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_next_step() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_previous_step() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_first_step() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_last_step() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_is_first_step() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_is_last_step() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_can_move_back() <reference-forms-twig-form-flow>`
+* :ref:`form_flow_can_move_next() <reference-forms-twig-form-flow>`
 
 .. _reference-twig-filters:
 


### PR DESCRIPTION
Fixes #21994

Documents the 12 new `form_flow_*` Twig functions introduced in Symfony 8.1 (symfony/symfony#63335) for multi-step form flows:

- `form_flow_current_step()`, `form_flow_total_steps()`, `form_flow_steps()`, `form_flow_step_index()`
- `form_flow_next_step()`, `form_flow_previous_step()`, `form_flow_first_step()`, `form_flow_last_step()`
- `form_flow_is_first_step()`, `form_flow_is_last_step()`, `form_flow_can_move_back()`, `form_flow_can_move_next()`

Includes a practical example showing step progress and navigation buttons.