### PR TITLE
[JsonStreamer] Document DateTimeZone value object support

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -226,7 +226,7 @@ Uploading Multiple Files
 
 If you want to allow multiple files to be uploaded at once, set the ``multiple``
 option of ``FileType`` to ``true``. The form field's data is then an array of
-:class:`Symfony\Component\HttpFoundation\File\UploadedFile` instances instead of
+:class:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile` instances instead of
 a single one, so you must wrap the ``File`` constraint inside the
 :doc:`All </reference/constraints/All>` constraint to validate each uploaded file::
 

--- a/serializer/streaming_json.rst
+++ b/serializer/streaming_json.rst
@@ -730,10 +730,10 @@ traversing the object's properties::
 
 .. note::
 
-    ``DateTimeInterface`` and ``DateInterval`` objects are handled as value objects
-    internally. The previous ``DateTimeToStringValueTransformer`` and
-    ``StringToDateTimeValueTransformer`` are deprecated in favor of
-    ``DateTimeValueObjectTransformer``.
+    ``DateTimeInterface``, ``DateInterval`` and ``DateTimeZone`` objects are
+    handled as value objects internally. The previous
+    ``DateTimeToStringValueTransformer`` and ``StringToDateTimeValueTransformer``
+    are deprecated in favor of ``DateTimeValueObjectTransformer``.
 
     ``DateInterval`` objects are serialized to ISO 8601 duration strings
     (e.g. ``P2Y6M1DT12H30M5S``) and deserialized back using the
@@ -749,9 +749,15 @@ traversing the object's properties::
             'date_interval_format' => 'P%yY%mM%dDT%hH%iM%sS',
         ]);
 
+    ``DateTimeZone`` objects are serialized to their identifier string
+    (``DateTimeZone::getName()``, e.g. ``"Europe/Paris"`` or ``"+02:00"``)
+    and rebuilt with ``new \DateTimeZone($value)`` on read by the
+    ``DateTimeZoneValueObjectTransformer``.
+
     .. versionadded:: 8.1
 
-        ``DateInterval`` value object support was introduced in Symfony 8.1.
+        Support for ``DateInterval`` and ``DateTimeZone`` value objects was
+        introduced in Symfony 8.1.
 
 Configuring Keys and Values Dynamically
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Documents the new ``DateTimeZone`` value object support introduced by symfony/symfony#63879. Extends the existing ``DateTimeInterface`` / ``DateInterval`` note in ``serializer/streaming_json.rst`` to cover the new ``DateTimeZoneValueObjectTransformer``: serializes through ``DateTimeZone::getName()`` (e.g. ``"Europe/Paris"``, ``"+02:00"``) and rebuilds with ``new \DateTimeZone($value)`` on read, throwing ``InvalidArgumentException`` for non-string or invalid identifiers.

Fixes #22289