### PR TITLE
[VarDumper] Remove unused NelmioSecurityBundle link definition

### DIFF
--- a/components/var_dumper.rst
+++ b/components/var_dumper.rst
@@ -900,4 +900,3 @@ that holds a file name or a URL, you can wrap them in a ``LinkStub`` to tell
     }
 
 .. _`Content Security Policy`: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-.. _`NelmioSecurityBundle`: https://github.com/nelmio/NelmioSecurityBundle


### PR DESCRIPTION
The `NelmioSecurityBundle` link reference is no longer used anywhere in `components/var_dumper.rst` (the only mention is in a code comment, which doesn't resolve link targets), so DOCtor-RST flags it on every CI run on `8.1`.