### PR TITLE
[Mailer] Refactor mailer test to use static methods

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1974,14 +1974,14 @@ the :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\MailerAssertionsTrait`::
         {
             $client = static::createClient();
             $client->request('GET', '/mail/send');
-            $this->assertResponseIsSuccessful();
+            self::assertResponseIsSuccessful();
 
-            $this->assertEmailCount(1); // use assertQueuedEmailCount() when using Messenger
+            self::assertEmailCount(1); // use assertQueuedEmailCount() when using Messenger
 
-            $email = $this->getMailerMessage();
+            $email = self::getMailerMessage();
 
-            $this->assertEmailHtmlBodyContains($email, 'Welcome');
-            $this->assertEmailTextBodyContains($email, 'Welcome');
+            self::assertEmailHtmlBodyContains($email, 'Welcome');
+            self::assertEmailTextBodyContains($email, 'Welcome');
         }
     }
 


### PR DESCRIPTION
Methods in MailerAssertionsTrait are static and should not be called via `$this`
