### PR TITLE
[Messenger] Document MessageExecutionStrategyInterface

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1174,6 +1174,36 @@ resetting leads to memory leaks or stale state:
 
     The ability to pass a number to the ``--no-reset`` option was introduced in Symfony 8.1.
 
+Custom Message Execution Strategy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.1
+
+    The ``MessageExecutionStrategyInterface`` was introduced in Symfony 8.1.
+
+By default, the worker processes messages synchronously using
+:class:`Symfony\\Component\\Messenger\\Execution\\SyncMessageExecutionStrategy`.
+To customize how messages are executed (for example to run them in parallel),
+implement
+:class:`Symfony\\Component\\Messenger\\Execution\\MessageExecutionStrategyInterface`
+and pass it to the ``Worker`` constructor. The interface ``execute()`` method
+contains the actual execution logic, while the other methods (``wait()``,
+``flush()``, ``shutdown()``, ``shouldPauseConsumption()``) coordinate with the
+worker loop::
+
+    use Symfony\Component\Messenger\Envelope;
+    use Symfony\Component\Messenger\Execution\MessageExecutionStrategyInterface;
+
+    class MyCustomExecutionStrategy implements MessageExecutionStrategyInterface
+    {
+        public function execute(Envelope $envelope, string $transportName, callable $onHandled): void
+        {
+            // custom execution logic
+        }
+
+        // ... implement the remaining interface methods
+    }
+
 .. _messenger-retries-failures:
 
 Rate Limited Transport


### PR DESCRIPTION
Document the new `MessageExecutionStrategyInterface` that makes the worker's message execution model pluggable.

Fixes https://github.com/symfony/symfony-docs/issues/22157