### PR TITLE
[Form] Clarify that data transformers reshape the empty_data return value

### DIFF
--- a/reference/forms/types/integer.rst
+++ b/reference/forms/types/integer.rst
@@ -80,7 +80,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
 .. include:: /reference/forms/types/options/empty_data_declaration.rst.inc
 
-The default value is ``''`` (the empty string).
+The default value is ``''`` (the empty string), but submitted empty values
+return ``null`` (the field's data transformer reshapes the value).
 
 .. include:: /reference/forms/types/options/empty_data_description.rst.inc
 

--- a/reference/forms/types/money.rst
+++ b/reference/forms/types/money.rst
@@ -121,7 +121,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
 .. include:: /reference/forms/types/options/empty_data_declaration.rst.inc
 
-The default value is ``''`` (the empty string).
+The default value is ``''`` (the empty string), but submitted empty values
+return ``null`` (the field's data transformer reshapes the value).
 
 .. include:: /reference/forms/types/options/empty_data_description.rst.inc
 

--- a/reference/forms/types/number.rst
+++ b/reference/forms/types/number.rst
@@ -78,7 +78,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
 .. include:: /reference/forms/types/options/empty_data_declaration.rst.inc
 
-The default value is ``''`` (the empty string).
+The default value is ``''`` (the empty string), but submitted empty values
+return ``null`` (the field's data transformer reshapes the value).
 
 .. include:: /reference/forms/types/options/empty_data_description.rst.inc
 

--- a/reference/forms/types/options/empty_data_description.rst.inc
+++ b/reference/forms/types/options/empty_data_description.rst.inc
@@ -24,7 +24,8 @@ value will be set. Use the ``data`` option or the ``placeholder`` key of the
 
 .. warning::
 
-    :doc:`Form data transformers </form/data_transformers>` will still be
-    applied to the ``empty_data`` value. This means that an empty string will
-    be cast to ``null``. Use a custom data transformer if you explicitly want
-    to return the empty string.
+    :doc:`Form data transformers </form/data_transformers>` are applied to
+    the ``empty_data`` value before it is returned. For example, numeric
+    field types (``IntegerType``, ``NumberType``, ``MoneyType``,
+    ``PercentType``, ``RangeType``) cast the empty string to ``null``. Use
+    a custom data transformer if a different return value is required.

--- a/reference/forms/types/percent.rst
+++ b/reference/forms/types/percent.rst
@@ -94,7 +94,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
 .. include:: /reference/forms/types/options/empty_data_declaration.rst.inc
 
-The default value is ``''`` (the empty string).
+The default value is ``''`` (the empty string), but submitted empty values
+return ``null`` (the field's data transformer reshapes the value).
 
 .. include:: /reference/forms/types/options/empty_data_description.rst.inc
 

--- a/reference/forms/types/range.rst
+++ b/reference/forms/types/range.rst
@@ -49,7 +49,8 @@ These options inherit from the :doc:`FormType </reference/forms/types/form>`:
 
 .. include:: /reference/forms/types/options/empty_data_declaration.rst.inc
 
-The default value is ``''`` (the empty string).
+The default value is ``''`` (the empty string), but submitted empty values
+return ``null`` (the field's data transformer reshapes the value).
 
 .. include:: /reference/forms/types/options/empty_data_description.rst.inc
 


### PR DESCRIPTION
Reorders the `empty_data` warning to explain why a field can return `null` even when its default is `''` (the data transformer rewrites the value), and lists the numeric field types where this happens. Adds an inline note in `IntegerType`, `NumberType`, `MoneyType`, `PercentType` and `RangeType` to surface the actual returned value next to the configured default.

Fixes #22274