### PR TITLE
[Security] Update the security config reference

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -19,26 +19,6 @@ key in your application configuration.
     namespace and the related XSD schema is available at:
     ``https://symfony.com/schema/dic/services/services-1.0.xsd``
 
-**Basic Options**:
-
-* `access_denied_url`_
-* `erase_credentials`_
-* `expose_security_errors`_
-* `hide_user_not_found`_ (deprecated)
-* `session_fixation_strategy`_
-
-**Advanced Options**:
-
-Some of these options define tens of sub-options and they are explained in
-separate articles:
-
-* `access_decision_manager`_
-* `access_control`_
-* `password_hashers`_
-* `firewalls`_
-* `providers`_
-* `role_hierarchy`_
-
 access_denied_url
 -----------------
 
@@ -171,7 +151,7 @@ authorization decisions (e.g. when ``is_granted()`` is called):
     voters, see :doc:`/security/voters`.
 
 strategy
-........
+~~~~~~~~
 
 **type**: ``string`` **default**: ``affirmative``
 
@@ -179,7 +159,7 @@ Defines the strategy used by the access decision manager to decide whether
 access should be granted. Read about :ref:`all the available strategies <security-voters-change-strategy>`.
 
 allow_if_all_abstain
-....................
+~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``false``
 
@@ -188,7 +168,7 @@ abstain (no voter explicitly grants or denies access). If ``false``
 (the default), access is denied when all voters abstain.
 
 allow_if_equal_granted_denied
-.............................
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **type**: ``boolean`` **default**: ``true``
 
@@ -198,7 +178,7 @@ voters denying access, this option determines the final decision. If ``true``
 (the default), access is granted in case of a tie.
 
 service
-.......
+~~~~~~~
 
 **type**: ``string`` **default**: ``null``
 
@@ -210,7 +190,7 @@ When this option is set, the ``strategy``, ``allow_if_all_abstain`` and
 ``allow_if_equal_granted_denied`` options are ignored.
 
 strategy_service
-................
+~~~~~~~~~~~~~~~~
 
 **type**: ``string`` **default**: ``null``
 
@@ -352,8 +332,8 @@ the ``debug:firewall`` command:
 
 .. _reference-security-firewall-form-login:
 
-``form_login`` Authentication
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+form_login
+~~~~~~~~~~
 
 When using the ``form_login`` authentication listener beneath a firewall,
 there are several common options for configuring the "form login" experience.
@@ -640,8 +620,8 @@ The ``invalidate_session`` option allows you to redefine this behavior. Set this
 option to ``false`` in every firewall and the user will only be logged out from
 the current firewall and not the other ones.
 
-``path``
-........
+path
+....
 
 **type**: ``string`` **default**: ``/logout``
 
