### PR TITLE
 Document deprecation of terminate_on_cache_hit http_cache option

### DIFF
--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -272,8 +272,7 @@ Value              Recommended situation
 =================  =====================================================================================
 ``max[total]=0``   Recommended for actively maintained projects with robust/no dependencies
 ``max[direct]=0``  Recommended for projects with dependencies that fail to keep up with new deprecations
-``max[self]=0``    Recommended for libraries that use the deprecation system themselves
-                   and cannot afford to use one of the modes above
+``max[self]=0``    Recommended for libraries that use the deprecation system themselves and cannot afford to use one of the modes above
 =================  =====================================================================================
 
 Ignoring Deprecations

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1247,6 +1247,17 @@ a stale response while it revalidates it in the background.
 This setting is overridden by the stale-while-revalidate HTTP Cache-Control
 extension (see RFC 5861).
 
+terminate_on_cache_hit
+......................
+
+**type**: ``boolean``
+
+.. deprecated:: 8.1
+
+    The ``terminate_on_cache_hit`` option is deprecated since Symfony 8.1
+    because the underlying ``HttpCache`` option it configured was removed in
+    Symfony 7.0. Remove it from your configuration.
+
 trace_header
 ............
 


### PR DESCRIPTION
Fixes #22092

Documents the deprecation of the `terminate_on_cache_hit` option in `framework.http_cache`, deprecated since Symfony 8.1.