### PR TITLE
[Console] Document the optional PSR container parameter

### DIFF
--- a/components/console.rst
+++ b/components/console.rst
@@ -64,6 +64,48 @@ This is useful when creating a :doc:`single-command application </components/con
 
 See the :doc:`/console` article for information about how to create commands.
 
+Using a PSR Container
+---------------------
+
+.. versionadded:: 8.1
+
+    The ``$container`` parameter of the ``Application`` class was introduced
+    in Symfony 8.1.
+
+The ``Application`` class accepts an optional third argument: a PSR-11
+``ContainerInterface``. When provided, the application
+automatically wires several services from the container:
+
+* ``event_dispatcher`` — sets the event dispatcher via ``setDispatcher()``
+* ``console.argument_resolver`` — sets the argument resolver via ``setArgumentResolver()``
+* ``console.command_loader`` — sets the command loader via ``setCommandLoader()``
+* ``console.command.ids`` — eagerly loads commands registered in the container
+* ``services_resetter`` — resets services after ``run()`` completes
+
+When using Symfony's :class:`Symfony\\Component\\DependencyInjection\\ContainerInterface`,
+the ``kernel.environment`` and ``kernel.debug`` parameters are also displayed
+in the application's long version output.
+
+This allows you to build console applications with dependency injection without
+requiring HttpKernel or FrameworkBundle::
+
+    #!/usr/bin/env php
+    <?php
+
+    use Symfony\Component\Console\Application;
+    use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+    require __DIR__.'/vendor/autoload.php';
+
+    $container = new ContainerBuilder();
+    // ... register your services, commands, etc.
+    $container->compile();
+
+    $application = new Application('my-cli', '1.0', $container);
+    $application->run();
+
+All existing behavior is preserved when no container is passed.
+
 Learn more
 ----------
 


### PR DESCRIPTION
Fixes #22185

Document the new `$container` parameter added to `Application` in Symfony 8.1.