### PR TITLE
[RateLimiter] Document the #[RateLimit] controller attribute

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -226,7 +226,7 @@ Uploading Multiple Files
 
 If you want to allow multiple files to be uploaded at once, set the ``multiple``
 option of ``FileType`` to ``true``. The form field's data is then an array of
-:class:`Symfony\Component\HttpFoundation\File\UploadedFile` instances instead of
+:class:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile` instances instead of
 a single one, so you must wrap the ``File`` constraint inside the
 :doc:`All </reference/constraints/All>` constraint to validate each uploaded file::
 

--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -191,6 +191,74 @@ prevents that number from being higher than 5,000).
 Rate Limiting in Action
 -----------------------
 
+Rate Limiting a Controller With the RateLimit Attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.1
+
+    The ``#[RateLimit]`` attribute was introduced in Symfony 8.1.
+
+The simplest way to apply rate limiting to a controller is to add the
+:class:`Symfony\\Component\\HttpKernel\\Attribute\\RateLimit` attribute. The
+attribute references a limiter declared under ``framework.rate_limiter``;
+when the limit is exceeded, the kernel returns a ``429 Too Many Requests``
+response with a ``Retry-After`` header. Without a custom ``key``, the bucket
+is keyed by client IP, HTTP method and path::
+
+    // src/Controller/ApiController.php
+    namespace App\Controller;
+
+    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\ExpressionLanguage\Expression;
+    use Symfony\Component\HttpFoundation\JsonResponse;
+    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpKernel\Attribute\RateLimit;
+
+    class ApiController extends AbstractController
+    {
+        #[RateLimit('api')]
+        public function index(): JsonResponse
+        {
+            // ...
+        }
+
+        // restrict the limit to specific HTTP methods
+        #[RateLimit('api', methods: ['POST', 'PUT', 'PATCH', 'DELETE'])]
+        public function edit(): JsonResponse
+        {
+            // ...
+        }
+
+        // build the bucket key from a submitted form field
+        #[RateLimit('per_account', key: new Expression('request.request.get("email")'))]
+        public function resetPassword(): Response
+        {
+            // ...
+        }
+
+        // consume more than one token per request
+        #[RateLimit('api', tokens: 5)]
+        public function export(): JsonResponse
+        {
+            // ...
+        }
+    }
+
+The ``key`` argument also accepts a ``Closure`` receiving the ``Request`` and
+returning a string. Stacking multiple ``#[RateLimit]`` attributes combines
+the limits: each one is evaluated independently and **all** of them must
+pass::
+
+    #[RateLimit('global')]
+    #[RateLimit('login', methods: ['POST'])]
+    public function login(): Response
+    {
+        // ...
+    }
+
+The attribute can also be placed on the controller class to apply the limit
+to every action.
+
 Injecting the Rate Limiter Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Documents the new ``#[RateLimit]`` attribute introduced by symfony/symfony#63907: declarative rate limiting on controllers (or classes / invokables / functions) backed by ``framework.rate_limiter`` definitions, with an automatic 429 response carrying ``Retry-After`` when exceeded. Covers the four constructor arguments (``limiter``, ``key`` literal/Expression/Closure with the default IP+method+path key, ``tokens``, ``methods``) and the stacked-attributes case.

Fixes #22287