### PR TITLE
[Doctrine][DBAL] Clarify keep_replica behavior and worker mode persistence

### DIFF
--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -149,16 +149,27 @@ class from Doctrine DBAL, which decides where to route each database operation:
 
 .. note::
 
-    In long-running processes (e.g. messenger workers), the connection
-    instance persists across multiple messages, so the "switch to primary"
-    behavior applies for the lifetime of that connection instance, not just
-    a single HTTP request.
+    In long-running processes (e.g. messenger workers, FrankenPHP server
+    worker mode), the connection instance persists across multiple messages,
+    so the "switch to primary" behavior applies for the lifetime of that
+    connection instance, not just a single HTTP request.
 
 .. tip::
 
-    Set the ``keep_replica`` option to ``true`` to keep using the replica
-    for read queries even after a write operation. This is useful when
-    eventual consistency is acceptable for subsequent reads:
+    Set the ``keep_replica`` option to ``true`` to preserve the replica
+    connection in memory after the primary has been used. This does **not**
+    change the automatic routing of read queries: once the primary has been
+    picked, ``executeQuery()`` and other read methods keep going to the
+    primary for the rest of the connection's lifetime.
+
+    What ``keep_replica: true`` enables is an **explicit** switch back to
+    the replica via ``$connection->ensureConnectedToReplica()``.
+
+    Note that in Symfony Messenger workers or FrankenPHP worker mode,
+    switching back to the replica between requests/messages is not handled
+    automatically — you need to wire it manually (e.g. via a ``ResetInterface``
+    service for Messenger or a ``kernel.terminate`` listener for FrankenPHP)
+    that calls ``$connection->ensureConnectedToReplica()`` at the boundary.
 
     .. code-block:: yaml
 


### PR DESCRIPTION
## Problem

The current `keep_replica` tip in `doctrine/dbal.rst` reads as if `keep_replica: true` makes read queries continue going to the replica after a write operation (eventual consistency). That contradicts the bullet point right above it on the same page:

> Once the primary has been used, **all subsequent operations** on that connection use the primary too, ensuring read-your-writes consistency.

and the documented behavior of `PrimaryReadReplicaConnection` itself. In practice, `keep_replica: true` does **not** change the automatic routing — once the primary has been picked, reads keep going to the primary for the rest of the connection's lifetime, regardless of `keep_replica`.

What `keep_replica: true` actually enables is an **explicit** switch back to the replica via `$connection->ensureConnectedToReplica()` (without `keep_replica: true` that call becomes a no-op, because after a write the replica slot is overwritten to point at the primary).

This becomes practically relevant in long-running processes (Symfony Messenger workers, FrankenPHP worker mode), where the connection instance persists across requests/messages and there is no built-in mechanism that resets DBAL connection state between them. Users running read replicas under workers usually want a way to switch back to the replica between requests; the natural fit is `keep_replica: true` + explicit `ensureConnectedToReplica()` wired through a `ResetInterface` service (Messenger) or a `kernel.terminate` listener (FrankenPHP).

## Changes

- Rewrite the `keep_replica` tip to describe its actual effect: it preserves the replica connection slot, enabling an explicit `ensureConnectedToReplica()` switch later.
- Add a short paragraph inside that tip pointing out that, in Messenger workers and FrankenPHP worker mode, the switch back to the replica between requests/messages must be wired manually.
- Extend the existing note about long-running processes to mention FrankenPHP server worker mode alongside Messenger workers.

Happy to adjust the wording — let me know.