### PR TITLE
[DependencyInjection] Fix note about service tags in documentation

### DIFF
--- a/service_container/service_decoration.rst
+++ b/service_container/service_decoration.rst
@@ -315,8 +315,8 @@ name via the ``decoration_inner_name`` option:
 .. note::
 
     All custom :doc:`service tags </service_container/tags>` from the decorated
-    service are removed in the new service. Only certain built-in service tags
-    defined by Symfony are retained: ``container.service_locator``, ``container.service_subscriber``,
+    service are removed and added to the new service. Only certain built-in service tags
+    defined by Symfony are kept: ``container.service_locator``, ``container.service_subscriber``,
     ``kernel.event_subscriber``, ``kernel.event_listener``, ``kernel.locale_aware``,
     and ``kernel.reset``.
 


### PR DESCRIPTION
I'm mostly more confused by the comment, as it seems like it even removes tags from the new service, but reality is what happening is that the top service get all tags and the decorated only keeps the internal tags.

```xml
<service
    id="sulu_admin.form_metadata_provider"
    class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider"
>
    <argument type="tagged_iterator" tag="sulu_admin.form_metadata_loader"/>
    <argument type="tagged_iterator" tag="sulu_admin.form_metadata_visitor"/>
    <argument type="tagged_iterator" tag="sulu_admin.typed_form_metadata_visitor"/>
    <argument>%sulu_core.fallback_locale%</argument>

    <tag name="sulu_admin.metadata_provider" type="form"/>
</service>

<service
    id="sulu_admin.cached_form_metadata_provider"
    class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\CachedFormMetadataProvider"
    decorates="sulu_admin.form_metadata_provider"
>
    <argument type="service" id=".inner"/>

     <tag name="kernel.reset" method="reset"/>
</service>
```

<img width="2486" height="1222" alt="Bildschirmfoto 2026-02-19 um 16 12 44" src="https://github.com/user-attachments/assets/dfa8ddb1-da68-4004-a3af-580e76349e2e" />

