### PR TITLE
 Add missing enabled options in framework configuration reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -65,6 +65,11 @@ assets
 The following options configure the behavior of the
 :ref:`Twig asset() function <reference-twig-function-asset>`.
 
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
 .. _reference-assets-base-path:
 
 base_path
@@ -1464,6 +1469,11 @@ When the HttpClient component is installed, an HTTP client is available
 as a service named ``http_client`` or using the autowiring alias
 :class:`Symfony\\Contracts\\HttpClient\\HttpClientInterface`.
 
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
 .. _reference-http-client-default-options:
 
 This service can be configured using ``framework.http_client.default_options``:
@@ -2415,6 +2425,11 @@ Name of the lock you want to create.
 mailer
 ~~~~~~
 
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
 .. _mailer-dsn:
 
 dsn
@@ -2715,6 +2730,11 @@ requests (and not on the subrequests).
 property_access
 ~~~~~~~~~~~~~~~
 
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
 magic_call
 ..........
 
@@ -2785,6 +2805,11 @@ using the :ref:`ConstructorExtractor <components-property-information-constructo
 rate_limiter
 ~~~~~~~~~~~~
 
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
 .. _reference-rate-limiter-name:
 
 name
@@ -2828,6 +2853,11 @@ Whether to enable or not the RemoteEvent support.
 
 request
 ~~~~~~~
+
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``false``
 
 formats
 .......
@@ -2890,6 +2920,11 @@ To configure a ``jsonp`` format:
 
 router
 ~~~~~~
+
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``false``
 
 cache_dir
 .........
@@ -3987,6 +4022,11 @@ reverse proxy. See :doc:`/deployment/proxies`.
 
 uid
 ~~~
+
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
 
 Read the :doc:`UID component documentation </components/uid>` for complete
 details about each option.


### PR DESCRIPTION
Fixes #22068

Adds the missing `enabled` options for `assets`, `http_client`, `mailer`, `property_access`, `rate_limiter`, `request`, `router` and adds the missing `uid` section.