### PR TITLE
[KeyManagement] Initial documentation for the new KeyManagement component

### DIFF
--- a/components/key-management.rst
+++ b/components/key-management.rst
@@ -182,8 +182,76 @@ Envelopes are always randomized: there is no deterministic counterpart to
 the ``$deterministic`` flag of the direct path. A stable output would require
 a stable data key, which ``generateDataKey()`` refuses to return by contract.
 When equal plaintexts must yield equal ciphertexts, encrypt through the
-direct path on a backend that offers the flag, or keep a blind index (an
-HMAC of the plaintext) in a sibling column.
+direct path on a backend that offers the flag, or keep a
+:ref:`blind index <key-management-blind-index>` in a sibling column.
+
+.. _key-management-blind-index:
+
+Blind Indexes
+-------------
+
+An encrypted column cannot be searched: encryption is randomized, so two
+encryptions of the same value differ and ``WHERE email = ?`` never matches.
+A blind index keeps a searchable trace of the value in a sibling column, a
+keyed digest that is equal for equal values and matched exactly::
+
+    use Symfony\Component\KeyManagement\BlindIndex\Email;
+
+    // minted once with "key-management:generate-data-key" and kept wrapped
+    // in the configuration
+    $index = new Email($kms, $wrappedIndexKey);
+
+    $user->setEmail($email);
+    $user->setEmailIndex($index->of($email));               // on the way in
+
+    $repository->findOneBy([                                // and on the way out
+        'emailIndex' => $index->of($email),
+    ]);
+
+The tags are derived under a data key of its own, wrapped by the KMS and
+unwrapped once per process, so every backend can drive an index and the KMS
+is not reached per value. That key must be used by nothing else and, above
+all, must **never rotate**: every tag already written was derived under it,
+and a new key matches none of them.
+
+:class:`Symfony\\Component\\KeyManagement\\BlindIndex` indexes the value it
+is given, byte for byte. Anything the value has to go through first belongs
+in a subclass overriding ``project()``, and it belongs there rather than at
+the call sites: a tag computed on a trimmed value and searched on an
+untrimmed one silently matches nothing, which is the failure the whole
+arrangement exists to avoid. Two projections ship:
+
+* :class:`Symfony\\Component\\KeyManagement\\BlindIndex\\Email` folds the
+  domain and leaves the local part alone, which is what RFC 5321 says about
+  each;
+* :class:`Symfony\\Component\\KeyManagement\\BlindIndex\\EmailDomain` keeps
+  the domain only, which answers "every account of that company" without the
+  database holding a single address.
+
+That is also how far a partial search goes here: rather than making one
+index searchable by pieces, name the question and index the answer in a
+column of its own.
+
+The keyed function is
+:class:`Symfony\\Component\\KeyManagement\\BlindIndex\\HmacSha256` by
+default, which needs nothing beyond what PHP always has.
+:class:`Symfony\\Component\\KeyManagement\\BlindIndex\\Blake2b` is around
+three times faster for the same 32 bytes of tag and requires the sodium
+extension, which a row carrying several tags notices and a row carrying one
+does not. Which one is in use is part of the stored format: the same value
+gives a different tag under each, so changing it means reindexing.
+
+.. warning::
+
+    Equal values give equal tags, so anyone reading the column learns which
+    rows share a value, and how often each occurs. On a column with few
+    distinct values, or one whose distribution is known, that is enough to
+    recover the values themselves by frequency analysis. Index what is
+    high-entropy and looked up by equality, and leave the rest to a
+    decrypted scan.
+
+On a Doctrine entity, Symfony fills these columns for you; see
+:ref:`key-management-blind-index-doctrine`.
 
 .. _key-management-data-key-store:
 

