### PR TITLE
[Form][Validator] Refactor validation constraints to use named parameters

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -1518,12 +1518,12 @@ but here's a short example::
     {
         $builder
             ->add('firstName', TextType::class, [
-                'constraints' => new Assert\Length(['min' => 3]),
+                'constraints' => new Assert\Length(min: 3),
             ])
             ->add('lastName', TextType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['min' => 3]),
+                    new Assert\Length(min: 3),
                 ],
             ])
         ;
@@ -1535,7 +1535,7 @@ but here's a short example::
     ``Default`` group when creating the form, or set the correct group on
     the constraint you are adding::
 
-        new NotBlank(['groups' => ['create', 'update']]);
+        new NotBlank(groups: ['create', 'update']);
 
 .. tip::
 
@@ -1571,13 +1571,13 @@ the ``constraints`` option in the ``configureOptions()`` method::
     {
         $resolver->setDefaults([
             'data_class' => null,
-            'constraints' => new Assert\Collection([
-                'firstName' => new Assert\Length(['min' => 3]),
-                'lastName' => [
+            'constraints' => new Assert\Collection(
+                firstName: new Assert\Length(min: 3),
+                lastName: [
                     new Assert\NotBlank(),
-                    new Assert\Length(['min' => 3]),
+                    new Assert\Length(min: 3),
                 ],
-            ]),
+            ),
         ]);
     }
 
@@ -1588,10 +1588,10 @@ in your controller::
 
     $form = $this->createFormBuilder($defaultData, [
             'constraints' => [
-                'firstName' => new Assert\Length(['min' => 3]),
+                'firstName' => new Assert\Length(min: 3),
                 'lastName' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['min' => 3]),
+                    new Assert\Length(min: 3),
                 ],
             ],
         ])


### PR DESCRIPTION
to avoid depreciation :  Since symfony/validator 7.3: Passing an array of options to configure the \"Symfony\\Component\\Validator\\Constraints\\.....\" constraint is deprecated, use named arguments instead

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
