### PR TITLE
[Form] Explain why data events aren't dispatched with inherit_data

### DIFF
--- a/form/inherit_data_option.rst
+++ b/form/inherit_data_option.rst
@@ -167,4 +167,7 @@ location form that you can reuse wherever you need it.
 
 .. warning::
 
-    Forms with the ``inherit_data`` option set cannot have ``*_SET_DATA`` event listeners.
+    Forms with the ``inherit_data`` option set do not dispatch the
+    ``PRE_SET_DATA`` and ``POST_SET_DATA`` events, because they don't have
+    their own data lifecycle. To modify fields dynamically based on the
+    underlying data, add the event listeners to the parent form instead.

--- a/reference/forms/types/options/inherit_data.rst.inc
+++ b/reference/forms/types/options/inherit_data.rst.inc
@@ -13,3 +13,11 @@ multiple forms. See :doc:`/form/inherit_data_option`.
     the parent form as is. This means that
     :doc:`Data Transformers </form/data_transformers>` won't be
     applied to that field.
+
+.. warning::
+
+    Forms with ``inherit_data`` set to ``true`` do not dispatch the
+    ``PRE_SET_DATA`` and ``POST_SET_DATA`` :doc:`form events </form/events>`,
+    because they don't have their own data lifecycle. If you need to modify
+    fields dynamically based on data, add the event listeners to the parent
+    form instead.


### PR DESCRIPTION
Explain why `PRE_SET_DATA` and `POST_SET_DATA` events are not dispatched in forms with `inherit_data` set to `true`, and suggest using event listeners on the parent form instead.

Fixes #21739