--- a/components/key-management.rst
+++ b/components/key-management.rst
@@ -1,0 +1,764 @@
+The KeyManagement Component
+===========================
+
+    The KeyManagement Component provides a unified abstraction over Key Management
+    Systems (KMS) such as AWS KMS or HashiCorp Vault Transit. It exposes a
+    small high-level API to encrypt and decrypt payloads, and to generate
+    data encryption keys for envelope encryption, without ever exposing
+    the master key material to the application.
+
+.. warning::
+
+    The KeyManagement component is :doc:`experimental </contributing/code/experimental>`
+    and is not covered by Symfony's :doc:`Backward Compatibility Promise </contributing/code/bc>`.
+
+If you're using the Symfony Framework, read the
+:doc:`Symfony Framework KMS documentation </key-management>`.
+
+.. versionadded:: 8.2
+
+    The KeyManagement component was introduced in Symfony 8.2.
+
+Installation
+------------
+
+.. code-block:: terminal
+
+    $ composer require symfony/key-management
+
+.. include:: /components/require_autoload.rst.inc
+
+Each KMS backend ships as its own Composer package: install only the bridge(s)
+you need. The component itself includes three local backends (libsodium,
+OpenSSL, sealed box) suitable for development, tests and self-hosted setups.
+
+Two Encryption Modes
+--------------------
+
+The component offers two complementary APIs:
+
+* **Direct mode**: encrypt small payloads (config secrets, API tokens,
+  identifiers, ...) by handing the plaintext to the KMS and getting back an
+  opaque :class:`Symfony\\Component\\KeyManagement\\Ciphertext`. Backed by
+  :class:`Symfony\\Component\\KeyManagement\\EncrypterInterface` /
+  :class:`Symfony\\Component\\KeyManagement\\DecrypterInterface`.
+
+* **Envelope mode**: encrypt arbitrary-size payloads (files, JSON
+  documents, database rows, ...). The KMS only ever sees a short data
+  encryption key (DEK); the bulk plaintext is encrypted locally with that
+  DEK using AES-256-GCM. Backed by
+  :class:`Symfony\\Component\\KeyManagement\\EnvelopeEncrypterInterface` and the
+  :class:`Symfony\\Component\\KeyManagement\\Envelope` value object.
+
+Both modes share the same configured backend; pick the API that matches the
+size and lifecycle of the payload. As a rule of thumb:
+
+* **Direct mode** for sub-kB payloads (config secrets, API tokens, short
+  identifiers). Network round-trip cost dominates; the KMS does the actual
+  encryption. AWS KMS caps direct ``encrypt`` at 4 KiB; cloud bridges
+  typically have similar limits.
+
+* **Envelope mode** for anything larger (files, JSON documents, database
+  rows, ...). The bulk encryption is local and scales linearly with the
+  payload size. The :class:`Symfony\\Component\\KeyManagement\\Envelope` itself
+  is a binary frame, suitable for direct persistence.
+
+Envelope mode itself comes in two flavors, which differ only in where the data
+key comes from and what the frame carries:
+
+* :class:`Symfony\\Component\\KeyManagement\\EnvelopeEncrypter` mints a fresh
+  data key per payload and ships it wrapped inside the envelope. One KMS
+  round-trip per ``encrypt``/``decrypt`` call, and a frame that decrypts with
+  nothing but the KMS.
+
+* :class:`Symfony\\Component\\KeyManagement\\StoredEnvelopeEncrypter` takes the
+  data key from a :ref:`data key store <key-management-data-key-store>` and
+  ships a 16-byte reference to it. One KMS round-trip per data key and per
+  process, and a master key that can be rotated by rewrapping a handful of
+  rows instead of rewriting every payload.
+
+Direct Mode
+-----------
+
+The simplest way to encrypt and decrypt with a managed key::
+
+    use Symfony\Component\KeyManagement\KeyLoader\InMemoryKeyLoader;
+    use Symfony\Component\KeyManagement\Local\SodiumKms;
+
+    $kms = new SodiumKms(new InMemoryKeyLoader([
+        'app-key' => sodium_crypto_aead_xchacha20poly1305_ietf_keygen(),
+    ]));
+
+    $ciphertext = $kms->encrypt('app-key', 'hello world');
+    // returns Symfony\Component\KeyManagement\Ciphertext (Stringable)
+
+    $plaintext = $kms->decrypt($ciphertext);
+    // returns 'hello world'
+
+The ``Ciphertext`` object is a :phpclass:`Stringable` opaque container that
+bundles the bytes returned by the backend with the ``$keyId`` needed to
+decrypt them. Persist it as-is (stringification yields the raw bytes).
+
+Additional Authenticated Data
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``$aad`` argument is integrity-protected (the same bytes must be
+supplied at decryption time) but is **not** encrypted. Use it to bind a
+ciphertext to a context (tenant id, user id, document type, ...) so that a
+ciphertext stolen from one row cannot be replayed in another::
+
+    $ciphertext = $kms->encrypt('app-key', $payload, aad: 'tenant=acme');
+    $plaintext = $kms->decrypt($ciphertext, aad: 'tenant=acme');
+
+AAD is treated as opaque bytes. If you have structured data, serialize it
+to a stable form (e.g. canonical JSON with sorted keys) before passing it.
+Backends that cannot enforce AAD throw
+:class:`Symfony\\Component\\KeyManagement\\Exception\\UnsupportedOperationException`
+on a non-empty value rather than silently ignoring it.
+
+Deterministic Encryption
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default each call uses a fresh random nonce, so the same plaintext
+encrypts to a different ciphertext every time. Setting ``$deterministic``
+to ``true`` derives the nonce from the AAD and the plaintext keyed by the
+master key (HMAC-SHA512 truncated for OpenSSL, keyed BLAKE2b for libsodium),
+so the same ``(key, AAD, plaintext)`` triple always yields the same
+ciphertext. This enables exact-match indexing on encrypted columns at the
+cost of leaking equality::
+
+    $ciphertext = $kms->encrypt('app-key', $email, deterministic: true);
+
+The AAD takes part in that derivation, and does so unambiguously: two
+encryptions differing only by their AAD would otherwise reuse a nonce under
+the same key, which hands an attacker the authentication key of the AEAD.
+Two ciphertexts are therefore only comparable when they were produced with
+the same AAD.
+
+Only the local symmetric backends offer it. Sealed box and every cloud
+bridge (AWS KMS, Azure Key Vault, Google Cloud KMS, Vault Transit) throw
+:class:`Symfony\\Component\\KeyManagement\\Exception\\UnsupportedOperationException`
+when ``$deterministic`` is ``true``.
+
+Envelope Mode
+-------------
+
+For arbitrary-size payloads, use
+:class:`Symfony\\Component\\KeyManagement\\EnvelopeEncrypter`. The KMS only ever sees
+the wrapped data key; the bulk plaintext is encrypted locally with
+AES-256-GCM::
+
+    use Symfony\Component\KeyManagement\Envelope;
+    use Symfony\Component\KeyManagement\EnvelopeEncrypter;
+
+    $envelopeEncrypter = new EnvelopeEncrypter($kms);
+
+    $envelope = $envelopeEncrypter->encrypt('app-key', $largePayload);
+    file_put_contents('/var/data/payload.bin', $envelope);
+
+    $payload = $envelopeEncrypter->decrypt(
+        Envelope::fromBytes(file_get_contents('/var/data/payload.bin'))
+    );
+
+The :class:`Symfony\\Component\\KeyManagement\\Envelope` value object is
+self-contained here: it carries the key id, the wrapped DEK, the IV, the AEAD
+tag and the ciphertext, laid out by
+:class:`Symfony\\Component\\KeyManagement\\SelfContainedFormat`. It is
+:phpclass:`Stringable` (yields the raw frame) and round-trips through
+:method:`Symfony\\Component\\KeyManagement\\Envelope::fromBytes`, which resolves
+the format from the leading byte.
+
+The same envelope decrypts identically regardless of which KMS backend
+produced it, as long as a backend with access to the same master key is
+used to decrypt. This makes it safe to swap backends (e.g. local during
+development, AWS KMS in production) without re-encrypting.
+
+The ``$aad`` argument is forwarded **both** to the KMS (binding the wrapped
+DEK) and to the local AEAD (binding the bulk ciphertext). The double
+binding is defense in depth: the local AEAD always catches AAD mismatches
+even on backends where the KMS cannot enforce them.
+
+Envelopes are always randomized: there is no deterministic counterpart to
+the ``$deterministic`` flag of the direct path. A stable output would require
+a stable data key, which ``generateDataKey()`` refuses to return by contract.
+When equal plaintexts must yield equal ciphertexts, encrypt through the
+direct path on a backend that offers the flag, or keep a blind index (an
+HMAC of the plaintext) in a sibling column.
+
+.. _key-management-data-key-store:
+
+Data Key Stores
+---------------
+
+A self-contained envelope pays one KMS round-trip per payload and carries a
+couple hundred bytes of wrapped key in every payload, and its master key
+cannot be rotated without rewriting the payloads that refer to it. A
+:class:`Symfony\\Component\\KeyManagement\\DataKeyStoreInterface` inverts that
+trade-off: it persists wrapped data keys, and each payload carries a
+reference to one instead of carrying the key itself::
+
+    use Symfony\Component\KeyManagement\StoredEnvelopeEncrypter;
+
+    $encrypter = new StoredEnvelopeEncrypter($store);
+
+    $envelope = $encrypter->encrypt('user.email', 'jane@example.com');
+    $plaintext = $encrypter->decrypt($envelope);
+
+The first argument is no longer a master key but a **scope**: whatever the
+application decides may share a data key, typically a column, a tenant or a
+purpose. Values encrypted under the same scope reuse the same key until it
+is retired, and each retirement only affects payloads written afterwards,
+since older payloads keep referring to the key they were written with. The
+master key and the KMS client belong to the store, which records them next
+to each data key so they can later be swapped.
+
+The store hands out a
+:class:`Symfony\\Component\\KeyManagement\\DataKeyHandle` rather than a
+:class:`Symfony\\Component\\KeyManagement\\DataKey`: a store exists precisely to
+unwrap once and encrypt many payloads, so the plaintext is retained until the
+handle is released or destroyed, and wiped there. It lives for the lifetime
+of the store, which means the lifetime of a process; implementations must not
+persist it nor share it between processes.
+
+The AAD binds the payload only, not the stored data key: that key is shared
+by the whole scope, so binding it to the AAD of one payload would make it
+unusable for the next.
+
+Reading a Dataset Written Before the Store
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The two envelope shapes never mix inside one frame, but a dataset that is
+being migrated holds both. Pass a decrypter for the self-contained format as
+the second argument and both keep resolving::
+
+    $encrypter = new StoredEnvelopeEncrypter($store, new EnvelopeEncrypter($kms));
+
+New payloads are then written in the stored format while the ones written
+before keep resolving through the KMS. Without that fallback, a
+self-contained envelope is refused with a
+:class:`Symfony\\Component\\KeyManagement\\Exception\\LogicException` rather than
+silently mishandled.
+
+Rewrapping and Rotating
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`Symfony\\Component\\KeyManagement\\RewrappableDataKeyStoreInterface` is
+the administration half of the contract, kept apart so that the encryption
+path only ever sees ``DataKeyStoreInterface``:
+
+* ``all(?string $client = null)``: walks the stored keys as
+  :class:`Symfony\\Component\\KeyManagement\\StoredDataKey` instances, oldest
+  first, optionally restricted to those wrapped by a given client;
+* ``rewrap(string $reference, Ciphertext $wrapped, string $client)``: replaces
+  the wrapping of a stored key, leaving its reference and its scope untouched
+  so that payloads referring to it keep resolving;
+* ``rotate(string $scope)``: retires the current key of a scope by creating a
+  fresh one, which becomes current.
+
+Moving an entire dataset to another master key, or to another provider,
+therefore rewrites a handful of rows and not a single payload. In a Symfony
+application, the ``key-management:rewrap-data-keys`` command does exactly
+that; see :ref:`key-management-store-config` in the framework documentation.
+
+The only store shipped for production use keeps its rows in a Doctrine DBAL
+table (see :ref:`key-management-bridges`); backing another storage is a
+matter of implementing the interface against it.
+
+Backends
+--------
+
+The component ships three local backends. Cloud and remote KMS backends are
+distributed as separate bridges (see :ref:`key-management-bridges` below).
+
+Local Symmetric (libsodium)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`Symfony\\Component\\KeyManagement\\Local\\SodiumKms` uses
+XChaCha20-Poly1305-IETF AEAD with a random 24-byte nonce. Each entry
+returned by the configured key loader must be exactly 32 bytes. Generate
+keys with::
+
+    $key = sodium_crypto_aead_xchacha20poly1305_ietf_keygen();
+    file_put_contents('/etc/kms/app-key', $key);
+
+This backend is the recommended default for local development and tests
+when the ``sodium`` extension is available (bundled with PHP since 7.2 but
+sometimes disabled at compile time).
+
+Local Symmetric (OpenSSL)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`Symfony\\Component\\KeyManagement\\Local\\OpenSslKms` uses AES-256-GCM with a
+random 12-byte IV. Each entry must be exactly 32 bytes. Use this backend
+when ``ext-sodium`` is unavailable or when you want to share keys with
+systems that only speak AES.
+
+Local Asymmetric (Sealed Box)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`Symfony\\Component\\KeyManagement\\Local\\SealedBoxKms` uses anonymous
+public-key encryption (``sodium_crypto_box_seal``: Curve25519 +
+XSalsa20-Poly1305). It enables a "Symfony Secrets"-style workflow in
+self-hosted setups:
+
+* deployments that load only the **public key** can encrypt new payloads
+  (developers commit encrypted blobs to git) but cannot decrypt anything;
+* deployments that load the full **keypair** (secret + public, the
+  libsodium 64-byte convention) can decrypt at runtime.
+
+Generate a keypair with::
+
+    $keypair   = sodium_crypto_box_keypair();              // 64 bytes
+    $publicKey = sodium_crypto_box_publickey($keypair);    // 32 bytes
+
+Sealed-box ciphertexts cannot be decrypted by the encrypting party (no
+authenticated tag from the recipient's side), so this backend does not
+support AAD nor deterministic encryption.
+
+Key Loaders
+~~~~~~~~~~~
+
+The three local backends source key material through a
+:class:`Symfony\\Component\\KeyManagement\\KeyLoader\\KeyLoaderInterface`. Two
+implementations ship with the component:
+
+* :class:`Symfony\\Component\\KeyManagement\\KeyLoader\\InMemoryKeyLoader`:
+  ``array<string, string>`` keyed by id. Useful for tests and for keys
+  passed through environment variables.
+
+* :class:`Symfony\\Component\\KeyManagement\\KeyLoader\\FilesystemKeyLoader`: reads
+  files from a local directory. The key id is the file basename; an
+  optional extension can be configured (``.bin``, ``.key``, ...).
+
+To load keys from S3, FTP, Azure Blob, or any other Flysystem-compatible
+filesystem, install ``symfony/flysystem-key-management``
+(see :ref:`key-management-bridges`).
+
+DSN Schemes
+~~~~~~~~~~~
+
+The matching factories accept a DSN, which is the format the FrameworkBundle
+configuration uses internally:
+
+==========================================  =======================================================================
+Scheme                                       Description
+==========================================  =======================================================================
+``sodium://``                                XChaCha20 / keys inlined in the DSN
+``sodium+dir:///path/to/keys``               XChaCha20 / keys read from a local directory
+``openssl://``                               AES-256-GCM / keys inlined in the DSN
+``openssl+dir:///path/to/keys``              AES-256-GCM / keys read from a local directory
+``sodium-sealed-box://``                     Sealed box / keys inlined in the DSN
+``sodium-sealed-box+dir:///path/to/keys``    Sealed box / keys read from a local directory
+==========================================  =======================================================================
+
+For the inline schemes, declare keys via the ``keys[<id>]=<base64>`` query
+option. Both standard base64 and the URL-safe variant (RFC 4648 section 5, with or
+without ``=`` padding) are accepted, so you can drop the ``urlencode()`` step
+when crafting DSNs by hand:
+
+.. code-block:: text
+
+    sodium://?keys[app-key]=BASE64_ENCODED_32_BYTES&keys[other]=BASE64_ENCODED_32_BYTES
+
+For the directory schemes, an optional ``ext`` query option restricts the
+loader to a given file extension:
+
+.. code-block:: text
+
+    sodium+dir:///etc/kms?ext=.bin
+
+That permissive decoding is exposed as
+:class:`Symfony\\Component\\KeyManagement\\Base64UrlSafe`, which the bridges
+share: Azure Key Vault speaks base64url for every value it exchanges and
+Google Cloud KMS needs it to assemble the JWT it authenticates with.
+
+.. _key-management-bridges:
+
+Bridges
+-------
+
+AWS KMS
+~~~~~~~
+
+Install the bridge:
+
+.. code-block:: terminal
+
+    $ composer require symfony/aws-key-management
+
+It implements both
+:class:`Symfony\\Component\\KeyManagement\\EncrypterInterface` and
+:class:`Symfony\\Component\\KeyManagement\\DataKeyGeneratorInterface`, backed by the
+lightweight `async-aws/kms`_ client. Encryption, decryption and data-key
+generation never expose the master key: AWS performs them server-side::
+
+    use AsyncAws\Core\Configuration;
+    use AsyncAws\Kms\KmsClient;
+    use Symfony\Component\KeyManagement\Bridge\AwsKms\AwsKms;
+
+    $kms = new AwsKms(new KmsClient(Configuration::create([
+        'region' => 'eu-west-1',
+    ])));
+
+    // Use the key ARN, key id, or alias.
+    $ciphertext = $kms->encrypt('alias/app-key', 'hello world');
+
+DSN scheme:
+
+.. code-block:: text
+
+    aws-kms://[<accessKey>:<secretKey>@]<host>[:<port>]?region=<region>[&session_token=<token>&scheme=http]
+
+The host ``default`` selects the public AWS endpoint for the region; any
+other host is treated as a custom endpoint (LocalStack, VPC endpoint, ...).
+Leaving the credentials out lets ``async-aws`` walk the standard provider
+chain (env vars, instance profile, ...). The ``scheme`` option only applies
+to custom hosts and defaults to ``https``; pass ``scheme=http`` when
+targeting a local sandbox such as LocalStack
+(``aws-kms://localhost:4566?region=eu-west-1&scheme=http``). Combining
+``scheme`` with ``host=default`` is rejected with an explicit
+``InvalidArgumentException``.
+
+AWS KMS exposes AAD as ``EncryptionContext`` (``array<string, string>``).
+To stay compatible with the opaque-bytes contract of
+``EncrypterInterface``, this bridge stores the AAD as a single
+base64-encoded entry under a conventional key. Cross-bridge interoperability
+is therefore not guaranteed when AAD is non-empty.
+
+Azure Key Vault
+~~~~~~~~~~~~~~~
+
+Install the bridge:
+
+.. code-block:: terminal
+
+    $ composer require symfony/azure-keyvault-key-management
+
+It implements
+:class:`Symfony\\Component\\KeyManagement\\EncrypterInterface`,
+:class:`Symfony\\Component\\KeyManagement\\DecrypterInterface` and
+:class:`Symfony\\Component\\KeyManagement\\DataKeyGeneratorInterface`, backed by the
+`Azure Key Vault REST API`_ (and Managed HSM). Encryption, decryption and
+data-key wrapping never expose the master key: Azure performs them
+server-side::
+
+    use Symfony\Component\HttpClient\HttpClient;
+    use Symfony\Component\KeyManagement\Bridge\AzureKeyVault\AzureKeyVault;
+    use Symfony\Component\KeyManagement\Bridge\AzureKeyVault\ClientCredentialsTokenProvider;
+
+    $client = HttpClient::createForBaseUri('https://my-vault.vault.azure.net/');
+    $tokens = new ClientCredentialsTokenProvider(
+        $client,
+        $_SERVER['AZURE_TENANT_ID'],
+        $_SERVER['AZURE_CLIENT_ID'],
+        $_SERVER['AZURE_CLIENT_SECRET'],
+    );
+
+    $kms = new AzureKeyVault($client, $tokens);
+
+DSN scheme:
+
+.. code-block:: text
+
+    azure-keyvault://<clientId>:<clientSecret>@<vault-name>.vault.azure.net?tenant=<tenantId>[&algorithm=...&wrap_algorithm=...&api_version=...&audience=...]
+
+The host is the full vault DNS (use ``<name>.managedhsm.azure.net`` for
+Managed HSM). The audience is inferred from the host suffix
+(``.managedhsm.azure.net``, ``.managedhsm.usgovcloudapi.net``,
+``.managedhsm.azure.cn`` selects the Managed HSM audience; everything else
+falls back to ``https://vault.azure.net/.default``). Override with
+``audience=...`` for sovereign clouds (US gov / China) whose audience
+differs from the commercial one. ``api_version`` defaults to ``7.4``.
+
+The default algorithm is ``RSA-OAEP-256`` for both ``encrypt``/``decrypt``
+and ``wrapKey``; ``A256GCM`` (AEAD with native AAD support) and ``A256KW``
+are accepted on Managed HSM by passing them explicitly.
+
+Decrypt is forward-compatible across algorithm rotations: AEAD ciphertexts
+embed their algorithm in the blob (``ALG.iv.tag.value``), so a bridge
+reconfigured from AEAD to RSA can still decrypt blobs written under the
+previous AEAD setup.
+
+Authentication uses Azure AD's ``client_credentials`` grant by default. To
+plug Managed Identity, Workload Identity, or any other flow, implement
+:class:`Symfony\\Component\\KeyManagement\\Bridge\\AzureKeyVault\\TokenProviderInterface`
+and pass it to ``AzureKeyVault`` directly.
+
+Google Cloud KMS
+~~~~~~~~~~~~~~~~
+
+Install the bridge:
+
+.. code-block:: terminal
+
+    $ composer require symfony/google-cloud-key-management
+
+It implements
+:class:`Symfony\\Component\\KeyManagement\\EncrypterInterface`,
+:class:`Symfony\\Component\\KeyManagement\\DecrypterInterface` and
+:class:`Symfony\\Component\\KeyManagement\\DataKeyGeneratorInterface`, backed by the
+`Google Cloud KMS REST API`_::
+
+    use Symfony\Component\HttpClient\HttpClient;
+    use Symfony\Component\KeyManagement\Bridge\GoogleCloudKms\GoogleCloudKms;
+    use Symfony\Component\KeyManagement\Bridge\GoogleCloudKms\ServiceAccountTokenProvider;
+
+    $client = HttpClient::createForBaseUri('https://cloudkms.googleapis.com/v1/');
+    $tokens = ServiceAccountTokenProvider::fromJsonFile($client, '/path/to/service-account.json');
+
+    $kms = new GoogleCloudKms($client, $tokens);
+
+    // The key id is the full Cloud KMS resource name; append
+    // /cryptoKeyVersions/<n> to pin to a version.
+    $ciphertext = $kms->encrypt(
+        'projects/my-project/locations/global/keyRings/app/cryptoKeys/master',
+        'hello world',
+    );
+
+DSN scheme:
+
+.. code-block:: text
+
+    gcp-kms://default?credentials=/path/to/service-account.json
+
+The host ``default`` selects the public Cloud KMS endpoint; any other host
+is treated as a custom endpoint. The ``credentials`` option must point at
+a service-account JSON key file.
+
+Authentication uses the JWT-bearer flow by default: the bundled
+:class:`Symfony\\Component\\KeyManagement\\Bridge\\GoogleCloudKms\\ServiceAccountTokenProvider`
+signs an assertion with the service-account RSA private key (RS256) and
+exchanges it for an access token. For Application Default Credentials, the
+GCE/GKE/Cloud Run metadata server, Workload Identity Federation, or any
+other flow, implement
+:class:`Symfony\\Component\\KeyManagement\\Bridge\\GoogleCloudKms\\TokenProviderInterface`.
+
+Cloud KMS does not expose a ``GenerateDataKey`` primitive. The bridge mirrors
+the Azure pattern: a fresh DEK is drawn locally with ``random_bytes()`` and
+wrapped via the regular ``:encrypt`` endpoint.
+
+HashiCorp Vault Transit
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Install the bridge:
+
+.. code-block:: terminal
+
+    $ composer require symfony/vault-key-management
+
+It implements both
+:class:`Symfony\\Component\\KeyManagement\\EncrypterInterface` and
+:class:`Symfony\\Component\\KeyManagement\\DataKeyGeneratorInterface`, backed by the
+`Vault Transit secret engine`_::
+
+    use Symfony\Component\HttpClient\HttpClient;
+    use Symfony\Component\KeyManagement\Bridge\Vault\TransitKms;
+
+    $kms = new TransitKms(
+        HttpClient::createForBaseUri('https://vault.example.com:8200/v1/'),
+        $_SERVER['VAULT_TOKEN'],
+    );
+
+    $ciphertext = $kms->encrypt('app-key', 'hello world');
+    // Ciphertext blob looks like "vault:v1:..."
+
+DSN scheme:
+
+.. code-block:: text
+
+    vault-transit://<token>@<host>[:<port>][/<path>][?mount=<mount>&namespace=<ns>&scheme=http]
+
+Default mount point is ``transit``. The ``namespace`` option maps to
+Vault's ``X-Vault-Namespace`` header (Vault Enterprise multi-tenancy). The
+``scheme`` option defaults to ``https``; pass ``scheme=http`` when running
+Vault locally in dev mode.
+
+The ``$aad`` argument is forwarded as Vault's ``context`` parameter (HKDF
+context, base64-encoded). It works for keys created with ``derived=true``
+and is rejected on plain symmetric keys. Vault Transit does not support
+deterministic encryption per call; the ``convergent_encryption`` feature is
+set at key creation, not negotiated per request.
+
+Flysystem
+~~~~~~~~~
+
+Install the bridge:
+
+.. code-block:: terminal
+
+    $ composer require symfony/flysystem-key-management
+
+It exposes a
+:class:`Symfony\\Component\\KeyManagement\\Bridge\\Flysystem\\FlysystemKeyLoader`
+that lets the local backends source their key material through any
+`league/flysystem`_ reader (S3, FTP, SFTP, Azure Blob, Google Cloud
+Storage, ...). It also registers three DSN schemes (``sodium+fly://``,
+``openssl+fly://`` and ``sodium-sealed-box+fly://``) that the
+FrameworkBundle picks up automatically.
+
+Doctrine DBAL
+~~~~~~~~~~~~~
+
+Install the bridge:
+
+.. code-block:: terminal
+
+    $ composer require symfony/doctrine-dbal-key-management
+
+It provides two things. The first is a
+:class:`Symfony\\Component\\KeyManagement\\Bridge\\DoctrineDbal\\EncryptedType`
+that decorates any Doctrine DBAL ``Type`` with column-level envelope
+encryption. See :ref:`key-management-doctrine` in the framework documentation.
+
+The second is a
+:class:`Symfony\\Component\\KeyManagement\\Bridge\\DoctrineDbal\\DataKeyStore`,
+the production implementation of
+:class:`Symfony\\Component\\KeyManagement\\RewrappableDataKeyStoreInterface`. It
+holds the wrapped data keys in a table of five columns and nothing more::
+
+    use Symfony\Component\KeyManagement\Bridge\DoctrineDbal\DataKeyStore;
+    use Symfony\Component\KeyManagement\StoredEnvelopeEncrypter;
+
+    $store = new DataKeyStore($connection, $clients, 'aws', 'alias/app-key');
+    $store->createTable();
+
+    $encrypter = new StoredEnvelopeEncrypter($store);
+
+``$clients`` is a PSR-11 container of KMS clients indexed by name, each one a
+``DataKeyGeneratorInterface``. Every row records which of them wrapped it,
+which is what makes a provider migration possible while the application keeps
+running.
+
+==================  =================  ==============================================================
+Column               Type               Role
+==================  =================  ==============================================================
+``id``               ``BINARY(16)``     A UUIDv7, primary key, and the reference recorded by payloads
+``scope``            ``VARCHAR(191)``   The unit a data key is shared over
+``key_material``     ``BLOB``           The wrapped data key
+``master_key_id``    ``VARCHAR(255)``   The master key that wrapped it
+``client``           ``VARCHAR(64)``    The configured KMS client able to unwrap it
+==================  =================  ==============================================================
+
+There is no timestamp column on purpose: a UUIDv7 carries its creation
+instant and sorts chronologically, so the newest row of a scope is its
+current key and the retirement age is read back from the reference itself.
+
+A scope is resolved once and then held, unwrapped, for as long as the store
+lives, which is what spares the round trips. That also means the store holds
+plaintext key material in memory: ``forget()`` drops it, and the Symfony
+wiring calls it between two units of work through the ``kernel.reset`` tag.
+
+This bridge requires Doctrine DBAL >= 4.5 (4.3 lifted the ``final``
+constructor on ``Type``, which the encrypted type needs, and 4.5 brought the
+schema editor the data key store uses).
+
+.. _key-management-wire-format:
+
+The Envelope Wire Format
+------------------------
+
+The :class:`Symfony\\Component\\KeyManagement\\Envelope` byte framing is owned by
+an :class:`Symfony\\Component\\KeyManagement\\EnvelopeFormat`, and the leading
+byte of every frame is its id, so a reader resolves the format before parsing
+anything else. Two formats ship:
+
+.. code-block:: text
+
+    # SelfContainedFormat, id 0x01
+    [0x01][2B keyIdLen][keyId][2B wrappedLen][wrappedDek][IV][tag][ciphertext]
+
+    # StoredFormat, id 0x02
+    [0x02][2B referenceLen][reference][IV][tag][ciphertext]
+
+Both map to AES-256-GCM with a 32-byte data key, a 12-byte IV and a 16-byte
+tag. That key length also matches the cross-bridge data-key intersection
+(see :class:`Symfony\\Component\\KeyManagement\\DataKeyGeneratorInterface`), so
+envelopes round-trip through every shipped backend.
+
+Ids are a wire contract: once a format ships, its id and its layout are
+frozen. A change of cipher, of lengths or of layout is a new format with a
+new id rather than an edit to an existing one.
+
+Formats are not a configuration point either. Each encrypter owns the one
+matching its shape (``EnvelopeEncrypter`` writes ``SelfContainedFormat``,
+``StoredEnvelopeEncrypter`` writes ``StoredFormat``), and
+:method:`Symfony\\Component\\KeyManagement\\EnvelopeFormat::fromId` resolves
+nothing but the formats shipped with the component, so a payload written
+anywhere reads back anywhere. A new layout is therefore added to the
+component, with its own id, rather than plugged in by an application.
+
+Serializer Integration
+----------------------
+
+When the :doc:`Serializer component </serializer>` is installed,
+the FrameworkBundle registers
+:class:`Symfony\\Component\\KeyManagement\\Serializer\\EnvelopeNormalizer`
+automatically. It encodes an ``Envelope`` to (and from) a base64-encoded
+string so it travels through any structured format (JSON, XML, YAML, ...)
+without needing per-property normalization. Useful when an envelope is a
+field of a Messenger message, an API resource, or any class going through
+the serializer.
+
+Memory Wiping
+-------------
+
+Plaintext data keys returned by
+:method:`Symfony\\Component\\KeyManagement\\DataKeyGeneratorInterface::generateDataKey`
+are wrapped in a :class:`Symfony\\Component\\KeyManagement\\DataKey` instance whose
+plaintext is **not** exposed as a public field. Access is mediated by
+:method:`Symfony\\Component\\KeyManagement\\DataKey::use`, which passes the bytes to
+a caller-provided closure and releases the reference as soon as the closure
+returns or throws::
+
+    $dataKey = $kms->generateDataKey('app-key', 32);
+
+    $ciphertext = $dataKey->use(function (string $dek): string {
+        return openssl_encrypt($plaintext, 'aes-256-gcm', $dek, \OPENSSL_RAW_DATA, $iv, $tag);
+    });
+
+When the ``sodium`` extension is available, ``sodium_memzero()`` clears the
+underlying PHP zval before the reference is dropped. Without sodium, PHP
+offers no in-place zeroing primitive, so the property is just nulled and
+the engine releases the buffer.
+
+PHP strings are reference-counted with copy-on-write, so a consumer that
+returns the plaintext, or keeps it anywhere, leaves the wipe with nothing to
+wipe. Pass the parameter straight to the crypto primitives and let it go.
+
+A :class:`Symfony\\Component\\KeyManagement\\DataKeyHandle` is the opposite
+trade-off, and the one a data key store hands out: it takes a buffer of its
+own out of the ``DataKey`` (so the ``DataKey`` still wipes what it held) and
+keeps the plaintext usable across calls until ``release()`` or destruction.
+
+This is what the envelope encrypters already do internally; you only have to
+think about it if you call ``generateDataKey()`` yourself.
+
+Testing
+-------
+
+Two in-memory doubles live in the ``Test\`` namespace, for test fixtures
+only:
+
+* :class:`Symfony\\Component\\KeyManagement\\Test\\InMemoryKms`: a no-crypto
+  ``EncrypterInterface``/``DecrypterInterface``/``DataKeyGeneratorInterface``
+  whose ciphertext blob is the plaintext behind a marker embedding the key id
+  and the AAD. Decrypting under a different key id or AAD fails, which catches
+  key-routing and AAD-binding bugs; feeding a plaintext back into ``decrypt()``
+  fails too.
+
+* :class:`Symfony\\Component\\KeyManagement\\Test\\InMemoryDataKeyStore`: an
+  array-backed ``RewrappableDataKeyStoreInterface`` that wraps its data keys
+  through a real KMS client and orders its UUIDv7 references the way a
+  database would. Its ``$maxAgeSeconds`` argument accepts ``0`` to rotate on
+  every call, which is how retirement is exercised in a test::
+
+      use Symfony\Component\KeyManagement\StoredEnvelopeEncrypter;
+      use Symfony\Component\KeyManagement\Test\InMemoryDataKeyStore;
+
+      $encrypter = new StoredEnvelopeEncrypter(new InMemoryDataKeyStore());
+
+.. _async-aws/kms: https://async-aws.com/
+.. _Azure Key Vault REST API: https://learn.microsoft.com/rest/api/keyvault/
+.. _Google Cloud KMS REST API: https://cloud.google.com/kms/docs/reference/rest
+.. _Vault Transit secret engine: https://developer.hashicorp.com/vault/docs/secrets/transit
+.. _league/flysystem: https://flysystem.thephpleague.com/

--- a/components/key-management.rst
+++ b/components/key-management.rst
@@ -643,9 +643,28 @@ Vault locally in dev mode.
 
 The ``$aad`` argument is forwarded as Vault's ``context`` parameter (HKDF
 context, base64-encoded). It works for keys created with ``derived=true``
-and is rejected on plain symmetric keys. Vault Transit does not support
-deterministic encryption per call; the ``convergent_encryption`` feature is
-set at key creation, not negotiated per request.
+and is rejected on plain symmetric keys: Vault does not reject a context on
+a non-derived key, it ignores it, so a ciphertext bound to one tenant would
+decrypt under another. The bridge therefore reads the key configuration once
+per key (``GET <mount>/keys/<name>``) whenever the AAD is non-empty, and
+throws
+:class:`Symfony\\Component\\KeyManagement\\Exception\\UnsupportedOperationException`
+when the key cannot enforce it.
+
+That read is a capability of its own, so a least-privilege token limited to
+the encryption endpoints stops working as soon as an AAD is passed:
+
+.. code-block:: text
+
+    path "transit/encrypt/*"           { capabilities = ["update"] }
+    path "transit/decrypt/*"           { capabilities = ["update"] }
+    path "transit/datakey/plaintext/*" { capabilities = ["update"] }
+    # only needed when AAD is used, to tell derived keys from non-derived ones
+    path "transit/keys/*"              { capabilities = ["read"] }
+
+Vault Transit does not support deterministic encryption per call; the
+``convergent_encryption`` feature is set at key creation, not negotiated per
+request.
 
 Flysystem
 ~~~~~~~~~
@@ -716,9 +735,25 @@ lives, which is what spares the round trips. That also means the store holds
 plaintext key material in memory: ``forget()`` drops it, and the Symfony
 wiring calls it between two units of work through the ``kernel.reset`` tag.
 
-This bridge requires Doctrine DBAL >= 4.5 (4.3 lifted the ``final``
-constructor on ``Type``, which the encrypted type needs, and 4.5 brought the
-schema editor the data key store uses).
+This bridge requires Doctrine DBAL >= 4.3, the release that lifted the
+``final`` constructor on ``Type`` the encrypted type decorates. The data key
+store describes its table through the schema editor of DBAL >= 4.5 when it is
+available and through the previous API below it; both produce the same table.
+
+Doctrine ORM
+~~~~~~~~~~~~
+
+Install the bridge:
+
+.. code-block:: terminal
+
+    $ composer require symfony/doctrine-orm-key-management
+
+It fills the blind index columns of an entity on every flush, from the
+:class:`Symfony\\Component\\KeyManagement\\Bridge\\DoctrineOrm\\Attribute\\BlindIndexed`
+attribute, and adds the data key store table to the schema the ORM generates
+so ``doctrine:schema:update`` and the migrations diff know about it. See
+:ref:`key-management-blind-index-doctrine` in the framework documentation.
 
 .. _key-management-wire-format:
 
@@ -773,7 +808,9 @@ Memory Wiping
 Plaintext data keys returned by
 :method:`Symfony\\Component\\KeyManagement\\DataKeyGeneratorInterface::generateDataKey`
 are wrapped in a :class:`Symfony\\Component\\KeyManagement\\DataKey` instance whose
-plaintext is **not** exposed as a public field. Access is mediated by
+plaintext is not a field at all, so that no dump of the object can print it:
+``var_dump()``, ``print_r()``, ``var_export()`` and the VarDumper cloner have
+nothing to reach, and ``serialize()`` throws. Access is mediated by
 :method:`Symfony\\Component\\KeyManagement\\DataKey::use`, which passes the bytes to
 a caller-provided closure and releases the reference as soon as the closure
 returns or throws::
@@ -785,9 +822,11 @@ returns or throws::
     });
 
 When the ``sodium`` extension is available, ``sodium_memzero()`` clears the
