### PR TITLE
[Logger][Monolog] Document subjectMaxLength behavior in MailerHandler

### DIFF
--- a/logging/monolog_email.rst
+++ b/logging/monolog_email.rst
@@ -130,6 +130,17 @@ actually deals with emailing you the error. The settings for this are
 straightforward, the to and from addresses, the formatter, the content type
 and the subject.
 
+.. versionadded:: 8.1
+
+    Starting from Symfony 8.1, the ``MailerHandler`` automatically truncates
+    the formatted email subject when it exceeds 200 characters, replacing the
+    extra characters with ``[...]``. This prevents errors with mail servers
+    that limit the subject length when ``%%message%%`` produces a very long
+    subject. You are free to adjust this limit to whatever value your mail
+    server accepts via the ``$subjectMaxLength`` constructor argument of
+    :class:`Symfony\\Bridge\\Monolog\\Handler\\MailerHandler`; setting it to
+    ``0`` makes the limit inoperative.
+
 You can combine these handlers with other handlers so that the errors still
 get logged on the server as well as the emails being sent:
 


### PR DESCRIPTION
Documents the new automatic subject truncation behavior of `MailerHandler`,
introduced in symfony/symfony#63925 (merged in 8.1).

Adds a short `versionadded:: 8.1` block under the `symfony_mailer` handler section
explaining that the formatted subject is now truncated to 200 characters by default
(replaced with `[...]`), and how to override or disable it via the
`$subjectMaxLength` constructor argument.

Fix #22286