### PR TITLE
[RateLimiter] Document anchor_at option for fixed_window policy

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -900,4 +900,3 @@ that holds a file name or a URL, you can wrap them in a ``LinkStub`` to tell
     }
 
 .. _`Content Security Policy`: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-.. _`NelmioSecurityBundle`: https://github.com/nelmio/NelmioSecurityBundle

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3307,6 +3307,20 @@ cache_pool
 
 The cache pool to use for storing the current limiter state.
 
+anchor_at
+"""""""""
+
+**type**: ``string`` **default**: ``null``
+
+A reference datetime (any string accepted by ``DateTimeImmutable``) used by the
+``fixed_window`` policy to align windows on a calendar. When set, windows reset
+at ``anchor_at + n*interval`` instead of starting on the first hit. This is
+useful for billing cycles, fiscal years or fixed-day weekly resets.
+
+.. versionadded:: 8.1
+
+    The ``anchor_at`` option was introduced in Symfony 8.1.
+
 interval
 """"""""
 


### PR DESCRIPTION
Documents the new `anchor_at` option of the `fixed_window` rate limiter policy introduced by symfony/symfony#62127.

Fixes #22324