-underlying PHP zval before the reference is dropped. Without sodium, PHP
-offers no in-place zeroing primitive, so the property is just nulled and
-the engine releases the buffer.
+underlying buffer before the reference is dropped, but only while nothing
+else holds it: PHP declines to zero a string another variable shares rather
+than blank it under that other holder. Without sodium there is no in-place
+zeroing primitive at all, so the holder is only dropped and the engine
+releases the buffer when it gets to it.
 
 PHP strings are reference-counted with copy-on-write, so a consumer that
 returns the plaintext, or keeps it anywhere, leaves the wipe with nothing to

--- a/index.rst
+++ b/index.rst
@@ -38,6 +38,7 @@ Topics
     html_sanitizer
     http_cache
     http_client
+    key-management
     lock
     logging
     mailer

--- a/key-management.rst
+++ b/key-management.rst
@@ -513,13 +513,88 @@ provider, without touching a single row.
 
 This bridge requires Doctrine DBAL >= 4.5.
 
-.. note::
+.. _key-management-blind-index-doctrine:
 
-    Envelope-encrypted columns are **not searchable**: the nonce is drawn
-    afresh every time, so the same plaintext encrypts to a different
-    ciphertext on every write. If you need exact-match lookups on an
-    encrypted column, store a blind index (an HMAC of the plaintext keyed by
-    an application secret) on a sibling column.
+Searching an Encrypted Column
+-----------------------------
+
+Envelope-encrypted columns are **not searchable**: the nonce is drawn afresh
+every time, so the same plaintext encrypts to a different ciphertext on every
+write and ``WHERE email = ?`` never matches. The answer is a
+:ref:`blind index <key-management-blind-index>` in a sibling column, a keyed
+digest of the value that is equal for equal values.
+
+Register one service per question the application asks, all sharing a key of
+their own, minted once with ``key-management:generate-data-key`` and kept
+wrapped in the configuration:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        services:
+            Symfony\Component\KeyManagement\BlindIndex\Email:
+                arguments:
+                    $kms: '@key_management.app'
+                    $wrappedKey: !service
+                        class: Symfony\Component\KeyManagement\Ciphertext
+                        arguments: ['%env(base64:KMS_INDEX_KEY)%', 'alias/app-key']
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use Symfony\Component\KeyManagement\BlindIndex\Email;
+        use Symfony\Component\KeyManagement\Ciphertext;
+
+        return static function (ContainerConfigurator $container): void {
+            $container->services()
+                ->set(Email::class)
+                    ->arg('$kms', service('key_management.app'))
+                    ->arg('$wrappedKey', inline_service(Ciphertext::class)
+                        ->args([env('base64:KMS_INDEX_KEY'), 'alias/app-key']))
+            ;
+        };
+
+Then say, on the column that holds the tag, where its value comes from. A
+listener shipped by ``symfony/doctrine-bridge`` then fills it on every flush,
+so no write path has to remember it::
+
+    // src/Entity/User.php
+    use Doctrine\ORM\Mapping as ORM;
+    use Symfony\Bridge\Doctrine\Attribute\BlindIndexed;
+    use Symfony\Component\KeyManagement\BlindIndex\Email;
+
+    #[ORM\Entity]
+    #[ORM\Index(columns: ['email_index'])]
+    class User
+    {
+        #[ORM\Column(type: 'app_user_email')]
+        public string $email = '';
+
+        #[ORM\Column(length: 64)]
+        #[BlindIndexed('email', Email::class)]
+        public string $emailIndex = '';
+    }
+
+The attribute names the class of the index, and any ``BlindIndex`` service
+the application registers is found by it, so nothing has to be tagged by
+hand. A property can be indexed by several columns, each naming its own
+projection.
+
+Queries are unchanged: they have no entity to read the attribute on, and go
+on computing the tag themselves::
+
+    $repository->findOneBy(['emailIndex' => $index->of($email)]);
+
+.. warning::
+
+    The attribute covers the write path of the ORM alone. A row inserted
+    through DBAL, or a bulk ``UPDATE ... SET email = ...``, never reaches the
+    listener and leaves the tag as it was. That is worse than an empty tag:
+    the search then returns the row that used to hold the value.
 
 Going Further
 -------------

