### PR TITLE
[Form] Add an example for date client side validation

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -1242,6 +1242,17 @@ browser from, for example, submitting blank fields.
         {{ form_widget(form) }}
     {{ form_end(form) }}
 
+HTML Validation for date/time inputs
+....................................
+
+When using ``DateType`` or ``DateTimeType``, you can rely on ``attr`` option to
+enable client-side validation::
+
+    $builder->add('dueDate', DateTimeType::class, [
+        'years' => range(2020, 2030),
+        'attr' => ['min' => '2020-01-01T00:00', 'max' => '2030-12-31T23:59']
+    ]);
+
 .. _form-type-guessing:
 
 Form Type Guessing


### PR DESCRIPTION
From [this issue](https://github.com/symfony/symfony/issues/63241) in code repo
Then I found [this one](https://github.com/symfony/symfony/issues/3533) and this [other one](https://github.com/symfony/symfony/issues/15375) about same topic : adding `min`/`max` attributes for client side validation

I didn't find any reference to this in documentation but this seems to be a recurring question, this PR aims to add a note about this :) 