### PR TITLE
[Workflow] Document `--with-listeners` option of `workflow:dump`

### DIFF
--- a/controller/upload_file.rst
+++ b/controller/upload_file.rst
@@ -226,7 +226,7 @@ Uploading Multiple Files
 
 If you want to allow multiple files to be uploaded at once, set the ``multiple``
 option of ``FileType`` to ``true``. The form field's data is then an array of
-:class:`Symfony\Component\HttpFoundation\File\UploadedFile` instances instead of
+:class:`Symfony\\Component\\HttpFoundation\\File\\UploadedFile` instances instead of
 a single one, so you must wrap the ``File`` constraint inside the
 :doc:`All </reference/constraints/All>` constraint to validate each uploaded file::
 

--- a/workflow/dumping-workflows.rst
+++ b/workflow/dumping-workflows.rst
@@ -76,6 +76,31 @@ The DOT image will look like this :
 
     The ``--with-metadata`` option only works for the DOT dumper for now.
 
+You can also pass ``--with-listeners`` to ``workflow:dump`` to annotate each
+place and transition with the workflow listeners subscribed to its events:
+
+* places get listeners on ``leave``, ``enter`` and ``entered``;
+* transitions get listeners on ``guard``, ``transition``, ``completed`` and
+  ``announce``.
+
+For each event, the three usual variants are inspected and merged: the generic
+``workflow.<event>``, the workflow-scoped ``workflow.<name>.<event>`` and the
+item-scoped ``workflow.<name>.<event>.<placeOrTransition>``.
+
+.. code-block:: terminal
+
+    $ php bin/console workflow:dump workflow-name --with-listeners | dot -Tsvg -o graph.svg
+
+.. versionadded:: 8.1
+
+    The ``--with-listeners`` option of ``workflow:dump`` was introduced in
+    Symfony 8.1. The listeners are only rendered by the DOT dumper; with
+    ``--dump-format=puml`` or ``--dump-format=mermaid`` the option is
+    silently ignored. The option also requires the EventDispatcher to be
+    available, otherwise a
+    :class:`Symfony\\Component\\Console\\Exception\\InvalidArgumentException`
+    is thrown.
+
 .. note::
 
     The ``label`` metadata is not included in the dumped metadata, because it is used as a place's title.


### PR DESCRIPTION
Documents the new ``--with-listeners`` option of the ``workflow:dump`` command, introduced by symfony/symfony#63809. The option annotates each transition in the DOT diagram with the workflow listeners subscribing to its events; it requires the EventDispatcher to be available.

Fixes #22290