### PR TITLE
[Serializer] Document `native-<type>` keys for `getSupportedTypes()`

### DIFF
--- a/serializer/custom_normalizer.rst
+++ b/serializer/custom_normalizer.rst
@@ -187,6 +187,10 @@ corresponding ``supports*()`` call can be cached. The array format is as follows
    ``supports*()`` call for that type is cacheable. Use ``true`` if the result
    can be cached, ``false`` if it cannot.
 #. A ``null`` value means the normalizer or denormalizer does not support that type.
+#. The ``native-<type>`` strings (e.g. ``native-string``, ``native-integer``,
+   ``native-boolean``) declare support for scalar values, using the names returned
+   by :phpfunction:`gettype`;
+
 
 Here is an example of how to use the ``getSupportedTypes()`` method::
 


### PR DESCRIPTION
Add a bullet to the `getSupportedTypes()` key list documenting the `native-<type>` strings used to declare support for scalar values (`native-string`, `native-integer`, `native-boolean`, ...).                                                                                                                                                                          

This is currently undocumented: returning a PHP type name like `'string'` from `getSupportedTypes()` silently never matches a scalar value, since the Serializer indexes scalars under their `gettype()` name prefixed with `native-`. Users have no way to discover this without reading the Serializer source.
