### PR TITLE
 Fix a typo in a routing example

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -1769,7 +1769,7 @@ when importing the routes.
 
         # config/routes.yaml
         controllers:
-            resource: routing.controllerss
+            resource: routing.controllers
             # this is added to the beginning of all imported route URLs
             prefix: '/blog'
             # this is added to the beginning of all imported route names


### PR DESCRIPTION
Fix a small typo in a YAML example of the routing documentation.

Based off of `7.4` because that's where it was introduced (i.e. prior branches don't have that typo).
