### PR TITLE
[DependencyInjection] Document kernel.reset support for non-shared services

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -900,4 +900,3 @@ that holds a file name or a URL, you can wrap them in a ``LinkStub`` to tell
     }
 
 .. _`Content Security Policy`: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-.. _`NelmioSecurityBundle`: https://github.com/nelmio/NelmioSecurityBundle

--- a/reference/dic_tags.rst
+++ b/reference/dic_tags.rst
@@ -626,6 +626,11 @@ reuse the Symfony application between requests to improve performance. This tag
 is applied for example to the built-in :ref:`data collectors <profiler-data-collector>`
 of the profiler to delete all their information.
 
+.. versionadded:: 8.1
+
+    Support for resetting non-shared services tagged with ``kernel.reset``
+    was introduced in Symfony 8.1.
+
 .. _dic_tags-mime:
 
 mime.mime_type_guesser


### PR DESCRIPTION
Documents the new `kernel.reset` support for non-shared services introduced by symfony/symfony#63751.

Fixes #22326