### PR TITLE
[Config] Add introduction to parameters and clarify section titles

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -174,10 +174,16 @@ configuration files, even if they use a different format:
 Configuration Parameters
 ------------------------
 
-Sometimes the same configuration value is used in several configuration files.
-Instead of repeating it, you can define it as a "parameter", which is like a
-reusable configuration value. By convention, parameters are defined under the
-``parameters`` key in the ``config/services.yaml`` file:
+Parameters are key-value pairs stored in the
+:doc:`service container </service_container>`. They allow you to centralize
+configuration values that can be reused across your application's configuration
+files and injected into services.
+
+When the same configuration value is used in several places, define it as a
+parameter to avoid repetition. Like other configuration values, parameters can
+also be :ref:`overridden per environment <configuration-environments>`. By
+convention, parameters are defined under the ``parameters`` key in the
+``config/services.yaml`` file:
 
 .. configuration-block::
 

--- a/configuration.rst
+++ b/configuration.rst
@@ -174,9 +174,13 @@ configuration files, even if they use a different format:
 Configuration Parameters
 ------------------------
 
-Sometimes the same configuration value is used in several configuration files.
-Instead of repeating it, you can define it as a "parameter", which is like a
-reusable configuration value. By convention, parameters are defined under the
+Parameters are key-value pairs stored in the
+:doc:`service container </service_container>`. They allow you to centralize
+configuration values that can be reused across your application's configuration
+files and injected into services.
+
+When the same configuration value is used in several places, define it as a
+parameter to avoid repetition. By convention, parameters are defined under the
 ``parameters`` key in the ``config/services.yaml`` file:
 
 .. configuration-block::

--- a/service_container.rst
+++ b/service_container.rst
@@ -783,15 +783,15 @@ reload the next page (even if that page doesn't use this service).
 
 .. _service-container-parameters:
 
-Service Parameters
-------------------
+Container Parameters and Service References
+-------------------------------------------
 
 In addition to holding service objects, the container also holds configuration,
 called **parameters**. The main article about Symfony configuration explains the
 :ref:`configuration parameters <configuration-parameters>` in detail and shows
 all their types (string, boolean, array, binary and PHP constant parameters).
 
-However, there is another type of parameter related to services. In YAML config,
+When defining services, you may also need to reference other services. In YAML config,
 any string which starts with ``@`` is considered as the ID of a service, instead
 of a regular string. In PHP config use the ``service()`` function:
 

--- a/service_container.rst
+++ b/service_container.rst
@@ -785,7 +785,7 @@ reload the next page (even if that page doesn't use this service).
 .. _service-parameters:
 
 Container Parameters and Service References
---------------------------------------------
+-------------------------------------------
 
 In addition to holding service objects, the container also holds configuration,
 called **parameters**. The main article about Symfony configuration explains the

--- a/service_container.rst
+++ b/service_container.rst
@@ -782,16 +782,17 @@ to something else - e.g. ``$mainEmail`` - you will get a clear exception when yo
 reload the next page (even if that page doesn't use this service).
 
 .. _service-container-parameters:
+.. _service-parameters:
 
-Service Parameters
-------------------
+Container Parameters and Service References
+--------------------------------------------
 
 In addition to holding service objects, the container also holds configuration,
 called **parameters**. The main article about Symfony configuration explains the
 :ref:`configuration parameters <configuration-parameters>` in detail and shows
 all their types (string, boolean, array, binary and PHP constant parameters).
 
-However, there is another type of parameter related to services. In YAML config,
+When defining services, you may also need to reference other services. In YAML config,
 any string which starts with ``@`` is considered as the ID of a service, instead
 of a regular string. In PHP config use the ``service()`` function:
 

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -676,7 +676,7 @@ logic about those arguments::
         }
     }
 
-The ``#[Autowire]`` attribute can also be used for :ref:`parameters <service-parameters>`,
+The ``#[Autowire]`` attribute can also be used for :ref:`container parameters <service-container-parameters>`,
 :doc:`complex expressions </service_container/expression_language>` and even
 :ref:`environment variables <config-env-vars>` ,
 :doc:`including env variable processors </configuration/env_var_processors>`::
@@ -690,7 +690,7 @@ The ``#[Autowire]`` attribute can also be used for :ref:`parameters <service-par
     class MessageGenerator
     {
         public function __construct(
-            // use the %...% syntax for parameters
+            // use the %...% syntax for container parameters
             #[Autowire('%kernel.project_dir%/data')]
             private string $dataDir,
 

--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -676,7 +676,7 @@ logic about those arguments::
         }
     }
 
-The ``#[Autowire]`` attribute can also be used for :ref:`parameters <service-parameters>`,
+The ``#[Autowire]`` attribute can also be used for :ref:`parameters <service-container-parameters>`,
 :doc:`complex expressions </service_container/expression_language>` and even
 :ref:`environment variables <config-env-vars>` ,
 :doc:`including env variable processors </configuration/env_var_processors>`::


### PR DESCRIPTION
Add an introductory paragraph to the parameters section in `configuration.rst`, rename the misleading "Service Parameters" title to "Container Parameters and Service References" in `service_container.rst`, and fix a broken `:ref:` in `autowiring.rst`.

Refs #21938