### PR TITLE
[RateLimiter] Use the standard "Retry-After" header in the rate limiter example

### DIFF
--- a/rate_limiter.rst
+++ b/rate_limiter.rst
@@ -397,6 +397,7 @@ the :class:`Symfony\\Component\\RateLimiter\\Reservation` object returned by the
     use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
     use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
     use Symfony\Component\RateLimiter\RateLimiterFactory;
 
     class ApiController extends AbstractController
@@ -407,12 +408,14 @@ the :class:`Symfony\\Component\\RateLimiter\\Reservation` object returned by the
             $limit = $limiter->consume();
             $headers = [
                 'X-RateLimit-Remaining' => $limit->getRemainingTokens(),
-                'X-RateLimit-Retry-After' => $limit->getRetryAfter()->getTimestamp() - time(),
                 'X-RateLimit-Limit' => $limit->getLimit(),
             ];
 
             if (false === $limit->isAccepted()) {
-                return new Response(null, Response::HTTP_TOO_MANY_REQUESTS, $headers);
+                throw new TooManyRequestsHttpException(
+                    $limit->getRetryAfter()->getTimestamp() - time(),
+                    headers: $headers,
+                );
             }
 
             // ...
@@ -423,6 +426,12 @@ the :class:`Symfony\\Component\\RateLimiter\\Reservation` object returned by the
             return $response;
         }
     }
+
+.. note::
+
+    The ``TooManyRequestsHttpException`` sets the standard ``Retry-After``
+    header automatically using the value passed as its first argument, so
+    you don't need to include that header yourself.
 
 .. versionadded:: 6.4
 


### PR DESCRIPTION
The "Exposing the Rate Limiter Status" example exposed a non-standard
`X-RateLimit-Retry-After` header. The standard HTTP header for `429 Too
Many Requests` responses is `Retry-After`:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/429

Since `TooManyRequestsHttpException` already sets the `Retry-After` header
from its first constructor argument, the example now throws that exception
instead of building the header by hand. This also matches the earlier
"Using the Rate Limiter Service" example, which throws the same exception.