### PR TITLE
 Update messenger.rst to remove outdated warning

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1722,12 +1722,6 @@ than the default polling behavior of the Doctrine transport because
 PostgreSQL will directly notify the workers when a new message is inserted
 in the table.
 
-.. warning::
-
-    When using Doctrine DBAL 4, Symfony Messenger does not automatically create
-    the PostgreSQL functions and triggers. You can create them manually using
-    the SQL script defined in the `PostgreSqlConnection`_ class.
-
 ``use_notify`` (default: ``true``)
     Whether to use LISTEN/NOTIFY.
 
@@ -3816,4 +3810,5 @@ Learn more
 .. _`article about CQRS`: https://martinfowler.com/bliki/CQRS.html
 .. _`SSL context options`: https://php.net/context.ssl
 .. _`SQS CreateQueue API`: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html
+.. _`no more than 10 priority levels`: https://www.rabbitmq.com/docs/priority
 .. _`PostgreSqlConnection`: https://github.com/symfony/symfony/blob/8.0/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php


### PR DESCRIPTION
Removed warning about PostgreSQL functions and triggers for Doctrine DBAL 4.

In this commit : https://github.com/symfony/symfony/commit/a025d5f17a343df20efd08c73a1c841b1e84c2b1 the SQL script has been removed.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
