### PR TITLE
[Runtime] Document FRANKENPHP_RESET_KERNEL

### DIFF
--- a/components/http_kernel.rst
+++ b/components/http_kernel.rst
@@ -631,6 +631,11 @@ To prevent this, make your service implement
 state in the ``reset()`` method. The kernel calls this method automatically after
 each request/response cycle in long-running processes.
 
+If implementing ``ResetInterface`` everywhere is not realistic, FrankenPHP worker
+mode also offers an opt-in escape hatch through the ``FRANKENPHP_RESET_KERNEL``
+environment variable: see :ref:`the Runtime component documentation
+<runtime-frankenphp-reset-kernel>` for details and the throughput trade-off.
+
 Creating an Event Listener
 --------------------------
 

--- a/components/runtime.rst
+++ b/components/runtime.rst
@@ -231,6 +231,26 @@ The ``SymfonyRuntime`` can handle these applications:
             return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
         };
 
+    .. _runtime-frankenphp-reset-kernel:
+
+    .. versionadded:: 8.1
+
+        The ``FRANKENPHP_RESET_KERNEL`` environment variable was introduced
+        in Symfony 8.1.
+
+    By default, ``FrankenPhpWorkerRunner`` reuses the same kernel instance
+    across every request handled by a worker process. This is what makes
+    worker mode fast, but it also means that any state captured by the kernel
+    or its services may leak across requests unless the relevant services
+    implement :class:`Symfony\\Contracts\\Service\\ResetInterface`.
+
+    Set the ``FRANKENPHP_RESET_KERNEL`` environment variable to ``1`` to make
+    the runner clone the application after each request, so the next request
+    starts from a fresh kernel state booted from the cached container file.
+    This is an opt-in escape hatch when auditing every service for proper
+    reset is not realistic; the trade-off is a noticeable throughput cost
+    compared to the default reuse mode, since each request boots a kernel.
+
 :class:`Symfony\\Component\\Console\\Command\\Command`
     To write single command applications. This will use the
     :class:`Symfony\\Component\\Runtime\\Runner\\Symfony\\ConsoleApplicationRunner`::

--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -226,7 +226,7 @@ Uploading Multiple Files
 
 If you want to allow multiple files to be uploaded at once, set the ``multiple``
 option of ``FileType`` to ``true``. The form field's data is then an array of
-:class:`Symfony\Component\HttpFoundation\File\UploadedFile` instances instead of
+:class:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile` instances instead of
 a single one, so you must wrap the ``File`` constraint inside the
 :doc:`All </reference/constraints/All>` constraint to validate each uploaded file::
 


### PR DESCRIPTION
Documents the new ``FRANKENPHP_RESET_KERNEL`` environment variable introduced by symfony/symfony#64055. When set to ``1``, ``FrankenPhpWorkerRunner`` clones the application after each request so the next one starts from a fresh kernel state, as an opt-in alternative to implementing ``ResetInterface`` on every service. Mentions the throughput trade-off and adds a cross-reference from the HttpKernel "reset state" section.

Fixes #22284