### PR TITLE
 [Doctrine] remove dbal notes incompatible with symfony 8

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -44,9 +44,6 @@ The database connection information is stored as an environment variable called
     DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=8.0.37"
 
     # to use mariadb:
-    # Before doctrine/dbal < 3.7
-    # DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=mariadb-10.5.8"
-    # Since doctrine/dbal 3.7
     # DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=10.5.8-MariaDB"
 
     # to use sqlite:

--- a/reference/configuration/doctrine.rst
+++ b/reference/configuration/doctrine.rst
@@ -116,11 +116,6 @@ The following block shows all possible configuration keys:
     to find your PostgreSQL version and ``mysql -V`` to get your MySQL
     version).
 
-    If you are running a MariaDB database, you must prefix the ``server_version``
-    value with ``mariadb-`` (e.g. ``server_version: mariadb-10.4.14``). This will
-    change in Doctrine DBAL 4.x, where you must define the version as output by
-    the server (e.g. ``10.4.14-MariaDB``).
-
     Always wrap the server version number with quotes to parse it as a string
     instead of a float number. Otherwise, the floating-point representation
     issues can make your version be considered a different number (e.g. ``5.7``


### PR DESCRIPTION
[Symfony 8 composer.json](https://github.com/symfony/symfony/blob/8.0/composer.json) do not allow `doctrine/dbal <4.3`

I think we can safely remove comments about how to write mariaDB serverVersion for different 3.x versions