--- a/key-management.rst
+++ b/key-management.rst
@@ -1,0 +1,530 @@
+Encrypting Data with KMS
+========================
+
+Symfony provides a Key Management System integration through the
+:doc:`KeyManagement component </components/key-management>` and the ``framework.key_management``
+configuration entry. It lets you encrypt and decrypt application data
+through a central key (held by AWS KMS, HashiCorp Vault Transit, a local
+keystore, ...) without ever exposing the master key material to the
+application.
+
+.. warning::
+
+    The KeyManagement component is :doc:`experimental </contributing/code/experimental>`
+    and is not covered by Symfony's :doc:`Backward Compatibility Promise </contributing/code/bc>`.
+
+.. versionadded:: 8.2
+
+    KMS integration was introduced in Symfony 8.2.
+
+Installation
+------------
+
+.. code-block:: terminal
+
+    $ composer require symfony/key-management
+
+Then install one or more bridges depending on where your master keys live:
+
+.. code-block:: terminal
+
+    # Cloud-managed KMS (server-side encryption, never exposes the master key)
+    $ composer require symfony/aws-key-management
+    $ composer require symfony/azure-keyvault-key-management
+    $ composer require symfony/google-cloud-key-management
+    $ composer require symfony/vault-key-management
+
+    # Source local keys from S3, FTP, Azure Blob, ...
+    $ composer require symfony/flysystem-key-management
+
+    # Column-level envelope encryption and data key storage with Doctrine
+    $ composer require symfony/doctrine-dbal-key-management
+
+The component itself ships local backends (libsodium XChaCha20-Poly1305,
+OpenSSL AES-256-GCM, sealed box) suitable for development, tests and
+self-hosted setups.
+
+Configuration
+-------------
+
+KMS clients are declared by DSN under ``framework.key_management``:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/key_management.yaml
+        framework:
+            key_management:
+                default_client: app
+                clients:
+                    app: '%env(KMS_DSN)%'
+
+    .. code-block:: php
+
+        // config/packages/key_management.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'key_management' => [
+                    'default_client' => 'app',
+                    'clients' => [
+                        'app' => env('KMS_DSN'),
+                    ],
+                ],
+            ],
+        ]);
+
+When a single client is registered, the ``default_client`` entry is
+inferred and can be omitted. As a shortcut, you can also pass a single
+DSN as the value of ``framework.key_management`` itself; it expands to one client
+named ``default``.
+
+DSN Schemes
+~~~~~~~~~~~
+
+Each backend documents its own DSN scheme. The most common ones are:
+
+============================  =========================================  =======================================
+Scheme                        Required package                           Backend
+============================  =========================================  =======================================
+``sodium://``                 ``symfony/key-management``                 Local XChaCha20-Poly1305 (inline keys)
+``sodium+dir://``             ``symfony/key-management``                 Local XChaCha20-Poly1305 (key dir)
+``openssl://``                ``symfony/key-management``                 Local AES-256-GCM (inline keys)
+``openssl+dir://``            ``symfony/key-management``                 Local AES-256-GCM (key dir)
+``sodium-sealed-box://``      ``symfony/key-management``                 Local sealed box (inline keys)
+``sodium-sealed-box+dir://``  ``symfony/key-management``                 Local sealed box (key dir)
+``aws-kms://``                ``symfony/aws-key-management``             AWS Key Management Service
+``azure-keyvault://``         ``symfony/azure-keyvault-key-management``  Azure Key Vault / Managed HSM
+``gcp-kms://``                ``symfony/google-cloud-key-management``    Google Cloud KMS
+``vault-transit://``          ``symfony/vault-key-management``           HashiCorp Vault Transit
+``sodium+fly://``             ``symfony/flysystem-key-management``       XChaCha20 + Flysystem-loaded keys
+``openssl+fly://``            ``symfony/flysystem-key-management``       AES-256-GCM + Flysystem-loaded keys
+``sodium-sealed-box+fly://``  ``symfony/flysystem-key-management``       Sealed box + Flysystem-loaded keys
+============================  =========================================  =======================================
+
+See :doc:`/components/key-management` for the syntax and options of each scheme.
+
+Local backends require their respective extension at runtime: ``ext-openssl``
+for ``openssl://``/``openssl+dir://``/``openssl+fly://``, ``ext-sodium`` for
+``sodium://``/``sodium+dir://``/``sodium+fly://`` and the sealed-box
+schemes. The :class:`Symfony\\Component\\KeyManagement\\EnvelopeEncrypter` itself
+also requires ``ext-openssl`` for the local AEAD step. ``ext-fileinfo``
+must be present whenever the Flysystem bridge is loaded, because
+``league/flysystem`` pulls in ``league/mime-type-detection`` which uses it.
+
+Environment-driven configuration is the recommended pattern: keep the DSN
+in ``.env``/``.env.local``/secrets and reference it via ``%env(...)%``.
+
+.. code-block:: env
+
+    # .env (example: AWS KMS)
+    KMS_DSN=aws-kms://default?region=eu-west-1
+
+    # .env.local (example: local libsodium for development)
+    KMS_DSN=sodium+dir:///etc/kms?ext=.bin
+
+Multiple Clients
+~~~~~~~~~~~~~~~~
+
+Most applications need a single client, but you can declare more than one
+when different parts of the system have different threat models, regions
+or rotation cadences:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/key_management.yaml
+        framework:
+            key_management:
+                default_client: app
+                clients:
+                    app: '%env(KMS_APP_DSN)%'
+                    pii: '%env(KMS_PII_DSN)%'
+
+    .. code-block:: php
+
+        // config/packages/key_management.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'key_management' => [
+                    'default_client' => 'app',
+                    'clients' => [
+                        'app' => env('KMS_APP_DSN'),
+                        'pii' => env('KMS_PII_DSN'),
+                    ],
+                ],
+            ],
+        ]);
+
+.. _key-management-store-config:
+
+Storing the Data Keys
+~~~~~~~~~~~~~~~~~~~~~
+
+By default every envelope-encrypted payload carries its own data key,
+wrapped by the master key: the KMS is contacted once per encrypted value,
+each payload is a couple hundred bytes larger, and the master key cannot be
+rotated without rewriting every payload that refers to it.
+
+Configuring a ``store`` inverts that. Data keys are persisted in a Doctrine
+DBAL table and payloads carry a 16-byte reference to one, so the KMS is
+contacted once per data key and per process, and the master key protecting
+those keys can be rotated (or swapped for another provider) by rewrapping a
+handful of rows:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/key_management.yaml
+        framework:
+            key_management:
+                clients:
+                    app: '%env(KMS_DSN)%'
+                store:
+                    # the client wrapping the data keys this store creates
+                    client: app
+                    # the master key on that client
+                    key_id: 'alias/app-key'
+                    # defaults below
+                    connection: 'doctrine.dbal.default_connection'
+                    table: 'key_management_data_keys'
+                    # seconds after which the current data key of a scope is
+                    # retired in favour of a fresh one; null keeps it in use
+                    max_age: null
+
+    .. code-block:: php
+
+        // config/packages/key_management.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'key_management' => [
+                    'clients' => [
+                        'app' => env('KMS_DSN'),
+                    ],
+                    'store' => [
+                        'client' => 'app',
+                        'key_id' => 'alias/app-key',
+                    ],
+                ],
+            ],
+        ]);
+
+This section requires the ``symfony/doctrine-dbal-key-management`` package;
+without it, the container fails to compile with the command to run.
+
+A data key is shared over a **scope**: whatever the application decides may
+share a key, typically a column, a tenant or a purpose. It is what the first
+argument of ``encrypt()`` names once a store is configured. Retiring a key
+(through ``max_age`` or an explicit rotation) only affects payloads written
+afterwards, since older payloads keep referring to the key they were written
+with.
+
+Configuring a store also changes what the envelope interfaces resolve to:
+:class:`Symfony\\Component\\KeyManagement\\EnvelopeEncrypterInterface` and
+:class:`Symfony\\Component\\KeyManagement\\EnvelopeDecrypterInterface` are then
+aliased to the store-backed encrypter, which is given the default client's
+encrypter as a fallback so it reads the payloads written before it as well
+as the ones it writes. The per-client encrypters stay reachable under their
+own name (see `Service IDs`_) for whoever wants the other regime explicitly.
+
+The table is not created for you. Either declare it in your own migration,
+or call ``createTable()`` on the store once::
+
+    use Symfony\Component\DependencyInjection\Attribute\Autowire;
+    use Symfony\Component\KeyManagement\Bridge\DoctrineDbal\DataKeyStore;
+
+    final class CreateDataKeyTable
+    {
+        public function __construct(
+            #[Autowire(service: 'key_management.store')]
+            private readonly DataKeyStore $store,
+        ) {
+        }
+
+        public function __invoke(): void
+        {
+            $this->store->createTable();
+        }
+    }
+
+Either way the table holds exactly five columns:
+
+============================  ================  ==============================================================
+Column                        Type              Role
+============================  ================  ==============================================================
+``id``                        ``BINARY(16)``    A UUIDv7, primary key, and the reference recorded by payloads
+``scope``                     ``VARCHAR(191)``  The unit a data key is shared over
+``key_material``              ``BLOB``          The wrapped data key
+``master_key_id``             ``VARCHAR(255)``  The master key that wrapped it
+``client``                    ``VARCHAR(64)``   The configured KMS client able to unwrap it
+============================  ================  ==============================================================
+
+Every query names those five explicitly, so columns of your own are invisible
+to the store as long as they are nullable or have a default: nothing fills
+them on insert.
+
+.. note::
+
+    The store holds plaintext key material in memory for as long as it lives:
+    that is what spares the round trips. The service is tagged
+    ``kernel.reset``, so a long-running worker drops everything it retained
+    between two units of work. A rotation performed elsewhere is picked up at
+    that point rather than at the next payload.
+
+Using KMS in Services
+---------------------
+
+Inject the encrypter / decrypter abstractions where you need them. The
+default client is autowired via the unqualified interfaces::
+
+    use Symfony\Component\KeyManagement\DecrypterInterface;
+    use Symfony\Component\KeyManagement\EncrypterInterface;
+
+    final class TokenVault
+    {
+        public function __construct(
+            private EncrypterInterface $encrypter,
+            private DecrypterInterface $decrypter,
+        ) {
+        }
+
+        public function store(string $token): string
+        {
+            return (string) $this->encrypter->encrypt('app-key', $token);
+        }
+    }
+
+To inject a non-default client, name it with the
+:ref:`#[Target] attribute <autowiring-multiple-implementations-same-type>`::
+
+    use Symfony\Component\DependencyInjection\Attribute\Target;
+    use Symfony\Component\KeyManagement\EncrypterInterface;
+
+    final class PiiVault
+    {
+        public function __construct(
+            #[Target('pii')]
+            private EncrypterInterface $encrypter,
+        ) {
+        }
+    }
+
+Each client is also aliased to a parameter named after it and suffixed by
+``KeyManagement`` (``$piiKeyManagement``), which autowiring still honours
+without the attribute.
+
+For envelope encryption, inject
+:class:`Symfony\\Component\\KeyManagement\\EnvelopeEncrypterInterface` /
+:class:`Symfony\\Component\\KeyManagement\\EnvelopeDecrypterInterface` instead.
+``#[Target]`` works the same way there, and the fallback parameter name is
+suffixed by ``EnvelopeEncrypter`` (``$piiEnvelopeEncrypter``)::
+
+    use Symfony\Component\KeyManagement\EnvelopeDecrypterInterface;
+    use Symfony\Component\KeyManagement\EnvelopeEncrypterInterface;
+
+    final class DocumentArchive
+    {
+        public function __construct(
+            private EnvelopeEncrypterInterface $envelopeEncrypter,
+            private EnvelopeDecrypterInterface $envelopeDecrypter,
+        ) {
+        }
+    }
+
+The component splits the encrypt/decrypt halves into separate interfaces
+so that components which only need to read or only need to write can
+declare that intent at the type level.
+
+When a store is configured, the unqualified interfaces resolve to the
+store-backed encrypter, and ``$storedEnvelopeEncrypter`` names it explicitly.
+The store itself is autowired through
+:class:`Symfony\\Component\\KeyManagement\\DataKeyStoreInterface` (or
+:class:`Symfony\\Component\\KeyManagement\\RewrappableDataKeyStoreInterface` for the
+administration half: listing, rewrapping and rotating).
+
+Service IDs
+~~~~~~~~~~~
+
+Beyond autowiring, ``framework.key_management`` registers stable service ids that you
+can reference manually in YAML / PHP service definitions:
+
+* ``key_management.<name>`` : the configured client. Implements
+  ``EncrypterInterface & DecrypterInterface`` (and
+  ``DataKeyGeneratorInterface`` when the backend supports it). Tagged
+  ``key_management.client`` with the client name as ``key``.
+* ``key_management.envelope_encrypter.<name>`` : the matching
+  :class:`Symfony\\Component\\KeyManagement\\EnvelopeEncrypter`, which writes
+  self-contained envelopes. Implements
+  ``EnvelopeEncrypterInterface & EnvelopeDecrypterInterface``.
+* ``key_management.store`` : the
+  :class:`Symfony\\Component\\KeyManagement\\Bridge\\DoctrineDbal\\DataKeyStore`,
+  registered only when ``store`` is configured.
+* ``key_management.stored_envelope_encrypter`` : the
+  :class:`Symfony\\Component\\KeyManagement\\StoredEnvelopeEncrypter` built on that
+  store, with the default client's encrypter as a fallback for the payloads
+  written before it.
+* ``key_management.factory`` : the
+  :class:`Symfony\\Component\\KeyManagement\\Factory\\FactoryRegistry` that turns a
+  DSN string into a backend instance (used internally by the bundle).
+
+The unqualified interfaces (``EncrypterInterface``,
+``EnvelopeEncrypterInterface``, ...) are aliased to the default client so
+type-hinted services pick it up without further wiring.
+
+Console Commands
+----------------
+
+Four commands ship with the bundle to operate the configured client(s)
+from the CLI:
+
+.. code-block:: terminal
+
+    # Encrypts the argument (or standard input) through the default client and
+    # writes a base64 envelope to standard output.
+    $ php bin/console key-management:encrypt app-key 'hello world'
+    $ cat secrets.json | php bin/console key-management:encrypt app-key
+
+    # Inverse operation: the key id is read from the envelope itself.
+    $ php bin/console key-management:decrypt < envelope.b64
+
+    # Generates a fresh data key and prints JSON with key_id, length,
+    # base64 plaintext and base64 wrapped form.
+    $ php bin/console key-management:generate-data-key app-key
+
+    # Moves every stored data key under another master key, or another
+    # provider. Payloads are neither read nor rewritten.
+    $ php bin/console key-management:rewrap-data-keys --to=azure --key-id=my-vault-key
+
+The first three commands take ``--client=<name>`` to pick a client, which is
+required as soon as several are registered and none of them is named
+``default``. They also take ``--aad``, and ``key-management:generate-data-key``
+accepts ``--length`` (16 bytes minimum).
+
+Both ``key-management:encrypt`` and ``key-management:decrypt`` read STDIN when
+their payload argument is omitted, and write their diagnostics to STDERR, so
+they compose in a shell pipeline. Re-encrypting an envelope under another key
+after a rotation is one command:
+
+.. code-block:: terminal
+
+    $ php bin/console key-management:decrypt < old.b64 \
+        | php bin/console key-management:encrypt new-key > new.b64
+
+These two commands always work with self-contained envelopes; an envelope
+referring to a stored data key is reported as such rather than decrypted,
+since the CLI has no store to resolve it with. Decrypt those through the
+application.
+
+``key-management:rewrap-data-keys`` requires a configured store. It unwraps
+each row with the client that row records and re-wraps it with ``--to``,
+committing row by row, so an interrupted run is resumed by running the same
+command again. Restrict it with ``--from=<client>`` while both the old and
+the new client are configured, and start with ``--dry-run`` to see the scope
+of the operation:
+
+.. code-block:: terminal
+
+    $ php bin/console key-management:rewrap-data-keys --from=aws --to=azure --key-id=my-vault-key --dry-run
+
+.. _key-management-doctrine:
+
+Encrypted Doctrine Columns
+--------------------------
+
+The ``symfony/doctrine-dbal-key-management`` bridge ships a Doctrine DBAL
+``Type`` that decorates any parent type with column-level envelope
+encryption. What a row ends up carrying is decided by the encrypter you give
+it: a self-contained envelope with the default wiring, or a reference to a
+stored data key when a :ref:`store <key-management-store-config>` is
+configured.
+
+Register one ``Type`` per ``(parent type, key)`` pair you need. Inject the
+default envelope encrypter (autowired by ``framework.key_management``) and
+call ``Type::getTypeRegistry()->register()``::
+
+    // src/Kms/EncryptedTypesRegistrar.php
+    use Doctrine\DBAL\Types\Type;
+    use Symfony\Component\KeyManagement\Bridge\DoctrineDbal\EncryptedType;
+    use Symfony\Component\KeyManagement\EnvelopeDecrypterInterface;
+    use Symfony\Component\KeyManagement\EnvelopeEncrypterInterface;
+
+    final class EncryptedTypesRegistrar
+    {
+        public function __construct(
+            private readonly EnvelopeEncrypterInterface&EnvelopeDecrypterInterface $envelopes,
+        ) {
+        }
+
+        public function register(): void
+        {
+            Type::getTypeRegistry()->register(
+                'app_user_email',
+                new EncryptedType(
+                    Type::getTypeRegistry()->get('string'),
+                    $this->envelopes,
+                    // a master key id without a store, a scope with one
+                    'alias/app-key',
+                ),
+            );
+        }
+    }
+
+Then use the registered alias on the entity::
+
+    // src/Entity/User.php
+    use Doctrine\ORM\Mapping as ORM;
+
+    #[ORM\Entity]
+    class User
+    {
+        #[ORM\Column(type: 'app_user_email')]
+        public string $email;
+    }
+
+The stored bytes are an opaque envelope (binary column). Doctrine reads
+it back through the same ``Type``, decrypts it via the configured
+``EnvelopeDecrypterInterface``, and feeds the plaintext to the parent
+type's ``convertToPHPValue()``.
+
+.. warning::
+
+    The registration must happen before the first query, on every request.
+    In particular, do not defer it to Doctrine ORM's ``loadClassMetadata``
+    event: that event does not fire when metadata comes from the cache, which
+    DoctrineBundle enables in production, so a cached field mapping would
+    reference a type name missing from the registry and every read of the
+    column would fail with ``UnknownColumnType``. Declare the types where the
+    application declares the rest of its Doctrine configuration instead.
+
+Migrating a column to a stored data key is a matter of keeping the same
+registered name: rows written before the store keep being read through the
+KMS, thanks to the fallback the bundle wires behind the store-backed
+encrypter, and rows written afterwards refer to the stored key. Rewrapping
+that key later moves the whole column to another master key, or another
+provider, without touching a single row.
+
+This bridge requires Doctrine DBAL >= 4.5.
+
+.. note::
+
+    Envelope-encrypted columns are **not searchable**: the nonce is drawn
+    afresh every time, so the same plaintext encrypts to a different
+    ciphertext on every write. If you need exact-match lookups on an
+    encrypted column, store a blind index (an HMAC of the plaintext keyed by
+    an application secret) on a sibling column.
+
+Going Further
+-------------
+
+* :doc:`/components/key-management`: full component reference, available backends
+  and bridges.
+* :ref:`Envelope wire format <key-management-wire-format>`: the two shipped
+  byte layouts and the contract they follow.

