### PR TITLE
 Use spread operator for controller arguments

### DIFF
--- a/create_framework/http_kernel_controller_resolver.rst
+++ b/create_framework/http_kernel_controller_resolver.rst
@@ -181,7 +181,7 @@ Let's conclude with the new version of our framework::
         $controller = $controllerResolver->getController($request);
         $arguments = $argumentResolver->getArguments($request, $controller);
 
-        $response = call_user_func_array($controller, $arguments);
+        $response = call_user_func_array($controller, ...$arguments);
     } catch (Routing\Exception\ResourceNotFoundException $exception) {
         $response = new Response('Not Found', 404);
     } catch (Exception $exception) {


### PR DESCRIPTION
$arguments is an array returned by getArguments(), and you're passing that array as a single argument. So index() receives the whole array instead of the unpacked Request object. Use spread operator in front to unpack it.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
