### PR TITLE
[DependencyInjection][Routing] Revert `ServicesConfig` and `RoutesConfig` documentation

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -390,22 +390,6 @@ files directly in the ``config/packages/`` directory.
                 ],
             ],
 
-.. tip::
-
-    The optional :ref:`PHP configuration wrappers <service-container-configuration-wrappers>`
-    also work with environment-specific configuration::
-
-        // config/services.php
-        use Symfony\Config\ServicesConfig;
-
-        return [
-            'when@dev' => new ServicesConfig(
-                services: [
-                    'App\\' => ['resource' => '../src/', 'exclude' => '../src/{Entity,Kernel.php}'],
-                ],
-            ),
-        ];
-
 .. seealso::
 
     See the ``configureContainer()`` method of

--- a/routing.rst
+++ b/routing.rst
@@ -130,21 +130,6 @@ the ``BlogController``:
             ],
         ]);
 
-When using the PHP format, you can wrap your configuration arrays with
-:class:`Symfony\\Config\\RoutesConfig`. This wrapper, which is entirely optional,
-provides `psalm array-shape`_ type definitions that enable autocompletion and
-static analysis in IDEs::
-
-    // config/routes.php
-    use Symfony\Config\RoutesConfig;
-
-    return new RoutesConfig([
-        'controllers' => [
-            'resource' => '../src/Controller/',
-            'type' => 'attribute',
-        ],
-    ]);
-
 .. _routing-matching-http-methods:
 
 Matching HTTP Methods
@@ -2788,4 +2773,3 @@ Learn more about Routing
 .. _`PCRE Unicode properties`: https://www.php.net/manual/en/regexp.reference.unicode.php
 .. _`FOSJsRoutingBundle`: https://github.com/FriendsOfSymfony/FOSJsRoutingBundle
 .. _`backed enumerations`: https://www.php.net/manual/en/language.enumerations.backed.php
-.. _`psalm array-shape`: https://psalm.dev/docs/annotating_code/type_syntax/array_types/#array-shapes

--- a/service_container.rst
+++ b/service_container.rst
@@ -231,35 +231,6 @@ each time you ask for it.
     If you'd prefer to manually wire your service, you can
     :ref:`use explicit configuration <services-explicitly-configure-wire-services>`.
 
-.. _service-container-configuration-wrappers:
-
-When using the PHP format, you can wrap your configuration arrays with
-:class:`Symfony\\Config\\ServicesConfig`. This wrapper, which is entirely optional,
-provides `psalm array-shape`_ type definitions that enable autocompletion and
-static analysis in IDEs::
-
-    // config/services.php
-    use App\Service\MyService;
-    use Symfony\Config\ServicesConfig;
-
-    return new ServicesConfig(
-        defaults: [
-            'autowire' => true,
-            'autoconfigure' => true,
-        ],
-        services: [
-            'App\\' => ['resource' => '../src/'],
-            MyService::class => null,
-        ],
-    );
-
-.. tip::
-
-    The ``ServicesConfig`` constructor also accepts ``imports``, ``parameters``
-    and ``instanceof`` arguments. The ``_defaults`` and ``_instanceof`` keys
-    should not be included in the ``services`` array; use the dedicated
-    ``defaults`` and ``instanceof`` parameters instead.
-
 .. _service-container_limiting-to-env:
 
 Limiting Services to a specific Symfony Environment
@@ -1453,4 +1424,3 @@ Learn more
 
 .. _`glob pattern`: https://en.wikipedia.org/wiki/Glob_(programming)
 .. _`Symfony Fundamentals screencast series`: https://symfonycasts.com/screencast/symfony-fundamentals
-.. _`psalm array-shape`: https://psalm.dev/docs/annotating_code/type_syntax/array_types/#array-shapes


### PR DESCRIPTION
This PR is related to code [62129](https://github.com/symfony/symfony/pull/62129)

This PR reverts #21989 and some related changes cause the relevant code were removed

Maybe the auto-generated `config/reference.php` deserves to be documented, but it's not the point here