### PR TITLE
[Console] Fix indentation for code example

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -654,10 +654,10 @@ you need lower-level control over the testing setup::
     Use PHP's first-class callable syntax to test
     :ref:`method-based commands <console-method-based-commands>`::
 
-    $commands = new UserCommands($userRepository);
+        $commands = new UserCommands($userRepository);
 
-    $tester = new CommandTester($commands->create(...));
-    $tester->execute([]);
+        $tester = new CommandTester($commands->create(...));
+        $tester->execute([]);
 
 .. note::
 


### PR DESCRIPTION
Fix indentation for a code example currently rendered as text

<img width="1622" height="356" alt="image" src="https://github.com/user-attachments/assets/587f3fc1-4ee3-437f-ab39-b40cdeabe590" />