### PR TITLE
[Routing] Replace \d+ route requirements with [0-9]+ to avoid matching Unicode digits

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -653,7 +653,7 @@ the ``{page}`` parameter using the ``requirements`` option:
 
         class BlogController extends AbstractController
         {
-            #[Route('/blog/{page}', name: 'blog_list', requirements: ['page' => '\d+'])]
+            #[Route('/blog/{page}', name: 'blog_list', requirements: ['page' => '[0-9]+'])]
             public function list(int $page): Response
             {
                 // ...
@@ -673,7 +673,7 @@ the ``{page}`` parameter using the ``requirements`` option:
             path:       /blog/{page}
             controller: App\Controller\BlogController::list
             requirements:
-                page: '\d+'
+                page: '[0-9]+'
 
         blog_show:
             path:       /blog/{slug}
@@ -705,7 +705,7 @@ the ``{page}`` parameter using the ``requirements`` option:
         return static function (RoutingConfigurator $routes): void {
             $routes->add('blog_list', '/blog/{page}')
                 ->controller([BlogController::class, 'list'])
-                ->requirements(['page' => '\d+'])
+                ->requirements(['page' => '[0-9]+'])
             ;
 
             $routes->add('blog_show', '/blog/{slug}')
@@ -715,7 +715,7 @@ the ``{page}`` parameter using the ``requirements`` option:
         };
 
 The ``requirements`` option defines the `PHP regular expressions`_ that route
-parameters must match for the entire route to match. In this example, ``\d+`` is
+parameters must match for the entire route to match. In this example, ``[0-9]+`` is
 a regular expression that matches a *digit* of any length. Now:
 
 ========================  =============  ===============================
@@ -816,7 +816,7 @@ concise, but it can decrease route readability when requirements are complex:
 
         class BlogController extends AbstractController
         {
-            #[Route('/blog/{page<\d+>}', name: 'blog_list')]
+            #[Route('/blog/{page<[0-9]+>}', name: 'blog_list')]
             public function list(int $page): Response
             {
                 // ...
@@ -827,7 +827,7 @@ concise, but it can decrease route readability when requirements are complex:
 
         # config/routes.yaml
         blog_list:
-            path:       /blog/{page<\d+>}
+            path:       /blog/{page<[0-9]+>}
             controller: App\Controller\BlogController::list
 
     .. code-block:: xml
@@ -852,7 +852,7 @@ concise, but it can decrease route readability when requirements are complex:
         use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
         return static function (RoutingConfigurator $routes): void {
-            $routes->add('blog_list', '/blog/{page<\d+>}')
+            $routes->add('blog_list', '/blog/{page<[0-9]+>}')
                 ->controller([BlogController::class, 'list'])
             ;
             // ...
@@ -883,7 +883,7 @@ other configuration formats they are defined with the ``defaults`` option:
 
         class BlogController extends AbstractController
         {
-            #[Route('/blog/{page}', name: 'blog_list', requirements: ['page' => '\d+'])]
+            #[Route('/blog/{page}', name: 'blog_list', requirements: ['page' => '[0-9]+'])]
             public function list(int $page = 1): Response
             {
                 // ...
@@ -899,7 +899,7 @@ other configuration formats they are defined with the ``defaults`` option:
             defaults:
                 page: 1
             requirements:
-                page: '\d+'
+                page: '[0-9]+'
 
         blog_show:
             # ...
@@ -932,7 +932,7 @@ other configuration formats they are defined with the ``defaults`` option:
             $routes->add('blog_list', '/blog/{page}')
                 ->controller([BlogController::class, 'list'])
                 ->defaults(['page' => 1])
-                ->requirements(['page' => '\d+'])
+                ->requirements(['page' => '[0-9]+'])
             ;
         };
 
@@ -972,7 +972,7 @@ parameter:
 
         class BlogController extends AbstractController
         {
-            #[Route('/blog/{page<\d+>?1}', name: 'blog_list')]
+            #[Route('/blog/{page<[0-9]+>?1}', name: 'blog_list')]
             public function list(int $page): Response
             {
                 // ...
@@ -983,7 +983,7 @@ parameter:
 
         # config/routes.yaml
         blog_list:
-            path:       /blog/{page<\d+>?1}
+            path:       /blog/{page<[0-9]+>?1}
             controller: App\Controller\BlogController::list
 
     .. code-block:: xml
@@ -1008,7 +1008,7 @@ parameter:
         use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
         return static function (RoutingConfigurator $routes): void {
-            $routes->add('blog_list', '/blog/{page<\d+>?1}')
+            $routes->add('blog_list', '/blog/{page<[0-9]+>?1}')
                 ->controller([BlogController::class, 'list'])
             ;
         };


### PR DESCRIPTION
Replace \d+ route requirements with [0-9]+ to avoid matching Unicode digits (۴۵۴۵۸۴)


```
php > var_dump(preg_match('/^\d+$/u', '۴۵۴۵۸۴'));
int(1)
```

This causes an TypeError like Argument #1 ($id) must be of type int, string given, 