### PR TITLE
[DependencyInjection] Document deprecation of named autowiring aliases without #[Target]

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -901,7 +901,7 @@ the :phpfunction:`json_encode` function is used.
 .. _controller_serialize:
 
 Serializing Controller Return Values Automatically
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Instead of manually calling the serializer and building a response, you can add
 the :class:`Symfony\\Component\\HttpKernel\\Attribute\\Serialize` attribute to

--- a/html_sanitizer.rst
+++ b/html_sanitizer.rst
@@ -196,38 +196,15 @@ You can do this by defining a new HTML sanitizer in the configuration:
         );
 
 This configuration defines a new ``html_sanitizer.sanitizer.app.post_sanitizer``
-service. Now you have two ways of injecting it in any service or controller:
-
-**(1) Use a specific argument name**
-
-Type-hint your constructor/method argument with ``HtmlSanitizerInterface`` and name
-the argument using this pattern: "HTML sanitizer name in camelCase". For example, to
-inject the ``app.post_sanitizer`` defined earlier, use an argument named ``$appPostSanitizer``::
+service. Use the ``#[Target]`` attribute to inject it in any service or
+controller. Symfony creates a target with the same name as the HTML sanitizer::
 
     // src/Controller/ApiController.php
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-    use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
-
-    class BlogController extends AbstractController
-    {
-        public function __construct(
-            private HtmlSanitizerInterface $appPostSanitizer,
-        ) {
-        }
-
-        // ...
-    }
-
-**(2) Use the ``#[Target]`` attribute**
-
-When :ref:`dealing with multiple implementations of the same type <autowiring-multiple-implementations-same-type>`
-the ``#[Target]`` attribute helps you select which one to inject. Symfony creates
-a target with the same name as the HTML sanitizer::
-
-    // ...
     use Symfony\Component\DependencyInjection\Attribute\Target;
+    use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
     class BlogController extends AbstractController
     {

--- a/lock.rst
+++ b/lock.rst
@@ -222,36 +222,14 @@ provides :ref:`named lock <reference-lock-resources-name>`:
             ],
         ]);
 
-After having configured one or more named locks, you have two ways of injecting
-them in any service or controller:
+After having configured one or more named locks, use the ``#[Target]``
+attribute to inject a specific lock factory in any service or controller.
+Symfony creates a target with the same name as the lock.
 
-**(1) Use a specific argument name**
+For example, to inject the ``invoice`` lock defined earlier::
 
-Type-hint your constructor/method argument with ``LockFactory`` and name the
-argument using this pattern: "lock name in camelCase" + ``LockFactory`` suffix.
-For example, to inject the ``invoice`` package defined earlier::
-
-    use Symfony\Component\Lock\LockFactory;
-
-    class SomeService
-    {
-        public function __construct(
-            private LockFactory $invoiceLockFactory
-        ) {
-            // ...
-        }
-    }
-
-**(2) Use the ``#[Target]`` attribute**
-
-When :ref:`dealing with multiple implementations of the same type <autowiring-multiple-implementations-same-type>`
-the ``#[Target]`` attribute helps you select which one to inject. Symfony creates
-a target with the same name as the lock.
-
-For example, to select the ``invoice`` lock defined earlier::
-
-    // ...
     use Symfony\Component\DependencyInjection\Attribute\Target;
