### PR TITLE
[DependencyInjection] Reduce redundancy between service container and autowiring docs

### DIFF
--- a/service_container.rst
+++ b/service_container.rst
@@ -43,6 +43,8 @@ service's class or interface name. Want to :doc:`log </logging>` something? No p
         }
     }
 
+.. _services-debug-container-types:
+
 What other services are available? Find out by running:
 
 .. code-block:: terminal
@@ -427,28 +429,10 @@ suggestion.
 By the way, this method of adding dependencies to your ``__construct()`` method is
 called *dependency injection*.
 
-.. _services-debug-container-types:
-
 How should you know to use ``LoggerInterface`` for the type-hint? You can either
-read the docs for whatever feature you're using, or get a list of autowireable
-type-hints by running:
-
-.. code-block:: terminal
-
-    $ php bin/console debug:autowiring
-
-      # this is just a *small* sample of the output...
-
-      Describes a logger instance.
-      Psr\Log\LoggerInterface - alias:monolog.logger
-
-      Request stack that controls the lifecycle of requests.
-      Symfony\Component\HttpFoundation\RequestStack - alias:request_stack
-
-      RouterInterface is the interface that all Router classes must implement.
-      Symfony\Component\Routing\RouterInterface - alias:router.default
-
-      [...]
+read the docs for whatever feature you're using, or use the ``debug:autowiring``
+command :ref:`shown earlier <services-debug-container-types>` to get a list of
+all autowireable type-hints in your application.
 
 In addition to injecting services, you can also pass scalar values and collections
 as arguments of other services:
@@ -781,6 +765,13 @@ But, isn't this fragile? Fortunately, no! If you rename the ``$adminEmail`` argu
 to something else - e.g. ``$mainEmail`` - you will get a clear exception when you
 reload the next page (even if that page doesn't use this service).
 
+.. tip::
+
+    Instead of configuring scalar arguments in YAML/XML, you can use the
+    ``#[Autowire]`` attribute directly in your class to inject parameters,
+    environment variables, expressions and even specific services. See
+    :ref:`autowire-attribute` for details.
+
 .. _service-container-parameters:
 
 Service Parameters
@@ -949,6 +940,13 @@ But, you can control this and pass in a different logger:
 
 This tells the container that the ``$logger`` argument to ``__construct`` should use
 service whose id is ``monolog.logger.request``.
+
+.. tip::
+
+    If you need to choose between multiple implementations of the same type
+    across your application, you can use
+    :ref:`named autowiring aliases <autowiring-multiple-implementations-same-type>`
+    instead of manually wiring each injection point.
 
 For a list of possible logger services that can be used with autowiring, run:
 
@@ -1274,7 +1272,11 @@ able to type-hint arguments in the ``__construct()`` method of your services and
 the container will automatically pass you the correct arguments. This entire entry
 has been written around autowiring.
 
-For more details about autowiring, check out :doc:`/service_container/autowiring`.
+For more details, check out :doc:`/service_container/autowiring`, which covers
+how autowiring works, how to handle
+:ref:`multiple implementations of the same type <autowiring-multiple-implementations-same-type>`,
+the :ref:`#[Autowire] attribute <autowire-attribute>` for non-service
+arguments, and :ref:`generating closures <autowiring_closures>` from services.
 
 .. _services-autoconfigure:
 


### PR DESCRIPTION
This addresses part of #22232 by reducing redundant content between
`service_container.rst` and `service_container/autowiring.rst`.

Changes:
- Remove duplicate `debug:autowiring` output that appeared twice in
  `service_container.rst` (replace with a back-reference to the first
  occurrence)
- Add a tip about the `#[Autowire]` attribute after the "Manually Wiring
  Arguments" section, pointing to the dedicated autowiring docs
- Add a cross-reference to named autowiring aliases in the "choose a
  specific service" section
- Expand the "The autowire Option" section with specific links to
  key topics covered in the autowiring page (multiple implementations,
  `#[Autowire]` attribute, closures)

Fixes #22232