### PR TITLE
[PasswordHasher] Document reading the password from stdin in security:hash-password

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -444,6 +444,18 @@ You can also manually hash a password by running:
 
     $ php bin/console security:hash-password
 
+To avoid passing the plaintext password as a command argument, pass ``-`` to read
+it from the standard input instead:
+
+.. code-block:: terminal
+
+    $ echo \$PASSWORD | php bin/console security:hash-password --no-interaction -
+
+.. versionadded:: 8.1
+
+    The support for reading the password from the standard input was introduced
+    in Symfony 8.1.
+
 Read more about all available hashers (including specific hashers) and password
 migration in :doc:`/security/passwords`.
 


### PR DESCRIPTION
Documents the new Symfony 8.1 ability of `security:hash-password` to read the password from the standard input by passing `-` as the password argument, which avoids exposing the plaintext as a command argument.

Fixes #22350.
