### PR TITLE
[Workflow] Add a missing constant to disable event

### DIFF
--- a/workflow.rst
+++ b/workflow.rst
@@ -796,6 +796,7 @@ These are all the available constants:
     * ``Workflow::DISABLE_ENTER_EVENT``
     * ``Workflow::DISABLE_ENTERED_EVENT``
     * ``Workflow::DISABLE_COMPLETED_EVENT``
+    * ``Workflow::DISABLE_ANNOUNCE_EVENT``
 
 Event Methods
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This `Workflow` constant is missing from the list (but used in an example few lines above)  

[Code for reference](https://github.com/symfony/symfony/blob/de84d0094fadc8cb54a9ac7c9b2bc5047100bb5a/src/Symfony/Component/Workflow/Workflow.php#L42) 