### PR TITLE
[Config][Configuration] Document runtime env vars in bundle config

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -272,8 +272,7 @@ Value              Recommended situation
 =================  =====================================================================================
 ``max[total]=0``   Recommended for actively maintained projects with robust/no dependencies
 ``max[direct]=0``  Recommended for projects with dependencies that fail to keep up with new deprecations
-``max[self]=0``    Recommended for libraries that use the deprecation system themselves
-                   and cannot afford to use one of the modes above
+``max[self]=0``    Recommended for libraries that use the deprecation system themselves and cannot afford to use one of the modes above
 =================  =====================================================================================
 
 Ignoring Deprecations

--- a/configuration.rst
+++ b/configuration.rst
@@ -949,6 +949,94 @@ already existing ``.env`` files).
         # .env.prod (or .env.prod.local) - this will fallback on the loaders you defined
         APP_ENV=
 
+Environment Variables in Bundle Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you use ``%env(...)%`` in bundle configuration (e.g.
+``config/packages/doctrine.yaml``), the value is **not** read at compile time.
+Instead, Symfony replaces it with a unique placeholder. The actual environment
+variable is only resolved at runtime, when the service using it is instantiated.
+
+This means that bundle authors must follow certain rules to ensure their bundle
+supports runtime env vars correctly:
+
+**In the Configuration class (TreeBuilder):**
+
+* Don't write ``beforeNormalization()`` steps that inspect or transform the
+  *values* of settings (steps that only move keys around without looking at
+  values, like DoctrineBundle's shortcut config, are fine);
+* Don't write ``validate()`` steps that check the *values* of settings
+  (at compile time, the value is still a placeholder string, not the real value).
+
+**In the DI extension (``load()`` method):**
+
+* Don't write logic that inspects the values of processed settings before
+  injecting them into DI parameters or service definition arguments. At compile
+  time, these values are placeholder strings, not the real env var values.
+
+.. tip::
+
+    The general rule is: **wire the value into the container, don't inspect it**.
+    As long as you pass env var values through to service arguments or parameters
+    without interpreting them, runtime resolution works automatically.
+
+**Handling DSNs and values that need parsing:**
+
+If a service needs a parsed version of a DSN (e.g. extracting the host, port
+and credentials from a database URL), don't parse it in the DI extension during
+container compilation. Instead, create a **factory service** that parses the DSN
+at runtime::
+
+    // src/Factory/ClientFactory.php
+    namespace App\Factory;
+
+    class ClientFactory
+    {
+        public static function create(string $dsn): SomeClient
+        {
+            $params = parse_url($dsn);
+
+            return new SomeClient(
+                host: $params['host'],
+                port: $params['port'] ?? 5432,
+                username: $params['user'] ?? '',
+                password: $params['pass'] ?? '',
+            );
+        }
+    }
+
+Then register the factory in the service configuration:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        services:
+            App\SomeClient:
+                factory: ['App\Factory\ClientFactory', 'create']
+                arguments:
+                    - '%env(DATABASE_DSN)%'
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Factory\ClientFactory;
+        use App\SomeClient;
+
+        return App::config([
+            'services' => [
+                SomeClient::class => service()
+                    ->factory([ClientFactory::class, 'create'])
+                    ->args([env('DATABASE_DSN')]),
+            ],
+        ]);
+
+This approach is used by DoctrineBundle with its ``ConnectionFactory``, which
+parses the database URL at runtime instead of during container compilation.
+
 .. _configuration-accessing-parameters:
 
 Accessing Configuration Parameters


### PR DESCRIPTION
Fixes #19942

Document how to correctly handle runtime-only environment variables in bundle configuration, including TreeBuilder constraints and the factory pattern for DSN parsing.