### PR TITLE
 Add type_info configuration to framework configuration reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3985,6 +3985,35 @@ The ``trusted_proxies`` option is needed to get precise information about the
 client (e.g. their IP address) when running Symfony behind a load balancer or a
 reverse proxy. See :doc:`/deployment/proxies`.
 
+type_info
+~~~~~~~~~
+
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
+Enables the TypeInfo component integration in the framework.
+
+aliases
+.......
+
+**type**: ``array`` **default**: ``[]``
+
+Defines global type aliases for the TypeInfo component. The keys are the alias
+names and the values are the type definitions (using PHPStan/Psalm syntax):
+
+.. code-block:: yaml
+
+    framework:
+        type_info:
+            aliases:
+                MoneyAmount: int
+                UserData: 'array{name: string, email: string, age: int}'
+
+See the :doc:`TypeInfo component documentation </components/type_info>` for more
+details about type aliases.
+
 uid
 ~~~
 


### PR DESCRIPTION
Fixes #22071

Adds the missing `type_info` section (`enabled` and `aliases` options) to the framework configuration reference.