--- a/key-management.rst
+++ b/key-management.rst
@@ -40,6 +40,9 @@ Then install one or more bridges depending on where your master keys live:
     # Column-level envelope encryption and data key storage with Doctrine
     $ composer require symfony/doctrine-dbal-key-management
 
+    # Blind index columns filled on flush, and the store table in the ORM schema
+    $ composer require symfony/doctrine-orm-key-management
+
 The component itself ships local backends (libsodium XChaCha20-Poly1305,
 OpenSSL AES-256-GCM, sealed box) suitable for development, tests and
 self-hosted setups.
@@ -102,9 +105,21 @@ Scheme                        Required package                           Backend
 ``sodium+fly://``             ``symfony/flysystem-key-management``       XChaCha20 + Flysystem-loaded keys
 ``openssl+fly://``            ``symfony/flysystem-key-management``       AES-256-GCM + Flysystem-loaded keys
 ``sodium-sealed-box+fly://``  ``symfony/flysystem-key-management``       Sealed box + Flysystem-loaded keys
+``service://<id>``            ``symfony/framework-bundle``               A client the application built itself
 ============================  =========================================  =======================================
 
 See :doc:`/components/key-management` for the syntax and options of each scheme.
+The bridges reject any query option they do not know, so a typo in one of
+their DSNs is an error rather than a setting that is silently ignored.
+
+``service://<id>`` is the odd one out: it names a service the application
+defined itself, so that a backend Symfony does not ship is declared like any
+other client. It keeps the tag the console commands look clients up by, gets
+an envelope encrypter of its own and is decorated by the profiler, which an
+alias would not. It is resolved while the container is built, which is also
+why it cannot come from an environment variable: a value unknown until
+runtime cannot reference a service, and such a DSN is reported as an
+unsupported scheme.
 
 Local backends require their respective extension at runtime: ``ext-openssl``
 for ``openssl://``/``openssl+dir://``/``openssl+fly://``, ``ext-sodium`` for
