### PR TITLE
[Console] Fix `ConsoleAlarmEvent` title

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -249,8 +249,8 @@ handle all signals e.g. to do some tasks before terminating the command.
     :method:`Symfony\\Component\\Console\\SignalRegistry\\SignalMap::getSignalName`
     method.
 
-The ``ConsoleEvents::ALARM`` Event
-----------------------------------
+The ``ConsoleAlarmEvent``
+-------------------------
 
 **Typical Purposes**: To perform periodic tasks during long-running commands
 (e.g. database connection keepalive, extending lock TTLs, heartbeat checks).


### PR DESCRIPTION
The `ConsoleAlarmEvent` doesn't actually have an alias, see https://github.com/symfony/symfony/pull/53533#discussion_r1776597586 for more information. 
