### PR TITLE
[HttpClient] Fix syntax

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -2334,9 +2334,7 @@ exception from a callback. For exceptions of this kind,
 ``getStatusCode()`` may indicate a success (200), but accessing
 ``getContent()`` fails.
 
-The following example code illustrates all three options.
-
-body::
+The following example code illustrates all three options::
 
     // ExternalArticleServiceTest.php
     use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
I don't know where it comes from but it leads to display the "body" text on documentation

<img width="1616" height="300" alt="image" src="https://github.com/user-attachments/assets/7171fb95-ac50-4c2a-b02d-320c41353b52" />