@@ -195,8 +210,10 @@ handful of rows:
                     connection: 'doctrine.dbal.default_connection'
                     table: 'key_management_data_keys'
                     # seconds after which the current data key of a scope is
-                    # retired in favour of a fresh one; null keeps it in use
-                    max_age: null
+                    # retired in favour of a fresh one; the default of 30 days
+                    # keeps what one key seals under the collision bound of the
+                    # random 96-bit IV each payload carries
+                    max_age: 2592000
 
     .. code-block:: php
 
@@ -235,8 +252,11 @@ encrypter as a fallback so it reads the payloads written before it as well
 as the ones it writes. The per-client encrypters stay reachable under their
 own name (see `Service IDs`_) for whoever wants the other regime explicitly.
 
-The table is not created for you. Either declare it in your own migration,
-or call ``createTable()`` on the store once::
+With ``symfony/doctrine-orm-key-management`` installed, the table joins the
+schema the ORM generates, so ``doctrine:schema:update`` and a migration diff
+see it like any mapped table instead of proposing to drop it. Without that
+package, declare it in your own migration or call ``createTable()`` on the
+store once::
 
     use Symfony\Component\DependencyInjection\Attribute\Autowire;
     use Symfony\Component\KeyManagement\Bridge\DoctrineDbal\DataKeyStore;
