### PR TITLE
[Form] Clarify Doctrine persistence for form collections

### DIFF
--- a/form/form_collections.rst
+++ b/form/form_collections.rst
@@ -667,10 +667,10 @@ the relationship between the removed ``Tag`` and ``Task`` object.
     work to ensure that the relationship between the ``Task`` and the removed
     ``Tag`` is properly removed.
 
-    In Doctrine, you have two sides of the relationship: the owning side and the
-    inverse side. Normally in this case you'll have a many-to-one relationship
-    and the deleted tags will disappear and persist correctly (adding new
-    tags also works effortlessly).
+    In Doctrine, you have two sides of the relationship: the owning side and
+    the inverse side. If ``Task`` is the owning side of the relationship (for
+    example, a many-to-many association without ``mappedBy`` on ``Task``),
+    adding and removing tags from the collection will be persisted correctly.
 
     But if you have a one-to-many relationship or a many-to-many relationship with a
     ``mappedBy`` on the Task entity (meaning Task is the "inverse" side),
@@ -714,6 +714,7 @@ the relationship between the removed ``Tag`` and ``Task`` object.
                             $entityManager->persist($tag);
 
                             // if you wanted to delete the Tag entirely, you can also do that
+                            // (or use Doctrine's orphanRemoval option to do it automatically)
                             // $entityManager->remove($tag);
                         }
                     }


### PR DESCRIPTION
The Doctrine sidebar suggested that removing tags from a collection
"persists correctly" in a many-to-one case, which is misleading when
``Task`` is the inverse side of the association. Reword to describe
the owning-side case accurately, and mention ``orphanRemoval`` as the
automatic alternative to ``$entityManager->remove($tag)``.

Fixes #22345