### PR TITLE
[Index] Improve discoverability of the Components documentation

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -64,7 +64,13 @@ Topics
 Components
 ----------
 
-Read the :doc:`Components </components/>` documentation.
+Symfony provides a set of decoupled and reusable PHP components that can be
+used independently in any project:
+
+.. toctree::
+    :maxdepth: 1
+
+    components/index
 
 Reference Documents
 -------------------


### PR DESCRIPTION
This replaces the plain text link to the Components page with a proper `toctree` entry, so that Components appear in the sidebar navigation alongside Topics, Reference and other sections.

Currently, the Components section on the documentation index is a single line of text (`Read the Components documentation.`), making it very easy to miss. As noted in #21282 and [this comment](https://github.com/symfony/symfony-docs/issues/21282#issuecomment-3878378556), many components (Finder, PropertyAccess, DomCrawler, VarExporter, etc.) are essentially hidden since they are not referenced from the Topics section either.

While #21282 asks for a link in the main site navigation (which is outside the scope of this repo), this change improves discoverability within the documentation itself.