### PR TITLE
[HttpFoundation] Document valkey:/valkeys: DSN schemes for sessions

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -719,6 +719,17 @@ and only the first one stored the CSRF token in the session.
     :ref:`handler_id <config-framework-session-handler-id>` config option, you can
     add the ``prefix`` and ``ttl`` options as query string parameters in the DSN.
 
+.. tip::
+
+    .. versionadded:: 7.3
+
+        Support for the ``valkey:`` and ``valkeys:`` DSN schemes in session
+        handlers was introduced in Symfony 7.3.
+
+    When using `Valkey`_ servers, you can use the ``valkey:`` or ``valkeys:``
+    DSN schemes instead of ``redis:`` or ``rediss:`` in the session handler
+    configuration.
+
 .. _session-database-pdo:
 
 Store Sessions in a Relational Database (MariaDB, MySQL, PostgreSQL)
@@ -1893,6 +1904,7 @@ the example below:
     has not been started before Symfony is initialized.
 
 .. _`Twig Live Component`: https://symfony.com/bundles/ux-live-component/current/index.html
+.. _`Valkey`: https://valkey.io/
 .. _`phpredis extension`: https://github.com/phpredis/phpredis
 .. _`DoctrineMongoDBBundle configuration`: https://symfony.com/doc/master/bundles/DoctrineMongoDBBundle/config.html
 .. _`MongoDB shell`: https://docs.mongodb.com/manual/mongo/


### PR DESCRIPTION
Documents the `valkey:` and `valkeys:` DSN schemes support for session handlers, added in Symfony 7.3. The cache adapter page already mentions this, but the session page did not.