### PR TITLE
[Messenger] Document deprecation of senders nesting level in routing config

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2494,6 +2494,11 @@ senders
 
 A list of transport names to route the message to.
 
+.. deprecated:: 8.1
+
+    The ``senders`` nesting level in the routing configuration is deprecated
+    since Symfony 8.1. Use a string or a list of strings directly instead.
+
 serializer
 ..........
 


### PR DESCRIPTION
Fixes #22112