### PR TITLE
[Form] Revert `with_reset` option documentation for FormFlow in 7.4

### DIFF
--- a/form/form_flow.rst
+++ b/form/form_flow.rst
@@ -178,11 +178,6 @@ finish buttons:
     $builder->add('navigator', NavigatorFlowType::class);
 
 Buttons are automatically shown or hidden depending on the current step.
-To also include a reset button, use the ``with_reset`` option:
-
-    $builder->add('navigator', NavigatorFlowType::class, [
-        'with_reset' => true,
-    ]);
 
 Custom Navigation Buttons
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #22256

If possible, this should not be merged in 8.1, or I can send another PR this version