### PR TITLE
[Translation] Remove a comment about function available since sf5

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -1348,9 +1348,9 @@ unused translation messages templates:
 
     The extractors can't find messages translated outside templates (like form
     labels or controllers) unless using :ref:`translatable objects
-    <translatable-objects>` or calling the ``trans()`` method on a translator
-    (since Symfony 5.3). Dynamic translations using variables or expressions in
-    templates are not detected either:
+    <translatable-objects>` or calling the ``trans()`` method on a translator.
+    Dynamic translations using variables or expressions in templates are not
+    detected either:
 
     .. code-block:: twig
 


### PR DESCRIPTION
It's probably no more relevant to say in documentation for 6.4 and newer the `trans()` method is available since 5.3