### PR TITLE
 Add note regarding 'multiple' option and 'File' constraint in upload_file.rst

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -94,6 +94,11 @@ so Symfony doesn't try to get/set its value from the related entity::
         }
     }
 
+.. note::
+
+    If you set ``multiple`` to ``true`` for multi-file selection, make sure to wrap the :doc:`File </reference/constraints/File>`
+    constraint in :doc:`All </reference/constraints/All>` so validation works correctly.
+
 Now, update the template that renders the form to display the new ``brochure``
 field (the exact template code to add depends on the method used by your application
 to :doc:`customize form rendering </form/form_customization>`):


### PR DESCRIPTION
If you set 'multiple' option to 'true' in combination with the 'File' constraint, as shown in the code listing on the page, validation fails with an ambiguous error message ("This value should be of type string"). This is because form submission will return an array of upload files, while the 'File' constraint is only intended for a single object. The correct approach is to wrap the 'File' constraint within an 'All' constraint. This change adds a note to highlight this pitfall.
