### PR TITLE
[Doctrine] Add Doctrine field types reference for Symfony Bridge types

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -272,8 +272,7 @@ Value              Recommended situation
 =================  =====================================================================================
 ``max[total]=0``   Recommended for actively maintained projects with robust/no dependencies
 ``max[direct]=0``  Recommended for projects with dependencies that fail to keep up with new deprecations
-``max[self]=0``    Recommended for libraries that use the deprecation system themselves
-                   and cannot afford to use one of the modes above
+``max[self]=0``    Recommended for libraries that use the deprecation system themselves and cannot afford to use one of the modes above
 =================  =====================================================================================
 
 Ignoring Deprecations

--- a/components/uid.rst
+++ b/components/uid.rst
@@ -357,6 +357,8 @@ By default, only the RFC 4122 format is accepted.
     The ``$format`` parameter of the :method:`Symfony\\Component\\Uid\\Uuid::isValid`
     method and the related constants were introduced in Symfony 7.2.
 
+.. _uid-uuid-doctrine:
+
 Storing UUIDs in Databases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -616,6 +618,8 @@ ULID objects created with the ``Ulid`` class can use the following methods::
     $ulid1->equals($ulid2); // false
     // this method returns $ulid1 <=> $ulid2
     $ulid1->compare($ulid2); // e.g. int(-1)
+
+.. _uid-ulid-doctrine:
 
 Storing ULIDs in Databases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -227,7 +227,8 @@ add/remove fields, add/remove methods or update configuration.
 
 Doctrine supports a wide variety of field types, each with their own options.
 Check out the `list of Doctrine mapping types`_ in the Doctrine documentation.
-If you want to use XML instead of attributes, add ``type: xml`` and
+Symfony also provides :doc:`additional field types </doctrine/field_types_reference>`
+for UIDs and DatePoints. If you want to use XML instead of attributes, add ``type: xml`` and
 ``dir: '%kernel.project_dir%/config/doctrine'`` to the entity mappings in your
 ``config/packages/doctrine.yaml`` file.
 
@@ -1163,6 +1164,7 @@ Learn more
     doctrine/custom_dql_functions
     doctrine/dbal
     doctrine/multiple_entity_managers
+    doctrine/field_types_reference
     doctrine/resolve_target_entity
     testing/database
 