@@ -379,6 +399,17 @@ The unqualified interfaces (``EncrypterInterface``,
 ``EnvelopeEncrypterInterface``, ...) are aliased to the default client so
 type-hinted services pick it up without further wiring.
 
+Profiling
+---------
+
+When the profiler is enabled, every configured client, envelope encrypter
+and store is decorated so that a request reports what it asked of the KMS.
+The **Key Management** panel lists the operations of the request: what each
+call site asked for, the key or scope it went through, the bytes in and out,
+and the time it took. It is the quickest way to see that a store is doing
+its job, one round trip for many encrypted values rather than one per
+value.
+
 Console Commands
 ----------------
 
@@ -494,6 +525,12 @@ it back through the same ``Type``, decrypts it via the configured
 ``EnvelopeDecrypterInterface``, and feeds the plaintext to the parent
 type's ``convertToPHPValue()``.
 
+The column is always declared as an unbounded blob, and a ``length`` on the
+mapping is ignored on purpose: an envelope is a hundred bytes or so larger
+than the value it holds, and a bounded column sized after the plaintext
+truncates it. On MySQL and MariaDB outside strict mode that truncation is a
+warning rather than an error, and it leaves a row that no longer decrypts.
+
 .. warning::
 
     The registration must happen before the first query, on every request.
