### PR TITLE
[WebLink] EarlyHints - mention RoadRunner support

### DIFF
--- a/web_link.rst
+++ b/web_link.rst
@@ -134,7 +134,7 @@ to start downloading assets while the server is still preparing the page.
 .. note::
 
     In order to work, the `SAPI`_ you're using must support this feature, like
-    `FrankenPHP`_.
+    `FrankenPHP`_ or `RoadRunner`_.
 
 The simplest way to send early hints is by using the ``preload()`` Twig function.
 When early hints are supported by your web server, the ``Link`` headers added via
@@ -315,3 +315,4 @@ instances::
 .. _`link defined in the HTML specification`: https://html.spec.whatwg.org/dev/links.html#linkTypes
 .. _`PSR-13`: https://www.php-fig.org/psr/psr-13/
 .. _`Speculation Rules API`: https://developer.mozilla.org/docs/Web/API/Speculation_Rules_API
+.. _`RoadRunner`: https://github.com/roadrunner-php/http#early-hints

--- a/web_link.rst
+++ b/web_link.rst
@@ -134,7 +134,7 @@ to start downloading assets while the server is still preparing the page.
 .. note::
 
     In order to work, the `SAPI`_ you're using must support this feature, like
-    `FrankenPHP`_.
+    `FrankenPHP`_ or `RoadRunner`_.
 
 The simplest way to send early hints is by using the ``preload()`` Twig function.
 When early hints are supported by your web server, the ``Link`` headers added via
@@ -319,3 +319,4 @@ instances::
 .. _`link defined in the HTML specification`: https://html.spec.whatwg.org/dev/links.html#linkTypes
 .. _`PSR-13`: https://www.php-fig.org/psr/psr-13/
 .. _`Speculation Rules API`: https://developer.mozilla.org/docs/Web/API/Speculation_Rules_API
+.. _`RoadRunner`: https://github.com/roadrunner-php/http#early-hints


### PR DESCRIPTION
Directly, the RR package in this PR diff does not support Symfony Kernel by itself, it's not a runtime. However there is [Symfony bundle adding runtime with early hints support built-in](https://github.com/FluffyDiscord/roadrunner-symfony-bundle#early-hints-103). Thus, I am not sure, if current link to RR itself can be referenced, or if the bundle supporting RR as runtime that supports these early hints should be referenced instead. If the bundle can actually be referenced in official symfony docs, but wording needs to be adjusted or there are steps to take to allow that, please point me to the right direction if possible.