### PR TITLE
 Add external links in agents.md file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,15 @@ The only exception is @reference/configuration/ files that use `~~~~~` (level 2)
 
 Always use absolute paths (starting with `/`), never relative.
 
+### External Links
+
+```rst
+`External link`_                          (link title)
+.. _`External link`: https://example.com/ (link target)
+```
+
+Do not use inline syntax for external link. Add target at the end of the file.
+
 ### API Links
 
 ```rst


### PR DESCRIPTION
Following [this review](https://github.com/symfony/symfony-docs/pull/22317#discussion_r3182496933) I suggest to add a small section about external link in `Agents.md` file to avoid usage of inline syntax for external links in documentation, in order to keep consistency with existing codebase
