### PR TITLE
 Recommend setting opcache.interned_strings_buffer

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -134,6 +134,10 @@ it's recommended to change these settings as follows:
     ; maximum number of files that can be stored in the cache
     opcache.max_accelerated_files=32531
 
+    ; memory (in MB) for interned strings; the default value (8 MB) is too low
+    ; for Symfony applications, which use many fully-qualified class names
+    opcache.interned_strings_buffer=32
+
 .. _performance-dont-check-timestamps:
 
 Don't Check PHP Files Timestamps


### PR DESCRIPTION
Suggest tuning `opcache.interned_strings_buffer` in the OPcache section of the performance page, since the default value is too low for typical Symfony applications.

Closes #22250.