### PR TITLE
[PropertyInfo] Document support for PHP 8.4 property hook settable types

### DIFF
--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -375,6 +375,21 @@ return and scalar types::
     // Initializable information
     $reflectionExtractor->isInitializable($class, $property);
 
+.. versionadded:: 8.1
+
+    Support for PHP 8.4 property hook settable types in ``ReflectionExtractor``
+    was introduced in Symfony 8.1.
+
+The ``ReflectionExtractor`` also supports `PHP 8.4 property hooks`_. When a
+property defines a ``set`` hook with a parameter type that differs from the
+property type, ``getType()`` returns the type of the ``set`` hook parameter
+instead.
+
+For example, given a ``Product`` class with a ``$slug`` property using a ``set``
+hook that accepts ``string|null`` while the property itself is ``string``,
+calling ``getType()`` returns the settable type (``string|null``) instead of
+the property type (``string``).
+
 .. note::
 
     When using the Symfony framework, this service is automatically registered
@@ -565,4 +580,5 @@ service by defining it as a service with one or more of the following
 .. _`symfony/serializer`: https://packagist.org/packages/symfony/serializer
 .. _`symfony/doctrine-bridge`: https://packagist.org/packages/symfony/doctrine-bridge
 .. _`doctrine/orm`: https://packagist.org/packages/doctrine/orm
+.. _`PHP 8.4 property hooks`: https://www.php.net/manual/en/language.oop5.property-hooks.php
 .. _`phpDocumentor`: https://www.phpdoc.org/

--- a/controller.rst
+++ b/controller.rst
@@ -901,7 +901,7 @@ the :phpfunction:`json_encode` function is used.
 .. _controller_serialize:
 
 Serializing Controller Return Values Automatically
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Instead of manually calling the serializer and building a response, you can add
 the :class:`Symfony\\Component\\HttpKernel\\Attribute\\Serialize` attribute to


### PR DESCRIPTION
This documents the new PHP 8.4 property hook settable types support in `ReflectionExtractor`, introduced in symfony/symfony#63451.

Fixes #22040.