--- a/reference/doctrine_field_types.rst
+++ b/reference/doctrine_field_types.rst
@@ -1,0 +1,134 @@
+Doctrine Field Types Reference
+==============================
+
+In addition to the `Doctrine mapping types`_, Symfony provides a set of
+custom Doctrine types in the ``Symfony\Bridge\Doctrine\Types`` namespace.
+
+UID Types
+---------
+
+These types allow storing :doc:`UIDs </components/uid>` as Doctrine fields.
+
+``uuid``
+~~~~~~~~
+
+Stores a :doc:`UUID </components/uid>` as a native GUID type if available, or
+as a 16-byte binary otherwise.
+
+**Class:** :class:`Symfony\\Bridge\\Doctrine\\Types\\UuidType`
+
+Example usage:
+
+.. code-block:: php-attributes
+
+    // src/Entity/Product.php
+    namespace App\Entity;
+
+    use Doctrine\ORM\Mapping as ORM;
+    use Symfony\Bridge\Doctrine\Types\UuidType;
+    use Symfony\Component\Uid\Uuid;
+
+    #[ORM\Entity]
+    class Product
+    {
+        #[ORM\Column(type: UuidType::NAME)]
+        private Uuid $sku;
+
+        // ...
+    }
+
+See :ref:`Storing UUIDs in Databases <uid-uuid-doctrine>` in the UID component
+documentation for more details, including how to use UUIDs as primary keys.
+
+``ulid``
+~~~~~~~~
+
+Stores a :ref:`ULID <ulid>` as a native GUID type if available, or as a
+16-byte binary otherwise.
+
+**Class:** :class:`Symfony\\Bridge\\Doctrine\\Types\\UlidType`
+
+Example usage:
+
+.. code-block:: php-attributes
+
+    // src/Entity/Product.php
+    namespace App\Entity;
+
+    use Doctrine\ORM\Mapping as ORM;
+    use Symfony\Bridge\Doctrine\Types\UlidType;
+    use Symfony\Component\Uid\Ulid;
+
+    #[ORM\Entity]
+    class Product
+    {
+        #[ORM\Column(type: UlidType::NAME)]
+        private Ulid $identifier;
+
+        // ...
+    }
+
+See :ref:`Storing ULIDs in Databases <uid-ulid-doctrine>` in the UID component
+documentation for more details, including how to use ULIDs as primary keys.
+
+DatePoint Types
+---------------
+
+These types allow storing :class:`Symfony\\Component\\Clock\\DatePoint` objects
+from the :doc:`Clock component </components/clock>`. They convert to/from
+``DatePoint`` objects automatically.
+
+====================  ==========================  =========================================================
+Type                  Extends Doctrine type       Class
+====================  ==========================  =========================================================
+``date_point``        ``datetime_immutable``      :class:`Symfony\\Bridge\\Doctrine\\Types\\DatePointType`
+``day_point``         ``date_immutable``          :class:`Symfony\\Bridge\\Doctrine\\Types\\DayPointType`
+``time_point``        ``time_immutable``          :class:`Symfony\\Bridge\\Doctrine\\Types\\TimePointType`
+====================  ==========================  =========================================================
+
+Example usage:
+
+.. code-block:: php-attributes
+
+    // src/Entity/Product.php
+    namespace App\Entity;
+
+    use Doctrine\ORM\Mapping as ORM;
+    use Symfony\Component\Clock\DatePoint;
+
+    #[ORM\Entity]
+    class Product
+    {
+        // Symfony autodetects the 'date_point' type when type-hinting with DatePoint
+        #[ORM\Column]
+        private DatePoint $createdAt;
+
+        // you can also set the type explicitly
+        #[ORM\Column(type: 'date_point')]
+        private DatePoint $updatedAt;
+
+        #[ORM\Column(type: 'day_point')]
+        public DatePoint $releaseDate;
+
+        #[ORM\Column(type: 'time_point')]
+        public DatePoint $openingTime;
+
+        // ...
+    }
+
+Choosing Between Similar Types
+------------------------------
+
+``datetime_immutable`` vs ``date_point``
+    Use ``date_point`` when you want to work with
+    :class:`Symfony\\Component\\Clock\\DatePoint` objects, which makes your code
+    easier to test with the :doc:`Clock component </components/clock>`. Use
+    ``datetime_immutable`` if you don't need the Clock component features.
+
+``uuid`` vs ``ulid``
+    Both are 128-bit identifiers. UUIDs are more widely used and recognized.
+    ULIDs are lexicographically sortable by creation time, which avoids index
+    fragmentation in databases. See the :doc:`UID component docs </components/uid>`
+    for a detailed comparison.
+
+.. _`Doctrine mapping types`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/basic-mapping.html#reference-mapping-types

--- a/reference/map.rst.inc
+++ b/reference/map.rst.inc
@@ -30,6 +30,11 @@ Format Specifications
 * :doc:`ICU MessageFormat </reference/formats/message_format>`
 * :doc:`Expression Language </reference/formats/expression_language>`
 
+Doctrine
+--------
+
+* :doc:`Doctrine Field Types Reference </reference/doctrine_field_types>`
+
 Others
 ------
 


### PR DESCRIPTION
Fixes #21893

Adds a reference page documenting the custom Doctrine field types provided by Symfony in the `Symfony\Bridge\Doctrine\Types` namespace (`uuid`, `ulid`, `date_point`, `day_point`, `time_point`), with guidance on choosing between similar types.