### PR TITLE
[Serializer] Add AbstractNormalizer import for circular reference handling

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -2061,6 +2061,7 @@ by custom callables. This is especially useful when serializing entities
 having unique identifiers::
 
     use Symfony\Component\Serializer\Exception\CircularReferenceException;
+    use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
     $context = [
         AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => function (object $object, ?string $format, array $context): string {


### PR DESCRIPTION
Added missing `use` if we go directly to item menu "Handling Circular References"
