### PR TITLE
 Update LTS version example from 6.4 to 7.4 in setup.rst

### DIFF
--- a/setup.rst
+++ b/setup.rst
@@ -272,14 +272,14 @@ stable version. If you want to use an LTS version, add the ``--version`` option:
     $ symfony new my_project_directory --version=next
 
     # you can also select an exact specific Symfony version
-    $ symfony new my_project_directory --version="6.4.*"
+    $ symfony new my_project_directory --version="7.4.*"
 
 The ``lts`` and ``next`` shortcuts are only available when using Symfony to
 create new projects. If you use Composer, you need to tell the exact version:
 
 .. code-block:: terminal
 
-    $ composer create-project symfony/skeleton:"6.4.*" my_project_directory
+    $ composer create-project symfony/skeleton:"7.4.*" my_project_directory
 
 The Symfony Demo application
 ----------------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | yes ✅
| New docs?     | no ❌
| Applies to    | 7.4+
| Fixed tickets | -

This PR updates the Symfony version in the LTS example command from `6.4.*` to `7.4.*` in `setup.rst`.

### Why?
- Symfony 7.4 is now the latest LTS version
- The current example still shows `--version="6.4.*"` which may confuse users looking for LTS installation instructions
- The change brings the example in line with the actual LTS version

### Before
```bash
$ symfony new my_project_directory --version="6.4.*"
```

### After
```bash
$ symfony new my_project_directory --version="7.4.*"
```