### PR TITLE
[DependencyInjection] Update attributes reference for 7.4

### DIFF
--- a/reference/attributes.rst
+++ b/reference/attributes.rst
@@ -34,6 +34,7 @@ Dependency Injection
 * :doc:`AsDecorator </service_container/service_decoration>`
 * :ref:`AsTaggedItem <tags_as-tagged-item>`
 * :ref:`Autoconfigure <lazy-services_configuration>`
+* :ref:`AutoconfigureResourceTag <di-resource-tags>`
 * :ref:`AutoconfigureTag <di-instanceof>`
 * :ref:`Autowire <autowire-attribute>`
 * :ref:`AutowireCallable <autowiring_closures>`


### PR DESCRIPTION
``AutoconfigureResourceTag`` attribute is missing from reference