### PR TITLE
[WebLink] Cleanup WebLink / HTTP2 Push / 103 Early Hints documentation

### DIFF
--- a/components/asset.rst
+++ b/components/asset.rst
@@ -427,6 +427,6 @@ Learn more
 ----------
 
 * :doc:`How to manage CSS and JavaScript assets in Symfony applications </frontend>`
-* :doc:`WebLink component </web_link>` to preload assets using HTTP/2.
+* :doc:`WebLink component </web_link>` to preload assets and send early hints.
 
 .. _`Webpack`: https://webpack.js.org/

--- a/controller.rst
+++ b/controller.rst
@@ -929,53 +929,9 @@ The ``file()`` helper provides some arguments to configure its behavior::
 Sending Early Hints
 ~~~~~~~~~~~~~~~~~~~
 
-`Early hints`_ tell the browser to start downloading some assets even before the
-application sends the response content. This improves perceived performance
-because the browser can prefetch resources that will be needed once the full
-response is finally sent. These resources are commonly Javascript or CSS files,
-but they can be any type of resource.
-
-.. note::
-
-    In order to work, the `SAPI`_ you're using must support this feature, like
-    `FrankenPHP`_.
-
-You can send early hints from your controller action thanks to the
-:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::sendEarlyHints`
-method::
-
-    namespace App\Controller;
-
-    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-    use Symfony\Component\HttpFoundation\Response;
-    use Symfony\Component\Routing\Attribute\Route;
-    use Symfony\Component\WebLink\Link;
-
-    class HomepageController extends AbstractController
-    {
-        #[Route("/", name: "homepage")]
-        public function index(): Response
-        {
-            $response = $this->sendEarlyHints([
-                new Link(rel: 'preconnect', href: 'https://fonts.google.com'),
-                (new Link(href: '/style.css'))->withAttribute('as', 'style'),
-                (new Link(href: '/script.js'))->withAttribute('as', 'script'),
-            ]);
-
-            // prepare the contents of the response...
-
-            return $this->render('homepage/index.html.twig', response: $response);
-        }
-    }
-
-Technically, Early Hints are an informational HTTP response with the status code
-``103``. The ``sendEarlyHints()`` method creates a ``Response`` object with that
-status code and sends its headers immediately.
-
-This way, browsers can start downloading the assets immediately; like the
-``style.css`` and ``script.js`` files in the above example. The
-``sendEarlyHints()`` method also returns the ``Response`` object, which you
-must use to create the full response sent from the controller action.
+You can improve performance by sending ``103`` Early Hints responses to hint
+the browser to start downloading assets before the full response is ready.
+See :ref:`early-hints` for details.
 
 .. _controller-server-sent-events:
 
@@ -1199,9 +1155,6 @@ Learn more about Controllers
 
 .. _`Symfony Maker`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
 .. _`unvalidated redirects security vulnerability`: https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
-.. _`Early hints`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103
-.. _`SAPI`: https://www.php.net/manual/en/function.php-sapi-name.php
-.. _`FrankenPHP`: https://frankenphp.dev
 .. _`Validate Filters`: https://www.php.net/manual/en/filter.constants.php
 .. _`phpstan/phpdoc-parser`: https://packagist.org/packages/phpstan/phpdoc-parser
 .. _`phpdocumentor/type-resolver`: https://packagist.org/packages/phpdocumentor/type-resolver

--- a/web_link.rst
+++ b/web_link.rst
@@ -1,23 +1,25 @@
-Asset Preloading and Resource Hints with HTTP/2 and WebLink
-===========================================================
+Asset Preloading and Resource Hints with WebLink
+================================================
 
 Symfony provides native support (via the `WebLink`_ component)
 for managing ``Link`` HTTP headers, which are the key to improve the application
-performance when using HTTP/2 and preloading capabilities of modern web browsers.
+performance when using preloading capabilities of modern web browsers.
 
-``Link`` headers are used in `HTTP/2 Server Push`_ and W3C's `Resource Hints`_
-to push resources (e.g. CSS and JavaScript files) to clients before they even
-know that they need them. WebLink also enables other optimizations that work
-with HTTP 1.x:
+``Link`` headers are used to hint resources (e.g. CSS and JavaScript files) to
+clients before they even know that they need them. WebLink enables several
+optimizations:
 
-* Asking the browser to fetch or to render another web page in the background;
+* Telling the browser to preload resources that will be needed for the current page;
+* Sending `103 Early Hints`_ responses so the browser starts downloading assets
+  before the full response is ready (see :ref:`early-hints`);
 * Making early DNS lookups, TCP handshakes or TLS negotiations.
 
-Something important to consider is that all these HTTP/2 features require a
-secure HTTPS connection, even when working on your local machine. The main web
-servers (Apache, nginx, Caddy, etc.) support this, but you can also use the
-`Docker installer and runtime for Symfony`_ created by Kévin Dunglas, from the
-Symfony community.
+.. note::
+
+    Some of these features (like Early Hints or resource hints) work best over
+    a secure HTTPS connection. The main web servers (Apache, nginx, Caddy, etc.)
+    support this, and you can also use the `Docker installer and runtime for Symfony`_
+    created by Kévin Dunglas, from the Symfony community.
 
 Installation
 ------------
@@ -51,9 +53,9 @@ Imagine that your application includes a web page like this:
     </html>
 
 In a traditional HTTP workflow, when this page is loaded, browsers make one
-request for the HTML document and another for the linked CSS file. With
-preloading, you can hint the browser to start fetching critical resources (like
-stylesheets, fonts or scripts) earlier, before it discovers them in the HTML.
+request for the HTML document and another for the linked CSS file. With the
+``Link`` HTTP header, your application can hint the browser to preload the
+CSS file while processing the HTML.
 
 This is useful for resources that are not directly linked in the HTML but are
 needed early (e.g. a font file referenced inside a CSS stylesheet).
@@ -83,6 +85,10 @@ as early as possible. You can also combine it with the ``asset()`` function:
     <link rel="preload" href="{{ preload(asset('build/app.css'), {as: 'style'}) }}" as="style">
     <link rel="stylesheet" href="{{ asset('build/app.css') }}">
 
+If you reload the page, the perceived performance will improve because the
+browser starts downloading the CSS file as soon as it receives the ``Link``
+header, without waiting for the full HTML to be parsed.
+
 .. tip::
 
     When using the :doc:`AssetMapper component </frontend/asset_mapper>` (e.g.
@@ -108,27 +114,99 @@ The WebLink component manages the ``Link`` HTTP headers added to the response.
 When using the ``preload()`` function, a header like this is added to the
 response: ``Link </fonts/myfont.woff2>; rel="preload"; as="font"``
 
-This header is interpreted in two ways depending on the infrastructure:
+When the browser receives this header, it starts downloading the resource right
+away, before it encounters the corresponding tag in the HTML.
 
-* **Browser preloading**: Modern browsers read ``Link`` headers and start
-  fetching the resources as early as possible, before parsing the full HTML.
-  This works with both HTTP/1.x and HTTP/2.
-* **HTTP/2 Server Push**: According to `the Preload specification`_, some
-  HTTP/2 servers detect this header and push the resource to the client
-  in the same connection, before the browser even requests it. Popular proxy
-  services and CDNs including `Cloudflare`_, `Fastly`_ and `Akamai`_ also
-  support this.
+Popular proxy services and CDNs including `Cloudflare`_, `Fastly`_ and `Akamai`_
+also leverage ``Link`` headers to optimize resource delivery and improve
+performance of your applications in production.
 
-If you want the browser to preload the resource via an early request but want
-to prevent the server from pushing it, use the ``nopush`` option:
+.. _early-hints:
+
+Sending Early Hints
+-------------------
+
+By default, ``Link`` headers are sent along with the final response. However,
+you can further improve performance by sending these headers *before* the full
+response is ready, using `103 Early Hints`_ responses. This tells the browser
+to start downloading assets while the server is still preparing the page.
+
+.. note::
+
+    In order to work, the `SAPI`_ you're using must support this feature, like
+    `FrankenPHP`_.
+
+The simplest way to send early hints is by using the ``preload()`` Twig function.
+When early hints are supported by your web server, the ``Link`` headers added via
+``preload()`` are automatically sent as ``103`` responses:
 
 .. code-block:: html+twig
 
     <head>
         <!-- ... -->
-        <link rel="preload" href="{{ preload('/app.css', {as: 'style', nopush: true}) }}" as="style">
+        <link rel="preload" href="{{ preload('/app.css', {as: 'style'}) }}" as="style">
         <!-- ... -->
     </head>
+
+For more control, you can send early hints explicitly from your controller action thanks to the
+:method:`Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController::sendEarlyHints`
+method::
+
+    namespace App\Controller;
+
+    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\Routing\Attribute\Route;
+    use Symfony\Component\WebLink\Link;
+
+    class HomepageController extends AbstractController
+    {
+        #[Route("/", name: "homepage")]
+        public function index(): Response
+        {
+            $response = $this->sendEarlyHints([
+                new Link(rel: 'preconnect', href: 'https://fonts.google.com'),
+                (new Link(href: '/style.css'))->withAttribute('as', 'style'),
+                (new Link(href: '/script.js'))->withAttribute('as', 'script'),
+            ]);
+
+            // prepare the contents of the response...
+
+            return $this->render('homepage/index.html.twig', response: $response);
+        }
+    }
+
+Technically, Early Hints are an informational HTTP response with the status code
+``103``. The ``sendEarlyHints()`` method creates a ``Response`` object with that
+status code and sends its headers immediately.
+
+This way, browsers can start downloading the assets immediately; like the
+``style.css`` and ``script.js`` files in the above example. The
+``sendEarlyHints()`` method also returns the ``Response`` object, which you
+must use to create the full response sent from the controller action.
+
+.. tip::
+
+    When using the :doc:`AssetMapper component </frontend/asset_mapper>`,
+    asset file names contain a version hash (e.g.
+    ``styles-3c16d9220694c0e56d8648f25e6035e9.css``). To reference the correct
+    versioned URL in early hints, use the
+    :class:`Symfony\\Component\\AssetMapper\\AssetMapperInterface` service::
+
+        use Symfony\Component\AssetMapper\AssetMapperInterface;
+
+        class HomepageController extends AbstractController
+        {
+            public function index(AssetMapperInterface $assetMapper): Response
+            {
+                $response = $this->sendEarlyHints([
+                    (new Link(href: $assetMapper->getAsset('styles/app.css')->publicPath))
+                        ->withAttribute('as', 'style'),
+                ]);
+
+                return $this->render('homepage/index.html.twig', response: $response);
+            }
+        }
 
 Resource Hints
 --------------
@@ -228,15 +306,16 @@ instances::
     The ``HttpHeaderParser`` class was introduced in Symfony 7.4.
 
 .. _`WebLink`: https://github.com/symfony/web-link
-.. _`HTTP/2 Server Push`: https://tools.ietf.org/html/rfc7540#section-8.2
-.. _`Resource Hints`: https://www.w3.org/TR/resource-hints/
 .. _`Docker installer and runtime for Symfony`: https://github.com/dunglas/symfony-docker
-.. _`"as" attribute`: https://w3c.github.io/preload/#as-attribute
-.. _`the Priority Hints specification`: https://wicg.github.io/priority-hints/
-.. _`the Preload specification`: https://www.w3.org/TR/preload/#server-push-http-2
+.. _`Resource Hints`: https://www.w3.org/TR/resource-hints/
 .. _`Cloudflare`: https://blog.cloudflare.com/announcing-support-for-http-2-server-push-2/
 .. _`Fastly`: https://docs.fastly.com/en/guides/http2-server-push
 .. _`Akamai`: https://http2.akamai.com/
+.. _`"as" attribute`: https://w3c.github.io/preload/#as-attribute
+.. _`the Priority Hints specification`: https://wicg.github.io/priority-hints/
+.. _`103 Early Hints`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103
+.. _`SAPI`: https://www.php.net/manual/en/function.header.php
+.. _`FrankenPHP`: https://frankenphp.dev
 .. _`link defined in the HTML specification`: https://html.spec.whatwg.org/dev/links.html#linkTypes
 .. _`PSR-13`: https://www.php-fig.org/psr/psr-13/
 .. _`Speculation Rules API`: https://developer.mozilla.org/docs/Web/API/Speculation_Rules_API


### PR DESCRIPTION
## Summary
- Remove obsolete HTTP/2 Server Push references from `web_link.rst` (Server Push has been deprecated/removed by major browsers and CDNs)
- Move Early Hints (103) documentation from `controller.rst` into `web_link.rst`, where the WebLink component is documented
- Add a tip about using `AssetMapperInterface` to resolve versioned file names in early hints
- Update cross-references between pages (`controller.rst`, `components/asset.rst`)

Fixes #22017