### PR TITLE
[Messenger] Rename redis_cluster option to cluster in Messenger Redis transport

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1636,7 +1636,7 @@ The Redis transport DSN may looks like this:
     # Redis Cluster Example
     MESSENGER_TRANSPORT_DSN=redis://host-01:6379,redis://host-02:6379,redis://host-03:6379,redis://host-04:6379
     # Redis Cluster with automatic node discovery
-    MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages?redis_cluster=true
+    MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages?cluster=true
     # Unix Socket Example
     MESSENGER_TRANSPORT_DSN=redis:///var/run/redis.sock
     # TLS Example
@@ -1724,14 +1724,14 @@ under the transport in ``messenger.yaml``:
 ``redis_sentinel`` (default: ``null``)
     An alias of the ``sentinel_master`` option
 
-``redis_cluster`` (default: ``false``)
+``cluster`` (default: ``false``)
     If ``true``, forces the use of ``RedisCluster`` instead of ``Redis``. This is
     useful when connecting to a Redis Cluster and you want automatic node discovery
     instead of listing all cluster nodes in the DSN.
 
     .. versionadded:: 8.1
 
-        The ``redis_cluster`` option was introduced in Symfony 8.1.
+        The ``cluster`` option was introduced in Symfony 8.1.
 
 ``ssl`` (default: ``null``)
     Map of `SSL context options`_ for the TLS channel. This is useful for example


### PR DESCRIPTION
Fixes #21805

The option was renamed to `cluster` in symfony/symfony@f4c736d4a93187fdd21cbcbaba10e05256563b45.