### PR TITLE
[Messenger] Fix typo in messenger.rst

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -389,7 +389,7 @@ to multiple transports:
     runtime by using the
     :class:`Symfony\\Component\\Messenger\\Stamp\\TransportNamesStamp` on
     the envelope of the message. This stamp takes an array of transport
-    name as its only argument. For more information about stamps, see
+    names as its only argument. For more information about stamps, see
     `Envelopes & Stamps`_.
 
 Doctrine Entities in Messages


### PR DESCRIPTION
Not sure if 8.0 is the correct target branch.
