### PR TITLE
[HttpFoundation] Document session locking limitation for RedisSessionHandler and MemcachedSessionHandler

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -540,14 +540,19 @@ installed and configured the `phpredis extension`_.
 
 You have two different options to use Redis to store sessions:
 
-The first PHP-based option is to configure Redis session handler directly
-in the server ``php.ini`` file:
+The first option is to configure the Redis session handler directly in the
+server ``php.ini`` file. This approach uses PHP's native session locking,
+which prevents race conditions when multiple requests access the same session:
 
 .. code-block:: ini
 
     ; php.ini
     session.save_handler = redis
     session.save_path = "tcp://192.168.0.178:6379?auth=REDIS_PASSWORD"
+
+    ; session locking is disabled by default in the phpredis extension
+    ; see https://github.com/phpredis/phpredis#php-session-handler for all options
+    redis.session.locking_enabled = 1
 
 The second option is to configure Redis sessions in Symfony. First, define
 a Symfony service for the connection to the Redis server:
@@ -692,17 +697,27 @@ configuration option to tell Symfony to use this service as the session handler:
             ;
         };
 
-Symfony will now use your Redis server to read and write the session data. The
-main drawback of this solution is that Redis does not perform session locking,
-so you can face *race conditions* when accessing sessions. For example, you may
-see an *"Invalid CSRF token"* error because two requests were made in parallel
-and only the first one stored the CSRF token in the session.
+Symfony will now use your Redis server to read and write the session data.
+
+.. warning::
+
+    ``RedisSessionHandler`` does not perform session locking. If your
+    application makes concurrent requests that write to the session (e.g.
+    JavaScript requests), this can cause *race conditions* and data loss. A
+    typical symptom is an *"Invalid CSRF token"* error when two requests run
+    in parallel and only one stores the CSRF token.
+
+    To get session locking, use the ``php.ini``-based option described above,
+    which relies on PHP's native Redis session handler.
 
 .. seealso::
 
     If you use Memcached instead of Redis, follow a similar approach but
     replace ``RedisSessionHandler`` by
     :class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\MemcachedSessionHandler`.
+    The same session locking limitation applies; to enable locking, configure
+    Memcached as the session handler via ``php.ini`` instead (the Memcached
+    PECL extension enables session locking by default).
 
 .. tip::
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | yes
| New docs?     | no
| Applies to    | 6.4
| Fixed tickets | symfony/symfony#4976

`RedisSessionHandler` and `MemcachedSessionHandler` do not perform session locking, which can lead to race conditions and data loss when concurrent requests write to the same session. This was mentioned in a single sentence with no solution offered.

This PR clarifies that the `php.ini`-based option (using PHP's native session handler) is the way to get session locking, documents that `redis.session.locking_enabled = 1` must be explicitly set (disabled by default in phpredis), and notes that the Memcached PECL extension enables locking by default.