### PR TITLE
[Twig] Enhance documentation about is_granted() twig function

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -187,12 +187,12 @@ is_granted
 
 .. code-block:: twig
 
-    {{ is_granted(role, object = null, field = null) }}
+    {{ is_granted(attribute, subject = null, field = null) }}
 
-``role``
+``attribute``
     **type**: ``string``
-``object`` *(optional)*
-    **type**: ``object``
+``subject`` *(optional)*
+    **type**: ``mixed``
 ``field`` *(optional)*
     **type**: ``string``
 


### PR DESCRIPTION
It's better to call the var `attribute`, because it's the Symfony
naming:
* https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php#L27
* https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php#L97-L107

And it fixes a typo on the
type:https://github.com/symfony/symfony/blob/8.1/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php#L37