+    use Symfony\Component\Lock\LockFactory;
 
     class SomeService
     {

--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -194,42 +194,19 @@ Rate Limiting in Action
 Injecting the Rate Limiter Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-After having configured one or more rate limiters, you have two ways of injecting
-them in any service or controller:
+After having configured one or more rate limiters, use the ``#[Target]``
+attribute to inject a specific rate limiter in any service or controller.
+Symfony creates a target with the same name as the rate limiter.
 
-**(1) Use a specific argument name**
-
-Type-hint your constructor/method argument with ``RateLimiterFactoryInterface`` and name
-the argument using this pattern: "rate limiter name in camelCase" + ``Limiter`` suffix.
-For example, to inject the ``anonymous_api`` limiter defined earlier, use an
-argument named ``$anonymousApiLimiter``::
+For example, to inject the ``anonymous_api`` limiter defined earlier::
 
     // src/Controller/ApiController.php
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
-
-    class ApiController extends AbstractController
-    {
-        public function index(RateLimiterFactoryInterface $anonymousApiLimiter): Response
-        {
-            // ...
-        }
-    }
-
-**(2) Use the ``#[Target]`` attribute**
-
-When :ref:`dealing with multiple implementations of the same type <autowiring-multiple-implementations-same-type>`
-the ``#[Target]`` attribute helps you select which one to inject. Symfony creates
-a target with the same name as the rate limiter.
-
-For example, to select the ``anonymous_api`` limiter defined earlier, use
-``anonymous_api.limiter`` as the target::
-
-    // ...
-    use Symfony\Component\DependencyInjection\Attribute\Target;
 
     class ApiController extends AbstractController
     {
@@ -253,6 +230,7 @@ to the API::
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
@@ -260,13 +238,14 @@ to the API::
 
     class ApiController extends AbstractController
     {
-        // the argument name here is important; read the previous section about
-        // how to inject a specific rate limiter service
-        public function index(Request $request, RateLimiterFactoryInterface $anonymousApiLimiter): Response
+        public function index(
+            Request $request,
+            #[Target('anonymous_api')] RateLimiterFactoryInterface $rateLimiter,
+        ): Response
         {
             // create a limiter based on a unique identifier of the client
             // (e.g. the client's IP address, a username/email, an API key, etc.)
-            $limiter = $anonymousApiLimiter->create($request->getClientIp());
+            $limiter = $rateLimiter->create($request->getClientIp());
 
             // the argument of consume() is the number of tokens to consume
             // and returns an object of type Limit
@@ -303,16 +282,20 @@ using the ``reserve()`` method::
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
     class ApiController extends AbstractController
     {
-        public function registerUser(Request $request, RateLimiterFactoryInterface $authenticatedApiLimiter): Response
+        public function registerUser(
+            Request $request,
+            #[Target('authenticated_api')] RateLimiterFactoryInterface $rateLimiter,
+        ): Response
         {
             $apiKey = $request->headers->get('apikey');
-            $limiter = $authenticatedApiLimiter->create($apiKey);
+            $limiter = $rateLimiter->create($apiKey);
 
             // this blocks the application until the given number of tokens can be consumed
             $limiter->reserve(1)->wait();
@@ -545,15 +528,19 @@ Then, inject and use as normal::
     namespace App\Controller;
 
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
     class ContactController extends AbstractController
     {
-        public function registerUser(Request $request, RateLimiterFactoryInterface $contactFormLimiter): Response
+        public function registerUser(
+            Request $request,
+            #[Target('contact_form')] RateLimiterFactoryInterface $rateLimiter,
+        ): Response
         {
-            $limiter = $contactFormLimiter->create($request->getClientIp());
+            $limiter = $rateLimiter->create($request->getClientIp());
 
             if (false === $limiter->consume(1)->isAccepted()) {
                 // either of the two limiters has been reached

--- a/service_container/alias_private.rst
+++ b/service_container/alias_private.rst
@@ -224,27 +224,8 @@ and need to inject a specific one based on context::
         // ...
     }
 
-The container will now match the ``target`` value against the argument name,
-so naming the constructor parameter accordingly is enough::
-
-    class UserNotificationService
-    {
-        public function __construct(
-            private MailerInterface $notificationMailer,
-        ) {
-        }
-    }
-
-    class OrderConfirmationService
-    {
-        public function __construct(
-            private MailerInterface $transactionalMailer,
-        ) {
-        }
-    }
-
-If you prefer to decouple the argument name from the target, use the
-:ref:`#[Target] attribute <autowiring-multiple-implementations-same-type>` instead::
+Then use the :ref:`#[Target] attribute <autowiring-multiple-implementations-same-type>`
+to inject the desired implementation::
 
     use Symfony\Component\DependencyInjection\Attribute\Target;
 

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -382,18 +382,20 @@ type hinted, but use the ``UppercaseTransformer`` implementation in some
 specific cases. To do so, you can create a normal alias from the
 ``TransformerInterface`` interface to ``Rot13Transformer``, and then
 create a *named autowiring alias* from a special string containing the
-interface followed by an argument name matching the one you use when doing
-the injection::
+interface followed by a variable name. Then, use the ``#[Target]``
+attribute on the argument to tell Symfony which named alias to inject::
 
     // src/Service/MastodonClient.php
     namespace App\Service;
 
     use App\Util\TransformerInterface;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
 
     class MastodonClient
     {
         public function __construct(
-            private TransformerInterface $shoutyTransformer,
+            #[Target('shoutyTransformer')]
+            private TransformerInterface $transformer,
         ) {
         }
 
@@ -480,24 +482,35 @@ the injection::
 
 Thanks to the ``App\Util\TransformerInterface`` alias, any argument type-hinted
 with this interface will be passed the ``App\Util\Rot13Transformer`` service.
-If the argument is named ``$shoutyTransformer``,
-``App\Util\UppercaseTransformer`` will be used instead.
-But, you can also manually wire any *other* service by specifying the argument
+When the ``#[Target('shoutyTransformer')]`` attribute is used,
+``App\Util\UppercaseTransformer`` will be injected instead.
+You can also manually wire any *other* service by specifying the argument
 under the arguments key.
 
-Another option is to use the ``#[Target]`` attribute. By adding this attribute
-to the argument you want to autowire, you can specify which service to inject by
-passing the name of the argument used in the named alias. This way, you can have
-multiple services implementing the same interface and keep the argument name
-separate from any implementation name (like shown in the example above). In addition,
-you'll get an exception in case you make any typo in the target name.
+.. deprecated:: 8.1
+
+    Relying solely on the parameter name to match a named autowiring alias
+    (i.e. without using the ``#[Target]`` attribute) is deprecated since
+    Symfony 8.1. Always use ``#[Target]`` to select a named autowiring alias.
 
 .. warning::
 
     The ``#[Target]`` attribute only accepts the name of the argument used in the
     named alias; it **does not** accept service ids or service aliases.
 
-You can get a list of named autowiring aliases by running the ``debug:autowiring`` command::
+.. tip::
+
+    Since the ``#[Target]`` attribute normalizes the string passed to it to its
+    camelCased form, name variations (e.g. ``shouty.transformer``) also work.
+
+.. note::
+
+    Some IDEs will show an error when using ``#[Target]``:
+    *"Attribute cannot be applied to a property because it does not contain the 'Attribute::TARGET_PROPERTY' flag"*.
+    The reason is that thanks to `PHP constructor promotion`_ this constructor
+    argument is both a parameter and a class property. You can safely ignore this error message.
+
+You can get a list of named autowiring aliases by running the ``debug:autowiring`` command:
 
 .. code-block:: terminal
 
@@ -517,36 +530,6 @@ You can get a list of named autowiring aliases by running the ``debug:autowiring
      Psr\Log\LoggerInterface $mailerLogger - alias:monolog.logger.mailer
 
      [...]
-
-Suppose you want to inject the ``App\Util\UppercaseTransformer`` service. You would use
-the ``#[Target]`` attribute by passing the name of the ``$shoutyTransformer`` argument::
-
-    // src/Service/MastodonClient.php
-    namespace App\Service;
-
-    use App\Util\TransformerInterface;
-    use Symfony\Component\DependencyInjection\Attribute\Target;
-
-    class MastodonClient
-    {
-        public function __construct(
-            #[Target('shoutyTransformer')]
-            private TransformerInterface $transformer,
-        ) {
-        }
-    }
-
-.. tip::
-
-    Since the ``#[Target]`` attribute normalizes the string passed to it to its
-    camelCased form, name variations (e.g. ``shouty.transformer``) also work.
-
-.. note::
-
-    Some IDEs will show an error when using ``#[Target]`` as in the previous example:
-    *"Attribute cannot be applied to a property because it does not contain the 'Attribute::TARGET_PROPERTY' flag"*.
-    The reason is that thanks to `PHP constructor promotion`_ this constructor
-    argument is both a parameter and a class property. You can safely ignore this error message.
 
 .. _autowire-attribute:
 

--- a/workflow.rst
+++ b/workflow.rst
@@ -607,47 +607,13 @@ if you are using Doctrine, the matching column definition should use the type ``
 Accessing the Workflow in a Class
 ---------------------------------
 
-Symfony creates a service for each workflow you define. You have two ways of
-injecting each workflow in any service or controller:
-
-**(1) Use a specific argument name**
-
-Type-hint your constructor/method argument with ``WorkflowInterface`` and name the
-argument using this pattern: "workflow name in camelCase" + ``Workflow`` suffix.
-If it is a state machine type, use the ``StateMachine`` suffix.
+Symfony creates a service for each workflow you define. Use the ``#[Target]``
+attribute to inject a specific workflow in any service or controller. Symfony
+creates a target with the same name as each workflow.
 
 For example, to inject the ``blog_publishing`` workflow defined earlier::
 
     use App\Entity\BlogPost;
-    use Symfony\Component\Workflow\WorkflowInterface;
-
-    class MyClass
-    {
-        public function __construct(
-            private WorkflowInterface $blogPublishingWorkflow,
-        ) {
-        }
-
-        public function toReview(BlogPost $post): void
-        {
-            try {
-                // update the currentState on the post
-                $this->blogPublishingWorkflow->apply($post, 'to_review');
-            } catch (LogicException $exception) {
-                // ...
-            }
-            // ...
-        }
-    }
-
-**(2) Use the ``#[Target]`` attribute**
-
-When :ref:`dealing with multiple implementations of the same type <autowiring-multiple-implementations-same-type>`
-the ``#[Target]`` attribute helps you select which one to inject. Symfony creates
-a target with the same name as each workflow.
-
-For example, to select the ``blog_publishing`` workflow defined earlier::
-
     use Symfony\Component\DependencyInjection\Attribute\Target;
     use Symfony\Component\Workflow\WorkflowInterface;
 
@@ -658,8 +624,22 @@ For example, to select the ``blog_publishing`` workflow defined earlier::
         ) {
         }
 
-        // ...
+        public function toReview(BlogPost $post): void
+        {
+            try {
+                // update the currentState on the post
+                $this->workflow->apply($post, 'to_review');
+            } catch (LogicException $exception) {
+                // ...
+            }
+            // ...
+        }
     }
+
+.. tip::
+
+    If it is a state machine type, use the state machine name as the target
+    (e.g. ``#[Target('my_state_machine')]``).
 
 To get the enabled transition of a Workflow, you can use
 :method:`Symfony\\Component\\Workflow\\WorkflowInterface::getEnabledTransition`
@@ -1405,23 +1385,27 @@ Then you can access this metadata in your controller as follows::
 
     // src/App/Controller/BlogPostController.php
     use App\Entity\BlogPost;
+    use Symfony\Component\DependencyInjection\Attribute\Target;
     use Symfony\Component\Workflow\WorkflowInterface;
     // ...
 
-    public function myAction(WorkflowInterface $blogPublishingWorkflow, BlogPost $post): Response
+    public function myAction(
+        #[Target('blog_publishing')] WorkflowInterface $workflow,
+        BlogPost $post,
+    ): Response
     {
-        $title = $blogPublishingWorkflow
+        $title = $workflow
             ->getMetadataStore()
             ->getWorkflowMetadata()['title'] ?? 'Default title'
         ;
 
-        $maxNumOfWords = $blogPublishingWorkflow
+        $maxNumOfWords = $workflow
             ->getMetadataStore()
             ->getPlaceMetadata('draft')['max_num_of_words'] ?? 500
         ;
 
-        $aTransition = $blogPublishingWorkflow->getDefinition()->getTransitions()[0];
-        $priority = $blogPublishingWorkflow
+        $aTransition = $workflow->getDefinition()->getTransitions()[0];
+        $priority = $workflow
             ->getMetadataStore()
             ->getTransitionMetadata($aTransition)['priority'] ?? 0
         ;


### PR DESCRIPTION
Fixes #22033

This documents the deprecation introduced in symfony/symfony#63426.

Since Symfony 8.1, relying solely on the parameter name to match a named autowiring alias (without using the `#[Target]` attribute) is deprecated.

Changes:
- Updated the main example to use `#[Target]` directly instead of relying on parameter naming
- Added a `.. deprecated:: 8.1` notice
- Removed the now-redundant second `#[Target]` example (merged into the main example)
- Moved the tips/notes about `#[Target]` right after its introduction