### PR TITLE
 Remove some XML config examples

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1405,35 +1405,6 @@ so the :doc:`Cache component </components/cache>` must be installed in your appl
                         adapter: cache.adapter.redis_tag_aware
                         tags: true
 
-    .. code-block:: xml
-
-        <!-- config/packages/framework.xml -->
-        <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:framework="http://symfony.com/schema/dic/symfony"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-
-            <framework:config>
-                <framework:http-client>
-                    <framework:scoped-client name="example.client"
-                        base-uri="https://example.com"
-                    >
-                        <framework:caching cache-pool="example_cache_pool"/>
-                    </framework:scoped-client>
-                </framework:http-client>
-
-                <framework:cache>
-                    <framework:pool name="example_cache_pool"
-                        adapter="cache.adapter.redis_tag_aware"
-                        tags="true"
-                    />
-                </framework:cache>
-            </framework:config>
-        </container>
-
     .. code-block:: php
 
         // config/packages/framework.php

--- a/service_container.rst
+++ b/service_container.rst
@@ -271,19 +271,6 @@ You can limit service registration to specific environments as follows:
             services:
                 App\Service\AnotherClass: ~
 
-    .. code-block:: xml
-
-        <!-- config/services.xml -->
-        <services>
-            <service id="App\Service\SomeClass"/>
-
-            <when env="dev">
-                <services>
-                    <service id="App\Service\AnotherClass"/>
-                </services>
-            </when>
-        </services>
-
     .. code-block:: php
 
         // config/services.php

--- a/webhook.rst
+++ b/webhook.rst
@@ -50,17 +50,6 @@ can customize this prefix in your routing configuration:
             resource: '@FrameworkBundle/Resources/config/routing/webhook.xml'
             prefix: /webhook  # customize as needed
 
-    .. code-block:: xml
-
-        <!-- config/routes/webhook.xml -->
-        <routes xmlns="http://symfony.com/schema/routing"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/routing
-                https://symfony.com/schema/routing/routing-1.0.xsd">
-            <import resource="@FrameworkBundle/Resources/config/routing/webhook.xml"
-                prefix="/webhook"/>
-        </routes>
-
     .. code-block:: php
 
         // config/routes/webhook.php
@@ -85,26 +74,6 @@ controller uses a routing mechanism to map incoming requests to the appropriate 
                     acme_webhook:  # routing name, maps to /webhook/acme_webhook
                         service: App\Webhook\AcmeWebhookRequestParser
                         secret: '%env(WEBHOOK_SECRET)%'  # optional
-
-    .. code-block:: xml
-
-        <!-- config/packages/framework.xml -->
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:framework="http://symfony.com/schema/dic/symfony"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/symfony
-                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-            <framework:config>
-                <framework:webhook enabled="true">
-                    <framework:routing type="acme_webhook">
-                        <framework:service>App\Webhook\AcmeWebhookRequestParser</framework:service>
-                        <framework:secret>%env(WEBHOOK_SECRET)%</framework:secret>
-                    </framework:routing>
-                </framework:webhook>
-            </framework:config>
-        </container>
 
     .. code-block:: php
 
@@ -159,18 +128,6 @@ request format:
                     acme_webhook:
                         service: Symfony\Component\Webhook\Client\RequestParser
                         secret: '%env(WEBHOOK_SECRET)%'
-
-    .. code-block:: xml
-
-        <!-- config/packages/framework.xml -->
-        <framework:config>
-            <framework:webhook enabled="true">
-                <framework:routing type="acme_webhook">
-                    <framework:service>Symfony\Component\Webhook\Client\RequestParser</framework:service>
-                    <framework:secret>%env(WEBHOOK_SECRET)%</framework:secret>
-                </framework:routing>
-            </framework:webhook>
-        </framework:config>
 
     .. code-block:: php
 
@@ -446,26 +403,6 @@ for :class:`Symfony\\Component\\RemoteEvent\\Messenger\\ConsumeRemoteEventMessag
             messenger:
                 routing:
                     'Symfony\Component\RemoteEvent\Messenger\ConsumeRemoteEventMessage': async
-
-    .. code-block:: xml
-
-        <!-- config/packages/messenger.xml -->
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns:framework="http://symfony.com/schema/dic/symfony"
-            xsi:schemaLocation="http://symfony.com/schema/dic/services
-                https://symfony.com/schema/dic/services/services-1.0.xsd
-                http://symfony.com/schema/dic/symfony
-                https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
-            <framework:config>
-                <framework:messenger>
-                    <framework:routing
-                        message-class="Symfony\Component\RemoteEvent\Messenger\ConsumeRemoteEventMessage">
-                        <framework:sender service="async"/>
-                    </framework:routing>
-                </framework:messenger>
-            </framework:config>
-        </container>
 
     .. code-block:: php
 


### PR DESCRIPTION
We removed all XML config examples in 8.0 branch and up ... but when we upmerge new contents from lower branches, we unawarely add some XML config examples. Let's remove them.

I only removed DI and route related examples. XML is still fine for serialization, validation, translations, etc.