### PR TITLE
[Form] Document translation_domain for expanded ChoiceType placeholder

### DIFF
--- a/reference/forms/types/options/placeholder.rst.inc
+++ b/reference/forms/types/options/placeholder.rst.inc
@@ -39,3 +39,14 @@ is false::
     $builder->add('states', ChoiceType::class, [
         'required' => false,
     ]);
+
+.. versionadded:: 8.1
+
+    Translating an expanded ``ChoiceType`` placeholder via ``translation_domain``
+    (instead of ``choice_translation_domain``) was introduced in Symfony 8.1.
+
+The placeholder label is translated using the ``translation_domain`` option,
+just like a non-expanded ``<select>`` placeholder, even when ``expanded`` is
+set to ``true``. This makes a ``TranslatableMessage`` placeholder work
+correctly on subtypes like :doc:`EntityType </reference/forms/types/entity>`,
+which default ``choice_translation_domain`` to ``false``.


### PR DESCRIPTION
Documents the 8.1 fix from symfony/symfony#63727: when ``expanded`` is ``true``, the placeholder label of ``ChoiceType`` (and subtypes such as ``EntityType``) is now translated via ``translation_domain``, matching the non-expanded ``<select>`` behavior. Notably this lets a ``TranslatableMessage`` placeholder work on ``EntityType`` whose ``choice_translation_domain`` defaults to ``false``. Adds a ``versionadded`` block plus a short paragraph in the shared ``placeholder`` option include.

Fixes #22299