### PR TITLE
[Setup] Update WSL local cert path

### DIFF
--- a/setup/symfony_cli.rst
+++ b/setup/symfony_cli.rst
@@ -197,6 +197,9 @@ everything for you:
 
     .. code-block:: terminal
 
+        $ explorer.exe `wslpath -w $HOME/.config/symfony-cli/certs`
+
+        # In symfony-cli before v5.17, use this path
         $ explorer.exe `wslpath -w $HOME/.symfony5/certs`
 
     In the file explorer window that just opened, double-click on the file


### PR DESCRIPTION
`symfony` cli creates the certificate in a different path. 

```sh
> find /home -name "default.p12" -type f
/home/user/.config/symfony-cli/certs/default.p12
```

This path changed in symfony-cli since v5.17.0 according [to this warning](https://github.com/symfony-cli/symfony-cli/blob/main/util/homedir.go#L64).

This PR updates this path to import the CA certificate into the host OS.
