### PR TITLE
[DependencyInjection] Clarify the return type of the CSV env var processor

### DIFF
--- a/configuration/env_var_processors.rst
+++ b/configuration/env_var_processors.rst
@@ -328,7 +328,8 @@ Symfony provides the following env var processors:
             ]);
 
 ``env(csv:FOO)``
-    Decodes the content of ``FOO``, which is a CSV-encoded string:
+    Decodes the content of ``FOO``, which is a CSV-encoded string and returns
+    an array. An empty string will result in an empty array.
 
     .. configuration-block::
 


### PR DESCRIPTION
State the actual return type and explicitly note the handling of empty values. Ensure discoverability of this processor when searching for `array`.
