### PR TITLE
[Workflow] Document BackedEnum support in MethodMarkingStore

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -258,6 +258,45 @@ you must declare a setter to write your property::
 
 .. tip::
 
+    .. versionadded:: 7.4
+
+        Support for ``BackedEnum`` in ``MethodMarkingStore`` was introduced in
+        Symfony 7.4.
+
+    When using a single state marking store, you can type-hint the property
+    with a ``BackedEnum`` instead of a string. The ``MethodMarkingStore`` will
+    automatically convert between the enum and its backing value::
+
+        // src/Entity/Status.php
+        namespace App\Entity;
+
+        enum Status: string
+        {
+            case Draft = 'draft';
+            case Reviewed = 'reviewed';
+            case Published = 'published';
+        }
+
+        // src/Entity/BlogPost.php
+        namespace App\Entity;
+
+        class BlogPost
+        {
+            public ?Status $currentPlace = null;
+
+            public function getCurrentPlace(): ?Status
+            {
+                return $this->currentPlace;
+            }
+
+            public function setCurrentPlace(Status $currentPlace, array $context = []): void
+            {
+                $this->currentPlace = $currentPlace;
+            }
+        }
+
+.. tip::
+
     The ``marking_store.type`` (the default value depends on the ``type`` value)
     and ``property`` (default value ``['marking']``) attributes of the
     ``marking_store`` option are optional. If omitted, their default values will


### PR DESCRIPTION
Documents the `BackedEnum` support in `MethodMarkingStore` added in Symfony 7.4 (symfony/symfony#60114).