@@ -511,7 +548,7 @@ encrypter, and rows written afterwards refer to the stored key. Rewrapping
 that key later moves the whole column to another master key, or another
 provider, without touching a single row.
 
-This bridge requires Doctrine DBAL >= 4.5.
+This bridge requires Doctrine DBAL >= 4.3.
 
 .. _key-management-blind-index-doctrine:
 
@@ -559,13 +596,13 @@ wrapped in the configuration:
         };
 
 Then say, on the column that holds the tag, where its value comes from. A
-listener shipped by ``symfony/doctrine-bridge`` then fills it on every flush,
-so no write path has to remember it::
+listener shipped by ``symfony/doctrine-orm-key-management`` then fills it on
+every flush, so no write path has to remember it::
 
     // src/Entity/User.php
     use Doctrine\ORM\Mapping as ORM;
-    use Symfony\Bridge\Doctrine\Attribute\BlindIndexed;
     use Symfony\Component\KeyManagement\BlindIndex\Email;
+    use Symfony\Component\KeyManagement\Bridge\DoctrineOrm\Attribute\BlindIndexed;
 
     #[ORM\Entity]
     #[ORM\Index(columns: ['email_index'])]


### PR DESCRIPTION
Documentation for the new KeyManagement component (introduced in symfony/symfony#64052) and its bridges.

Adds two new pages:

* `key-management.rst`: framework-level guide covering `framework.key_management` configuration (yaml/php), the DSN scheme table, multi-client setup, the data key store (`framework.key_management.store`), autowiring (default aliases, `#[Target]`, named arguments), the four console commands and Doctrine column-level encryption.
* `components/key-management.rst`: standalone component reference covering direct vs envelope mode, AAD, deterministic encryption, data key stores, the three local backends (libsodium, OpenSSL, sealed box), key loaders, all DSN schemes, the five bridges (AWS KMS, Azure Key Vault, Google Cloud KMS, Vault Transit, Flysystem, Doctrine DBAL), the two envelope wire formats, memory wiping and the in-memory test doubles.

`index.rst` gets a new `key-management` toctree entry; `components/index.rst` already uses `:glob: *` so the component page is picked up automatically.

Notable points the pages document:

* **Two envelope shapes.** `EnvelopeEncrypter` mints a data key per payload and ships it wrapped inside the frame (`SelfContainedFormat`, id `0x01`); `StoredEnvelopeEncrypter` takes it from a `DataKeyStoreInterface` and ships a 16-byte reference (`StoredFormat`, id `0x02`). The second one turns one KMS call per payload into one per data key and per process, and makes a master key rotation a matter of rewrapping a handful of rows.
* **`framework.key_management.store`** wires the Doctrine DBAL store, which then becomes what the envelope interfaces resolve to, with the default client's encrypter behind it so payloads written before the store keep being read.
* **Four console commands**, including `key-management:rewrap-data-keys`. `key-management:encrypt` and `key-management:decrypt` compose in a shell pipeline (STDIN/STDOUT for the payload, STDERR for the diagnostics).
* **Doctrine columns** are registered through `Type::getTypeRegistry()->register()`, with an explicit warning against deferring that to `loadClassMetadata`: the event does not fire when metadata comes from the cache.

The component is still experimental, and the pages say so.
