### PR TITLE
[Routing] Document trailingSlashOnRoot on CollectionConfigurator::prefix()

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -900,4 +900,3 @@ that holds a file name or a URL, you can wrap them in a ``LinkStub`` to tell
     }
 
 .. _`Content Security Policy`: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-.. _`NelmioSecurityBundle`: https://github.com/nelmio/NelmioSecurityBundle

--- a/routing.rst
+++ b/routing.rst
@@ -1591,6 +1591,23 @@ defined in the class attribute.
                 ],
             ]);
 
+The same behavior is available on ``CollectionConfigurator::prefix()``
+when grouping routes with the PHP DSL::
+
+    // config/routes.php
+    use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+    return function (RoutingConfigurator $routes) {
+        $routes->collection('cat.')
+            ->prefix('/categories', trailingSlashOnRoot: false)
+            ->add('index', '/');
+    };
+
+.. versionadded:: 8.1
+
+    The ``trailingSlashOnRoot`` argument of ``CollectionConfigurator::prefix()``
+    was introduced in Symfony 8.1.
+
 .. seealso::
 
     Symfony can :doc:`import routes from different sources </routing/custom_route_loader>`


### PR DESCRIPTION
Documents the new `trailingSlashOnRoot` option of `CollectionConfigurator::prefix()` introduced by symfony/symfony#63689.

Fixes #22325