### PR TITLE
[Messenger] Document deduplication lock release on definitive failure

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -226,7 +226,7 @@ Uploading Multiple Files
 
 If you want to allow multiple files to be uploaded at once, set the ``multiple``
 option of ``FileType`` to ``true``. The form field's data is then an array of
-:class:`Symfony\Component\HttpFoundation\File\UploadedFile` instances instead of
+:class:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile` instances instead of
 a single one, so you must wrap the ``File`` constraint inside the
 :doc:`All </reference/constraints/All>` constraint to validate each uploaded file::
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -3561,13 +3561,23 @@ identify when two messages should be considered duplicates (for example, using a
 project ID, an order ID, or a combination of relevant fields).
 
 By default, deduplication applies while the message is in the queue and while
-it is being processed. The lock is released when processing finishes. If you want
+it is being processed. The lock is released when processing succeeds. If you want
 deduplication only while the message is queued, set the third argument to ``true``::
 
     new DeduplicateStamp($deduplicationKey, 300, true)
 
 In this mode, the lock is released as soon as the worker receives the message,
 so another message with the same key can be processed concurrently.
+
+When a handler throws and the message is going to be retried, the lock is kept
+so that retries are deduplicated against new dispatches sharing the same key.
+Once the retry flow gives up, the lock is released, including when the
+message is moved to a :ref:`failure transport <messenger-failure-transport>`.
+
+.. versionadded:: 8.1
+
+    Releasing the deduplication lock on definitive failure was introduced in
+    Symfony 8.1.
 
 .. note::
 


### PR DESCRIPTION
Documents the new behavior introduced by symfony/symfony#64070: when a handled message definitively fails, the deduplication lock is released so fresh dispatches sharing the same key are no longer silently swallowed until the TTL expires.

Fixes #22282