### PR TITLE
 Remove annotations package from flex documentation

### DIFF
--- a/setup/flex.rst
+++ b/setup/flex.rst
@@ -71,8 +71,8 @@ manual steps:
 
    .. code-block:: terminal
 
-       $ composer require annotations asset orm twig \
-         logger mailer form security translation validator
+       $ composer require asset orm twig logger \
+         mailer form security translation validator
        $ composer require --dev dotenv maker-bundle orm-fixtures profiler
 
 #. If the project's ``composer.json`` file doesn't contain the ``symfony/symfony``


### PR DESCRIPTION
`composer require annotations` refers to SensioFrameworkExtraBundle which is deprecated and archived for 7.x versions