### PR TITLE
[Testing] Document how to access assertions

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -971,7 +971,7 @@ you can use a real browser instead of the test client. This is called an
 **end-to-end test**, and it is an effective way to test the application.
 
 You can achieve this using the Panther component. Learn more about
-:doc:`E2E testing in Symfony </testing/end_to_end>`.
+:doc:`End-to-End testing in Symfony </testing/end_to_end>`.
 
 .. _testing-application-assertions:
 
@@ -983,6 +983,11 @@ your tests. Symfony also provides many additional assertions.
 
 Response Assertions
 ~~~~~~~~~~~~~~~~~~~
+
+To use these assertions, your test class must extend
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`, use
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\BrowserKitAssertionsTrait` or
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestAssertionsTrait`.
 
 ``assertResponseIsSuccessful(string $message = '')``
     Asserts that the response was successful (HTTP status is 2xx).
@@ -1007,7 +1012,7 @@ Response Assertions
     :method:`Symfony\\Component\\HttpFoundation\\Response::getFormat` method
     is the same as the expected value.
 ``assertResponseIsUnprocessable(string $message = '')``
-    Asserts the response is unprocessable (HTTP status is 422)
+    Asserts the response is unprocessable (HTTP status is 422).
 
 .. versionadded:: 6.4
 
@@ -1017,6 +1022,11 @@ Response Assertions
 Request Assertions
 ~~~~~~~~~~~~~~~~~~
 
+To use these assertions, your test class must extend
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`, use
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\BrowserKitAssertionsTrait` or
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestAssertionsTrait`.
+
 ``assertRequestAttributeValueSame(string $name, string $expectedValue, string $message = '')``
     Asserts the given :ref:`request attribute <component-foundation-attributes>`
     is set to the expected value.
@@ -1025,6 +1035,11 @@ Request Assertions
 
 Browser Assertions
 ~~~~~~~~~~~~~~~~~~
+
+To use these assertions, your test class must extend
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`, use
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\BrowserKitAssertionsTrait` or
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestAssertionsTrait`.
 
 ``assertBrowserHasCookie(string $name, string $path = '/', ?string $domain = null, string $message = '')``/``assertBrowserNotHasCookie(string $name, string $path = '/', ?string $domain = null, string $message = '')``
     Asserts that the test Client does (not) have the given cookie set
@@ -1044,6 +1059,11 @@ Browser Assertions
 
 Crawler Assertions
 ~~~~~~~~~~~~~~~~~~
+
+To use these assertions, your test class must extend
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`, use
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\DomCrawlerAssertionsTrait` or
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestAssertionsTrait`.
 
 ``assertSelectorExists(string $selector, string $message = '')``/``assertSelectorNotExists(string $selector, string $message = '')``
     Asserts that the given selector does (not) match at least one element
@@ -1089,6 +1109,10 @@ Crawler Assertions
 Mailer Assertions
 ~~~~~~~~~~~~~~~~~
 
+To use these assertions, your test class must extend
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase`, or use
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\MailerAssertionsTrait`.
+
 ``assertEmailCount(int $count, ?string $transport = null, string $message = '')``
     Asserts that the expected number of emails was sent.
 ``assertQueuedEmailCount(int $count, ?string $transport = null, string $message = '')``
@@ -1129,6 +1153,10 @@ Mailer Assertions
 Notifier Assertions
 ~~~~~~~~~~~~~~~~~~~
 
+To use these assertions, your test class must extend
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\KernelTestCase`, or use
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\NotificationAssertionsTrait`.
+
 ``assertNotificationCount(int $count, string $transportName = null, string $message = '')``
     Asserts that the given number of notifications has been created
     (in total or for the given transport).
@@ -1158,6 +1186,11 @@ Notifier Assertions
 
 HttpClient Assertions
 ~~~~~~~~~~~~~~~~~~~~~
+
+To use these assertions, your test class must extend
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestCase`, use
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\HttpClientAssertionsTrait` or
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\WebTestAssertionsTrait`.
 
 .. tip::
 
@@ -1203,5 +1236,5 @@ Learn more
 .. _`Doctrine data fixtures`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html
 .. _`DoctrineFixturesBundle documentation`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html
 .. _`SymfonyMakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
-.. _`PHPUnit Assertion`: https://docs.phpunit.de/en/10.5/assertions.html
+.. _`PHPUnit assertion`: https://docs.phpunit.de/en/10.5/assertions.html
 .. _`section 4.1.18 of RFC 3875`: https://tools.ietf.org/html/rfc3875#section-4.1.18


### PR DESCRIPTION
I continue with some ideas about [Testing documentation](https://symfony.com/doc/6.4/testing.html#test-assertions-defined-by-symfony)
Currently, assertions are documented but without informations about how to access to them. For some components, this information can be found in the testing part, but it's not available for all of them

Edit : I made additional changes to fix CI