### PR TITLE
[MakerBundle] Remove reference to versions not supporting Symfony 8

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -23,7 +23,7 @@ Installing Doctrine
 -------------------
 
 First, install Doctrine support via the ``orm`` :ref:`Symfony pack <symfony-packs>`,
-as well as the MakerBundle, which will help generate some code:
+as well as the `MakerBundle`_, which will help generate some code:
 
 .. code-block:: terminal
 
@@ -184,14 +184,10 @@ Whoa! You now have a new ``src/Entity/Product.php`` file::
 
 .. tip::
 
-    Starting in `MakerBundle`_: v1.57.0 - You can pass either ``--with-uuid`` or
-    ``--with-ulid`` to ``make:entity``. Leveraging Symfony's :doc:`Uid Component </components/uid>`,
-    this generates an entity with the ``id`` type as :ref:`Uuid <uuid>`
-    or :ref:`Ulid <ulid>` instead of ``int``.
-
-.. note::
-
-    Starting in v1.44.0 - `MakerBundle`_: only supports entities using PHP attributes.
+    You can pass either ``--with-uuid`` or ``--with-ulid`` to ``make:entity``.
+    Leveraging Symfony's :doc:`Uid Component </components/uid>`, this generates
+    an entity with the ``id`` type as :ref:`Uuid <uuid>` or :ref:`Ulid <ulid>`
+    instead of ``int``.
 
 .. note::
 
@@ -358,8 +354,8 @@ already installed:
 
 .. tip::
 
-    Starting in `MakerBundle`_: v1.56.0 - Passing ``--formatted`` to ``make:migration``
-    generates a nice and tidy migration file.
+    Passing ``--formatted`` to ``make:migration`` generates a nice and tidy
+    migration file.
 
 If everything worked, you should see something like this:
 

--- a/doctrine/associations.rst
+++ b/doctrine/associations.rst
@@ -81,10 +81,10 @@ This will generate your new entity class::
 
 .. tip::
 
-    Starting in `MakerBundle`_: v1.57.0 - You can pass either ``--with-uuid`` or
-    ``--with-ulid`` to ``make:entity``. Leveraging Symfony's :doc:`Uid Component </components/uid>`,
-    this generates an entity with the ``id`` type as :ref:`Uuid <uuid>`
-    or :ref:`Ulid <ulid>` instead of ``int``.
+    You can pass either ``--with-uuid`` or ``--with-ulid`` to ``make:entity``.
+    Leveraging Symfony's :doc:`Uid Component </components/uid>`, this generates
+    an entity with the ``id`` type as :ref:`Uuid <uuid>` or :ref:`Ulid <ulid>`
+    instead of ``int``.
 
 Mapping the ManyToOne Relationship
 ----------------------------------
@@ -633,4 +633,3 @@ Doctrine's `Association Mapping Documentation`_.
 .. _`orphanRemoval`: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/working-with-associations.html#orphan-removal
 .. _`Mastering Doctrine Relations`: https://symfonycasts.com/screencast/doctrine-relations
 .. _`ArrayCollection`: https://www.doctrine-project.org/projects/doctrine-collections/en/1.6/index.html
-.. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html

--- a/security.rst
+++ b/security.rst
@@ -211,10 +211,10 @@ from the `MakerBundle`_:
 
 .. tip::
 
-    Starting in `MakerBundle`_: v1.57.0 - You can pass either ``--with-uuid`` or
-    ``--with-ulid`` to ``make:user``. Leveraging Symfony's :doc:`Uid Component </components/uid>`,
-    this generates a ``User`` entity with the ``id`` type as :ref:`Uuid <uuid>`
-    or :ref:`Ulid <ulid>` instead of ``int``.
+    You can pass either ``--with-uuid`` or ``--with-ulid`` to ``make:user``.
+    Leveraging Symfony's :doc:`Uid Component </components/uid>`, this
+    generates a ``User`` entity with the ``id`` type as :ref:`Uuid <uuid>` or
+    :ref:`Ulid <ulid>` instead of ``int``.
 
 If your user is a Doctrine entity, like in the example above, don't forget
 to create the tables by :ref:`creating and running a migration <doctrine-creating-the-database-tables-schema>`:
@@ -226,8 +226,8 @@ to create the tables by :ref:`creating and running a migration <doctrine-creatin
 
 .. tip::
 
-    Starting in `MakerBundle`_: v1.56.0 - Passing ``--formatted`` to ``make:migration``
-    generates a nice and tidy migration file.
+    Passing ``--formatted`` to ``make:migration`` generates a nice and tidy
+    migration file.
 
 .. _where-do-users-come-from-user-providers:
 .. _security-user-providers:

--- a/security/passwords.rst
+++ b/security/passwords.rst
@@ -225,10 +225,10 @@ you'll see a success message and a list of any other steps you need to do.
 
 .. tip::
 
-    Starting in `MakerBundle`_: v1.57.0 - You can pass either ``--with-uuid`` or
-    ``--with-ulid`` to ``make:reset-password``. Leveraging Symfony's :doc:`Uid Component </components/uid>`,
-    the entities will be generated with the ``id`` type as :ref:`Uuid <uuid>`
-    or :ref:`Ulid <ulid>` instead of ``int``.
+    You can pass either ``--with-uuid`` or ``--with-ulid`` to ``make:reset-password``.
+    Leveraging Symfony's :doc:`Uid Component </components/uid>`, the entities
+    will be generated with the ``id`` type as :ref:`Uuid <uuid>` or
+    :ref:`Ulid <ulid>` instead of ``int``.
 
 You can customize the reset password bundle's behavior by updating the
 ``reset_password.yaml`` file. For more information on the configuration,

--- a/webhook.rst
+++ b/webhook.rst
@@ -159,8 +159,8 @@ The easiest way is using the maker command:
 
 .. tip::
 
-    Starting in `MakerBundle`_ ``v1.58.0``, the ``make:webhook`` command generates
-    both the parser and consumer classes and updates your configuration automatically.
+    The ``make:webhook`` command generates both the parser and consumer classes
+    and updates your configuration automatically.
 
 When extending :class:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParser`,
 you need to implement two methods:
@@ -664,5 +664,4 @@ For advanced use cases, you can implement custom sending logic using
 :class:`Symfony\\Component\\Webhook\\Server\\TransportInterface` to control
 header generation, signing, and HTTP transport.
 
-.. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
 .. _`Webhook Component for Email Events screencast`: https://symfonycasts.com/screencast/mailtrap/email-event-webhook


### PR DESCRIPTION
MakerBundle supports Symfony 8 since version [1.65](https://github.com/symfony/maker-bundle/releases/tag/v1.65.0)
I suggest to remove notes about older version from 8.0 documentation as there is no longer value in specifying which version is required