### PR TITLE
[HttpClient] Document default CachingHttpClient maxTtl change to 86400s

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1478,6 +1478,44 @@ so the :doc:`Cache component </components/cache>` must be installed in your appl
         $client = HttpClient::createForBaseUri('https://example.com');
         $cachingClient = new CachingHttpClient($client, $cache);
 
+By default, cached responses are limited to a maximum TTL of 86400 seconds
+(24 hours) to prevent eternal cache items when the origin server doesn't send
+explicit cache-control directives. You can customize this value using the
+``max_ttl`` option:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/framework.yaml
+        framework:
+            http_client:
+                scoped_clients:
+                    example.client:
+                        caching:
+                            max_ttl: 3600
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        use Symfony\Config\FrameworkConfig;
+
+        return static function (FrameworkConfig $framework): void {
+            $framework->httpClient()->scopedClient('example.client')
+                ->caching()
+                    ->maxTtl(3600)
+            ;
+        };
+
+    .. code-block:: php-standalone
+
+        $cachingClient = new CachingHttpClient($client, $cache, maxTtl: 3600);
+
+.. deprecated:: 8.1
+
+    Before Symfony 8.1, ``max_ttl`` defaulted to ``null`` (no cap). Passing
+    ``null`` is deprecated since Symfony 8.1. Use a positive integer instead.
+
 .. tip::
 
     It is strongly recommended to configure a

--- a/http_client.rst
+++ b/http_client.rst
@@ -1492,6 +1492,7 @@ explicit cache-control directives. You can customize this value using the
             http_client:
                 scoped_clients:
                     example.client:
+                        base_uri: 'https://example.com'
                         caching:
                             max_ttl: 3600
 
@@ -1502,6 +1503,7 @@ explicit cache-control directives. You can customize this value using the
 
         return static function (FrameworkConfig $framework): void {
             $framework->httpClient()->scopedClient('example.client')
+                ->baseUri('https://example.com')
                 ->caching()
                     ->maxTtl(3600)
             ;

--- a/http_client.rst
+++ b/http_client.rst
@@ -1515,8 +1515,8 @@ explicit cache-control directives. You can customize this value using the
 
 .. deprecated:: 8.1
 
-    Before Symfony 8.1, ``max_ttl`` defaulted to ``null`` (no cap). Passing
-    ``null`` is deprecated since Symfony 8.1. Use a positive integer instead.
+    Setting ``max_ttl`` to ``null`` is deprecated since Symfony 8.1. Use a
+    positive integer instead.
 
 .. tip::
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1727,11 +1727,15 @@ users. Set it to ``false`` to use a `private cache`_.
 max_ttl
 """""""
 
-**type**: ``integer`` **default**: ``null``
+**type**: ``integer`` **default**: ``86400``
 
-The maximum time-to-live (in seconds) for cached responses. By default, responses
-are cached for as long as the TTL specified by the server. When this option is
-set, server-provided TTLs are capped to this value.
+The maximum time-to-live (in seconds) for cached responses. Server-provided
+TTLs are capped to this value to prevent eternal cache items.
+
+.. deprecated:: 8.1
+
+    Setting ``max_ttl`` to ``null`` is deprecated since Symfony 8.1. Use a
+    positive integer instead.
 
 cafile
 ......


### PR DESCRIPTION
Fixes #22111