### PR TITLE
[HttpKernel] Fix return type annotation in HttpKernelInterface, Importing the Resp…

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -51,13 +51,14 @@ that system::
     namespace Symfony\Component\HttpKernel;
 
     use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpFoundation\Response;
 
     interface HttpKernelInterface
     {
         // ...
 
         /**
-         * @return Response A Response instance
+         * @return a Response instance
          */
         public function handle(
             Request $request,


### PR DESCRIPTION
…onse class

Correct the return type annotation in the handle method. Importing the Response class

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
