### PR TITLE
[Testing] Fix DOCtor-RST lint errors

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -1013,14 +1013,14 @@ you can use a real browser instead of the test client. This is called an
 **end-to-end test**, and it is an effective way to test the application.
 
 You can achieve this using the Panther component. Learn more about
-:doc:`E2E testing in Symfony </testing/end_to_end>`.
+:doc:`End-to-End testing in Symfony </testing/end_to_end>`.
 
 .. _testing-application-assertions:
 
 Test Assertions Defined by Symfony
 ----------------------------------
 
-If your tests are based on PHPUnit, you can use any `PHPUnit assertion`_ in
+If your tests are based on PHPUnit, you can use any `PHPUnit Assertion`_ in
 your tests. Symfony also provides many additional assertions.
 
 Response Assertions


### PR DESCRIPTION
Fixes the two DOCtor-RST errors currently red on the `7.4` branch (regressions from #22257):

- `testing.rst:1023`: the `PHPUnit assertion` link reference does not match the link definition `PHPUnit Assertion` (line 1249). Restore the capitalization so the reference resolves.
- `testing.rst:1016`: replace `E2E` with `End-to-End` in the `:doc:` text (the `End to End Tests (E2E)` section title is already whitelisted in `.doctor-rst.yaml`).