@@ -693,8 +673,12 @@ An arbitrary string used to identify the token (and check its validity afterward
 
 .. _reference-security-firewall-json-login:
 
-JSON Login Authentication
-~~~~~~~~~~~~~~~~~~~~~~~~~
+json_login
+~~~~~~~~~~
+
+Use it to create an endpoint in your application that provides tokens to access
+APIs based on a username (or email) and password. Read more about
+:ref:`JSON login authentication <security-json-login>`.
 
 check_path
 ..........
@@ -789,12 +773,12 @@ Use this option to modify the expected request body structure. See
 
 .. _reference-security-ldap:
 
-LDAP Authentication
-~~~~~~~~~~~~~~~~~~~
+form_login_ldap
+~~~~~~~~~~~~~~~
 
-There are several options for connecting against an LDAP server,
-using the ``form_login_ldap``, ``http_basic_ldap`` and ``json_login_ldap`` authentication
-providers or the ``ldap`` user provider.
+This section shows the LDAP authentication options when using a login form, but
+the same options work when using HTTP basic (``http_basic_ldap``) or JSON login
+(``json_login_ldap``) with LDAP.
 
 For even more details, see :doc:`/security/ldap`.
 
@@ -845,8 +829,13 @@ providers: ``form_login_ldap`` or ``http_basic_ldap`` or ``json_login_ldap``.
 
 .. _reference-security-firewall-x509:
 
-X.509 Authentication
-~~~~~~~~~~~~~~~~~~~~
+x509
+~~~~
+
+The :ref:`X.509 authenticator <security-x509-client-certificates>` provided by
+Symfony lets your web server handle the entire authentication process. Symfony
+then extracts the user's email address from the client certificate and uses it
+as the user identifier.
 
 .. configuration-block::
 
@@ -940,8 +929,13 @@ and the value of this option is ``'CN'``, the user identifier will be ``'user1'`
 
 .. _reference-security-firewall-remote-user:
 
-Remote User Authentication
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+remote_user
+~~~~~~~~~~~
+
+In addition to :ref:`X.509 authentication <reference-security-firewall-x509>`
+based on client certificates, Symfony also supports :ref:`pre-authentication <security-remote-users>`
+performed by web servers (e.g. Kerberos) that store the authenticated user
+identifier in the ``REMOTE_USER`` environment variable.
 
 .. configuration-block::
 
@@ -1004,8 +998,8 @@ user
 
 The name of the ``$_SERVER`` parameter holding the user identifier.
 
-``access_token`` Authentication
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+access_token
+~~~~~~~~~~~~
 
 When using the ``access_token`` authentication mechanism beneath a firewall,
 the application authenticates users based on an API token sent with the request.
@@ -1058,9 +1052,8 @@ failure_handler
 The service id of a service that implements
 :class:`Symfony\\Component\\Security\\Http\\Authentication\\AuthenticationFailureHandlerInterface`.
 
-
-``login_link`` Authentication
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+login_link
+~~~~~~~~~~
 
 When using the ``login_link`` authentication mechanism beneath a firewall,
 users are authenticated via a unique, signed URL sent to them (e.g. by email).
@@ -1142,8 +1135,8 @@ The service id of a service that implements
 
 .. _reference-security-firewall-login-throttling:
 
-``login_throttling``
-~~~~~~~~~~~~~~~~~~~~
+login_throttling
+~~~~~~~~~~~~~~~~
 
 Login throttling limits the number of failed login attempts over a given period of
 time. This helps protect against brute-force attacks. For even more details, see
@@ -1199,8 +1192,8 @@ takes precedence over ``cache_pool``.
 
 .. _reference-security-firewall-remember-me:
 
-``remember_me``
-~~~~~~~~~~~~~~~
+remember_me
+~~~~~~~~~~~
 
 The "remember me" authentication mechanism allows users to stay authenticated
 across browser sessions by storing a special cookie. For even more details, see
@@ -1331,8 +1324,8 @@ the "remember me" feature should be activated.
 
 .. _reference-security-firewall-context:
 
-Firewall Context
-~~~~~~~~~~~~~~~~
+context
+~~~~~~~
 
 If your application uses multiple :ref:`firewalls <firewalls-authentication>`, you'll notice that
 if you're authenticated in one firewall, you're not automatically authenticated
@@ -1509,8 +1502,8 @@ session only if the application actually accesses the User object, (e.g. calling
             // ...
         };
 
-User Checkers
-~~~~~~~~~~~~~
+user_checker
+~~~~~~~~~~~~
 
 During the authentication of a user, additional checks might be required to
 verify if the identified user is allowed to log in. Each firewall can include
@@ -1518,7 +1511,7 @@ a ``user_checker`` option to define the service used to perform those checks.
 
 Learn more about user checkers in :doc:`/security/user_checkers`.
 
-Required Badges
+required_badges
 ~~~~~~~~~~~~~~~
 
 Firewalls can configure a list of required badges that must be present on the authenticated passport:

--- a/security.rst
+++ b/security.rst
@@ -1290,6 +1290,8 @@ which authenticates them.
 
 You can learn all about this authenticator in :doc:`/security/access_token`.
 
+.. _security-x509-client-certificates:
+
 X.509 Client Certificates
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1419,6 +1421,8 @@ ways:
 You can customize the name of some parameters under the ``x509`` key.
 See :ref:`the x509 configuration reference <reference-security-firewall-x509>`
 for more details.
+
+.. _security-remote-users:
 
 Remote Users
 ~~~~~~~~~~~~


### PR DESCRIPTION
Spotted by #22233.

In some config references we apply some local JS code to better dispaly the full paths of config options (see https://symfony.com/doc/current/reference/configuration/framework.html and https://symfony.com/doc/current/reference/configuration/twig.html).

In other reference docs we haven't enabled that yet. (e.g. on security). The reason is that for this JS to work properly, headings must match exactly the option names. This PR does that for SEcurity so we can enable it.