### PR TITLE
[FrameworkBundle] Document the debug:router --sort option

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -226,7 +226,7 @@ Uploading Multiple Files
 
 If you want to allow multiple files to be uploaded at once, set the ``multiple``
 option of ``FileType`` to ``true``. The form field's data is then an array of
-:class:`Symfony\Component\HttpFoundation\File\UploadedFile` instances instead of
+:class:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile` instances instead of
 a single one, so you must wrap the ``File`` constraint inside the
 :doc:`All </reference/constraints/All>` constraint to validate each uploaded file::
 

--- a/routing.rst
+++ b/routing.rst
@@ -445,6 +445,17 @@ evaluates them:
     $ php bin/console debug:router --method=GET
     $ php bin/console debug:router --method=ANY
 
+    # pass this option to sort the route list by a given column (case-insensitive
+    # alphabetical order); supported values are: name, path, method, scheme, host
+    # (the column name itself is also case-insensitive: --sort=PATH works); shell
+    # tab completion suggests the supported values
+    $ php bin/console debug:router --sort=path
+    $ php bin/console debug:router --sort=name
+
+.. versionadded:: 8.1
+
+    The ``--sort`` option of ``debug:router`` was introduced in Symfony 8.1.
+
 Pass the name (or part of the name) of some route to this argument to print the
 route details:
 


### PR DESCRIPTION
Documents the new ``--sort`` option introduced by symfony/symfony#63905 on the ``debug:router`` command. Lists the supported columns (``name``, ``path``, ``method``, ``scheme``, ``host``) and notes that the sort is applied to every output format (``txt``, ``json``, ``xml``, ``md``).

Fixes #22288