### PR TITLE
[Form] Fix custom forms link rendering in Bootstrap 4 theme doc

### DIFF
--- a/form/bootstrap4.rst
+++ b/form/bootstrap4.rst
@@ -122,7 +122,7 @@ for **all** users.
 Custom Forms
 ------------
 
-Bootstrap 4 has a feature called "`custom forms`_". You can enable that on your
+Bootstrap 4 has a feature called `custom forms`_. You can enable that on your
 Symfony Form ``RadioType`` and ``CheckboxType`` by adding some classes to the label:
 
 * For a `custom radio`_, use ``radio-custom``;


### PR DESCRIPTION
The `custom forms` link was wrapped in straight double quotes, which broke the inline link rendering. Removing the quotes fixes it and matches the other links in the same section.

Fixes #22368