### PR TITLE
[Config][DependencyInjection][Routing] Document removal of $this in PHP config files

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -1327,6 +1327,13 @@ the closure::
         // services depending on which environment you're on
     };
 
+.. deprecated:: 8.0
+
+    Using ``$this`` or the loader's internal scope in PHP configuration
+    files was deprecated in Symfony 7.4 and removed in 8.0. Use the
+    variables passed to the closure (e.g. ``$containerConfigurator``)
+    or the ``$loader`` variable instead.
+
 Generating Adapters for Functional Interfaces
 ---------------------------------------------
 


### PR DESCRIPTION
This PR documents the removal of `$this` and the loader's internal scope access in PHP configuration files, as introduced in Symfony 8.0.

Closes #21479