### PR TITLE
[Cli] Document new `open` option for `server:start` command

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -144,3 +144,4 @@ whitelist:
         - 'the `HTML5 color format`_ (``/^#[0-9a-f]{6}$/i``). If it doesn''t match it,'
         - '.. deprecated:: 2.29' # UX TogglePassword
         - '.. versionadded:: 3.11.0' # MonologBundle
+        - '.. versionadded:: 5.16' # Symfony CLI

--- a/setup/symfony_cli.rst
+++ b/setup/symfony_cli.rst
@@ -113,6 +113,15 @@ Now browse the given URL or run the following command to open it in the browser:
 
     $ symfony open:local
 
+.. versionadded:: 5.16
+
+    Starting from Symfony CLI 5.16, you can add ``--open`` option when you
+    start the local server to open your project directly in the browser:
+
+    .. code-block:: terminal
+
+        $ symfony server:start --open
+
 .. tip::
 
     If you work on more than one project, you can run multiple instances of the


### PR DESCRIPTION
I recently discovered this new option, I think it's worth to document it 

[Cli PR](https://github.com/symfony-cli/symfony-cli/pull/668) for reference