### PR TITLE
[ExpressionLanguage] Add warning about constant() function exposing PHP constants in expressions

### DIFF
--- a/components/expression_language.rst
+++ b/components/expression_language.rst
@@ -46,6 +46,12 @@ to external injections because you must explicitly declare which variables are
 available in an expression (but you should still sanitize any data given by end
 users and passed to expressions).
 
+.. warning::
+
+    By default, expressions have access to all PHP constants via the
+    ``constant()`` function. Be careful when exposing constants defined
+    by your application to end users through expressions.
+
 Usage
 -----
 


### PR DESCRIPTION
The ExpressionLanguage documentation states that expressions are a "very restricted PHP sandbox", but does not mention that the constant() function is registered by default and gives read access to all PHP constants defined in the application.

This includes built-in PHP constants (PHP_VERSION, PHP_OS, etc.) as well as constants defined by the application via define(), which can expose sensitive values such as API keys or passwords when expressions are built from user input.

Added a .. warning:: admonition to make developers aware of this behavior.