### PR TITLE
[VarDumper] Remove unused link definition

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -900,4 +900,3 @@ that holds a file name or a URL, you can wrap them in a ``LinkStub`` to tell
     }
 
 .. _`Content Security Policy`: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-.. _`NelmioSecurityBundle`: https://github.com/nelmio/NelmioSecurityBundle


### PR DESCRIPTION
The `NelmioSecurityBundle` link definition in `components/var_dumper.rst` is no longer referenced in the file (the only remaining mention is inside a PHP code comment), so DOCtor-RST flags it on every PR. Removing it unblocks the lint.