### PR TITLE
[TypeInfo] Document type alias configuration option

### DIFF
--- a/components/type_info.rst
+++ b/components/type_info.rst
@@ -183,6 +183,82 @@ You can also import type aliases defined in other classes::
 
     The type alias support was introduced in Symfony 7.3.
 
+You can also define type aliases globally through the framework configuration.
+These aliases are available everywhere in the type resolver, without needing
+``@phpstan-type`` annotations:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/framework.yaml
+        framework:
+            type_info:
+                aliases:
+                    MoneyAmount: int
+                    UserData: 'array{name: string, email: string, age: int}'
+
+    .. code-block:: xml
+
+        <!-- config/packages/framework.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony
+                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+            <framework:config>
+                <framework:type-info>
+                    <framework:alias name="MoneyAmount">int</framework:alias>
+                    <framework:alias name="UserData">array{name: string, email: string, age: int}</framework:alias>
+                </framework:type-info>
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        use Symfony\Config\FrameworkConfig;
+
+        return static function (FrameworkConfig $framework): void {
+            $framework->typeInfo()
+                ->aliases([
+                    'MoneyAmount' => 'int',
+                    'UserData' => 'array{name: string, email: string, age: int}',
+                ])
+            ;
+        };
+
+Once configured, these aliases can be used in PHPDoc annotations and will be
+resolved by the type resolver::
+
+    class Product
+    {
+        /**
+         * @var MoneyAmount
+         */
+        public mixed $price;
+    }
+
+    $typeResolver = TypeResolver::create();
+    $typeResolver->resolve(new \ReflectionProperty(Product::class, 'price'));
+    // returns an "int" Type instance
+
+    // aliases can also be resolved directly from strings
+    $typeResolver->resolve('MoneyAmount'); // returns an "int" Type instance
+
+.. note::
+
+    When a PHPDoc ``@phpstan-type`` annotation defines an alias with the same
+    name as a configuration alias, the PHPDoc annotation takes precedence.
+
+.. versionadded:: 7.4
+
+    The ``framework.type_info.aliases`` option was introduced in Symfony 7.4.
+
 Array Shapes
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR documents the `framework.type_info.aliases` configuration option introduced in Symfony 7.4 (symfony/symfony#61480).

This option allows defining custom type aliases globally through the framework configuration (YAML, XML, PHP), making them available everywhere in the type resolver without needing `@phpstan-type` annotations.

Fixes #21306