### PR TITLE
 Add missing options to Framework Configuration Reference

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -608,6 +608,167 @@ individually for each asset package:
 
     This parameter cannot be set at the same time as ``version`` or ``json_manifest_path``.
 
+.. _reference-asset-mapper:
+
+asset_mapper
+~~~~~~~~~~~~
+
+enabled
+.......
+
+**type**: ``boolean`` **default**: ``true`` or ``false`` depending on your installation
+
+Whether to enable the AssetMapper component in your application.
+
+paths
+.....
+
+**type**: ``array`` **default**: ``['assets/']``
+
+Directories that hold assets that should be available through the asset mapper.
+Can be a simple array of paths or an associative array of
+``"path/to/assets": "namespace"`` pairs.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/asset_mapper.yaml
+        framework:
+            asset_mapper:
+                paths:
+                    - assets/
+
+    .. code-block:: xml
+
+        <!-- config/packages/asset_mapper.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+            <framework:config>
+                <framework:asset-mapper>
+                    <framework:path>assets/</framework:path>
+                </framework:asset-mapper>
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/asset_mapper.php
+        use Symfony\Config\FrameworkConfig;
+
+        return static function (FrameworkConfig $framework): void {
+            $framework->assetMapper()
+                ->path('assets/', null)
+            ;
+        };
+
+excluded_patterns
+.................
+
+**type**: ``array``
+
+Array of glob patterns of asset file paths that should not be in the asset
+mapper (e.g. ``['*/assets/build/*', '*/*_.scss']``).
+
+exclude_dotfiles
+................
+
+**type**: ``boolean`` **default**: ``true``
+
+If ``true``, any files starting with ``.`` will be excluded from the asset mapper.
+
+server
+......
+
+**type**: ``boolean`` **default**: ``%kernel.debug%``
+
+If ``true``, a "dev server" will return the assets from the public directory.
+This is enabled by default in debug mode only.
+
+public_prefix
+.............
+
+**type**: ``string`` **default**: ``'/assets/'``
+
+The public path where the assets will be written to (and served from when
+``server`` is ``true``).
+
+missing_import_mode
+...................
+
+**type**: ``string`` **default**: ``'warn'`` **possible values**: ``'strict'``, ``'warn'`` or ``'ignore'``
+
+Behavior if an asset cannot be found when imported from JavaScript or CSS files
+(e.g. ``import './non-existent.js'``). ``strict`` means an exception is thrown,
+``warn`` means a warning is logged, ``ignore`` means the import is left as-is.
+
+extensions
+..........
+
+**type**: ``array``
+
+Key-value pair of file extensions set to their MIME type
+(e.g. ``['.zip': 'application/zip']``).
+
+importmap_path
+..............
+
+**type**: ``string`` **default**: ``'%kernel.project_dir%/importmap.php'``
+
+The path of the ``importmap.php`` file.
+
+importmap_polyfill
+..................
+
+**type**: ``string`` or ``false`` **default**: ``'es-module-shims'``
+
+The importmap name that will be used to load the polyfill. Set to ``false``
+to disable.
+
+importmap_script_attributes
+...........................
+
+**type**: ``array``
+
+Key-value pair of attributes to add to script tags output for the importmap
+(e.g. ``['data-turbo-track': 'reload']``).
+
+vendor_dir
+..........
+
+**type**: ``string`` **default**: ``'%kernel.project_dir%/assets/vendor'``
+
+The directory to store JavaScript vendors.
+
+precompress
+...........
+
+**type**: ``boolean`` **default**: ``false``
+
+When enabled, assets are precompressed with Brotli, Zstandard and gzip during
+compilation.
+
+precompress.formats
+"""""""""""""""""""
+
+**type**: ``array``
+
+Array of compression formats to enable. Supported values: ``brotli``,
+``zstandard`` and ``gzip``. Defaults to all formats supported by the system.
+
+precompress.extensions
+""""""""""""""""""""""
+
+**type**: ``array``
+
+Array of file extensions to compress. The entire list must be provided, no
+merging occurs.
+
 .. _reference-cache:
 
 cache
@@ -1647,6 +1808,23 @@ Response TTL precision is a second) during which the cache can immediately retur
 a stale response while it revalidates it in the background.
 This setting is overridden by the stale-while-revalidate HTTP Cache-Control
 extension (see RFC 5861).
+
+terminate_on_cache_hit
+......................
+
+**type**: ``boolean``
+
+If ``true``, the :ref:`kernel.terminate <component-http-kernel-kernel-terminate>`
+event is dispatched even when the cache is hit.
+
+Unless your application needs to process events on cache hits, it's recommended
+to set this to ``false`` to improve performance, because it avoids having to
+bootstrap the Symfony framework on a cache hit.
+
+.. deprecated:: 7.0
+
+    The underlying ``HttpCache`` option was removed in Symfony 7.0. This
+    configuration option has no effect and will be removed in a future version.
 
 trace_header
 ............
@@ -2725,6 +2903,65 @@ sender
 
 The "envelope sender" which is used as the value of ``MAIL FROM`` during the
 `SMTP session`_. This value overrides any other sender set in the code.
+
+allowed_recipients
+""""""""""""""""""
+
+**type**: ``array``
+
+A list of regular expressions that allow recipients to still receive their
+original emails when the ``recipients`` option is defined. These messages
+will also be sent to the address(es) defined in ``recipients``.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/mailer.yaml
+        framework:
+            mailer:
+                envelope:
+                    recipients: ['youremail@example.com']
+                    allowed_recipients:
+                        - 'internal@example.com'
+                        - 'internal-.*@example.(com|fr)'
+
+    .. code-block:: xml
+
+        <!-- config/packages/mailer.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:framework="http://symfony.com/schema/dic/symfony"
+            xsi:schemaLocation="http://symfony.com/schema/dic/services
+                https://symfony.com/schema/dic/services/services-1.0.xsd
+                http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+            <framework:config>
+                <framework:mailer>
+                    <framework:envelope>
+                        <framework:recipient>youremail@example.com</framework:recipient>
+                        <framework:allowed-recipient>internal@example.com</framework:allowed-recipient>
+                        <framework:allowed-recipient>internal-.*@example.(com|fr)</framework:allowed-recipient>
+                    </framework:envelope>
+                </framework:mailer>
+            </framework:config>
+        </container>
+
+    .. code-block:: php
+
+        // config/packages/mailer.php
+        use Symfony\Config\FrameworkConfig;
+
+        return static function (FrameworkConfig $framework): void {
+            $framework->mailer()
+                ->envelope()
+                    ->recipients(['youremail@example.com'])
+                    ->allowedRecipients([
+                        'internal@example.com',
+                        'internal-.*@example.(com|fr)',
+                    ])
+            ;
+        };
 
 .. _mailer-headers:
 


### PR DESCRIPTION
Add ``asset_mapper``, ``terminate_on_cache_hit`` and ``allowed_recipients`` to the Framework Configuration Reference.

Fixes #22181
Fixes #22182
Fixes #22183