### PR TITLE
[WebpackEncore] Updates for 7.0.0

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -128,6 +128,7 @@ whitelist:
         - '.. versionadded:: 1.9.0' # Encore
         - '.. versionadded:: 1.18' # Flex in setup/upgrade_minor.rst
         - '.. versionadded:: 1.0.0' # Encore
+        - '.. versionadded:: 7.0' # Encore
         - '.. versionadded:: 2.7.1' # Doctrine
         - '123,' # assertion for var_dumper - components/var_dumper.rst
         - '"foo",' # assertion for var_dumper - components/var_dumper.rst

--- a/frontend/encore/advanced-config.rst
+++ b/frontend/encore/advanced-config.rst
@@ -12,18 +12,26 @@ To do that, modify the config after fetching it from Encore:
 
     // webpack.config.js
 
-    const Encore = require('@symfony/webpack-encore');
+    import Encore from '@symfony/webpack-encore';
 
     // ... all Encore config here
 
     // fetch the config, then modify it!
-    const config = Encore.getWebpackConfig();
+    const config = await Encore.getWebpackConfig();
 
     // add an extension
     config.resolve.extensions.push('json');
 
     // export the final config
-    module.exports = config;
+    export default config;
+
+.. versionadded:: 7.0
+
+    Since Webpack Encore 7.0 the configuration is **ESM-only** and
+    ``Encore.getWebpackConfig()`` is asynchronous. Before Encore 7.0, you would
+    write ``const Encore = require('@symfony/webpack-encore')``,
+    ``const config = Encore.getWebpackConfig()`` (no ``await``) and
+    ``module.exports = config``.
 
 But be careful not to accidentally override any config from Encore:
 
@@ -73,7 +81,7 @@ state of the current configuration to build a new one:
     ;
 
     // build the first configuration
-    const firstConfig = Encore.getWebpackConfig();
+    const firstConfig = await Encore.getWebpackConfig();
 
     // Set a unique name for the config (needed later!)
     firstConfig.name = 'firstConfig';
@@ -92,13 +100,13 @@ state of the current configuration to build a new one:
     ;
 
     // build the second configuration
-    const secondConfig = Encore.getWebpackConfig();
+    const secondConfig = await Encore.getWebpackConfig();
 
     // Set a unique name for the config (needed later!)
     secondConfig.name = 'secondConfig';
 
     // export the final configuration as an array of multiple configurations
-    module.exports = [firstConfig, secondConfig];
+    export default [firstConfig, secondConfig];
 
 When running Encore, both configurations will be built in parallel. If you
 prefer to build configs separately, pass the ``--config-name`` option:
@@ -246,19 +254,19 @@ being able to create a configuration object, the most important one being what
 the target environment is.
 
 To solve this issue you can use ``configureRuntimeEnvironment``. This method
-must be called from a JavaScript file **before** requiring ``webpack.config.js``.
+must be called from a JavaScript file **before** importing ``webpack.config.js``.
 
 For instance:
 
 .. code-block:: javascript
 
-    const Encore = require('@symfony/webpack-encore');
+    import Encore from '@symfony/webpack-encore';
 
     // Set the runtime environment
     Encore.configureRuntimeEnvironment('dev');
 
-    // Retrieve the Webpack configuration object
-    const webpackConfig = require('./webpack.config');
+    // Retrieve the Webpack configuration object (it is exported asynchronously)
+    const { default: webpackConfig } = await import('./webpack.config.js');
 
 If needed, you can also pass to that method all the options that you would
 normally use from the command-line interface:
@@ -285,9 +293,9 @@ For example, you could use it to configure the ``vue`` loader to enable a specif
 .. code-block:: javascript
 
     // Manually
-    const webpackConfig = Encore.getWebpackConfig();
+    const webpackConfig = await Encore.getWebpackConfig();
 
-    const vueLoader = webpackConfig.module.rules.find(rule => /vue-loader/.test(rule.loader);
+    const vueLoader = webpackConfig.module.rules.find(rule => /vue-loader/.test(rule.loader));
     vueLoader.options.experimentalInlineMatchResource = true;
 
     // Using Encore.configureLoaderRule()
@@ -295,7 +303,7 @@ For example, you could use it to configure the ``vue`` loader to enable a specif
         loaderRule.options.experimentalInlineMatchResource = true;
     });
 
-    return Encore.getWebpackConfig();
+    export default await Encore.getWebpackConfig();
 
 The following loaders are configurable with ``configureLoaderRule()``:
   - ``javascript`` (alias ``js``)
@@ -319,10 +327,19 @@ folders). In Webpack Encore you can use this option via the ``addAliases()`` met
 
 .. code-block:: javascript
 
+    import path from 'path';
+
     Encore.addAliases({
-        Utilities: path.resolve(__dirname, 'src/utilities/'),
-        Templates: path.resolve(__dirname, 'src/templates/')
+        Utilities: path.resolve(import.meta.dirname, 'src/utilities/'),
+        Templates: path.resolve(import.meta.dirname, 'src/templates/')
     })
+
+.. versionadded:: 7.0
+
+    Because Encore is now ESM-only, the CommonJS ``__dirname`` and ``__filename``
+    globals are no longer available in ``webpack.config.js``. Use
+    ``import.meta.dirname`` and ``import.meta.filename`` instead (and remember to
+    ``import`` Node.js modules such as ``path`` rather than using ``require()``).
 
 With the above config, you could now import certain modules more concisely:
 
@@ -349,6 +366,13 @@ In Webpack Encore you can use this option via the ``addExternals()`` method:
         jquery: 'jQuery',
         react: 'react'
     })
+
+Configuring JavaScript and CSS Minification
+-------------------------------------------
+
+Encore lets you customize how your JavaScript and CSS assets are minified for
+production, and even switch the underlying minifier. This is covered in its own
+article: :doc:`/frontend/encore/minification`.
 
 .. _`configuration options`: https://webpack.js.org/configuration/
 .. _`array of configurations`: https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations

--- a/frontend/encore/babel.rst
+++ b/frontend/encore/babel.rst
@@ -41,6 +41,15 @@ The ``@babel/preset-env`` preset rewrites your JavaScript so that the final synt
 will work in whatever browsers you want. To configure the browsers that you need
 to support, see :ref:`browserslist_package_config`.
 
+.. warning::
+
+    Webpack Encore 7.0 requires `Babel 8`_. Without a ``browserslist``
+    configuration, Babel 8's ``@babel/preset-env`` targets **modern browsers** by
+    default instead of compiling down to ES5. Before Encore 7.0 (Babel 7), the
+    absence of a ``browserslist`` configuration meant transpiling to ES5. If you
+    need to support older browsers, add a ``browserslist`` configuration to your
+    project (see :ref:`browserslist_package_config`).
+
 After changing your "browserslist" config, you will need to manually remove the babel
 cache directory:
 
@@ -61,10 +70,28 @@ method to add any of the `@babel/preset-env configuration options`_:
         // ...
 
         .configureBabelPresetEnv((config) => {
-            config.useBuiltIns = 'usage';
-            config.corejs = 3;
+            // ...
         })
     ;
+
+.. warning::
+
+    The ``useBuiltIns`` and ``corejs`` options are **no longer supported** since
+    Webpack Encore 7.0, because Babel 8 removed them from ``@babel/preset-env``.
+    Encore throws an explicit error if you set them. Before Encore 7.0, you could
+    enable polyfills with ``config.useBuiltIns = 'usage'`` and ``config.corejs = 3``.
+
+    To polyfill with Babel 8, use `babel-plugin-polyfill-corejs3`_ instead, for
+    example:
+
+    .. code-block:: javascript
+
+        Encore.configureBabel((babelConfig) => {
+            babelConfig.plugins.push([
+                'polyfill-corejs3',
+                { method: 'usage-global' },
+            ]);
+        });
 
 Creating a ``.babelrc`` File
 ----------------------------
@@ -80,4 +107,6 @@ As soon as a ``.babelrc`` file is present, it will take priority over the Babel
 configuration added by Encore.
 
 .. _`Babel`: https://babeljs.io/
+.. _`Babel 8`: https://babeljs.io/docs/v8-migration/
+.. _`babel-plugin-polyfill-corejs3`: https://github.com/babel/babel-polyfills
 .. _`@babel/preset-env configuration options`: https://babeljs.io/docs/babel-preset-env

--- a/frontend/encore/bootstrap.rst
+++ b/frontend/encore/bootstrap.rst
@@ -51,14 +51,14 @@ Now, require bootstrap from any of your JavaScript files:
 
     // app.js
 
-    const $ = require('jquery');
+    import $ from 'jquery';
     // this "modifies" the jquery module: adding behavior to it
     // the bootstrap module doesn't export/return anything
-    require('bootstrap');
+    import 'bootstrap';
 
     // or you can include specific pieces
-    // require('bootstrap/js/dist/tooltip');
-    // require('bootstrap/js/dist/popover');
+    // import 'bootstrap/js/dist/tooltip.js';
+    // import 'bootstrap/js/dist/popover.js';
 
     $(document).ready(function() {
         $('[data-toggle="popover"]').popover();
@@ -95,10 +95,10 @@ and CSS like normal:
 
     // ...
 
-    // require the JavaScript
-    require('bootstrap-star-rating');
-    // require 2 CSS files needed
-    require('bootstrap-star-rating/css/star-rating.css');
-    require('bootstrap-star-rating/themes/krajee-svg/theme.css');
+    // import the JavaScript
+    import 'bootstrap-star-rating';
+    // import 2 CSS files needed
+    import 'bootstrap-star-rating/css/star-rating.css';
+    import 'bootstrap-star-rating/themes/krajee-svg/theme.css';
 
 .. _`Bootstrap CSS framework`: https://getbootstrap.com/

--- a/frontend/encore/custom-loaders-plugins.rst
+++ b/frontend/encore/custom-loaders-plugins.rst
@@ -31,15 +31,21 @@ additional information your need for the loader
             loader: 'handlebars-loader',
             options: {
                 helperDirs: [
-                    __dirname + '/helpers1',
-                    __dirname + '/helpers2',
+                    import.meta.dirname + '/helpers1',
+                    import.meta.dirname + '/helpers2',
                 ],
                 partialDirs: [
-                    path.join(__dirname, 'templates', 'partials')
+                    path.join(import.meta.dirname, 'templates', 'partials')
                 ]
             }
         })
     ;
+
+.. versionadded:: 7.0
+
+    Since Webpack Encore 7.0 is ESM-only, the CommonJS ``__dirname`` global is no
+    longer available in ``webpack.config.js``. Use ``import.meta.dirname`` instead
+    (and ``import path from 'path';`` rather than ``require('path')``).
 
 Adding Custom Plugins
 ---------------------
@@ -51,7 +57,7 @@ to use the `IgnorePlugin`_ (see `moment/moment#2373`_):
 .. code-block:: diff
 
       // webpack.config.js
-    + var webpack = require('webpack');
+    + import webpack from 'webpack';
 
       Encore
           // ...

--- a/frontend/encore/dev-server.rst
+++ b/frontend/encore/dev-server.rst
@@ -61,7 +61,7 @@ you can reuse the Symfony web server SSL certificate:
 
       // webpack.config.js
       // ...
-    + const path = require('path');
+    + import path from 'path';
 
       Encore
           // ...

--- a/frontend/encore/faq.rst
+++ b/frontend/encore/faq.rst
@@ -88,7 +88,7 @@ now contain the subdirectory.
 ---------------------------------------------
 
 This error happens when your code (or some library that you are using) expects ``$``
-or ``jQuery`` to be a global variable. But, when you use Webpack and ``require('jquery')``,
+or ``jQuery`` to be a global variable. But, when you use Webpack and ``import $ from 'jquery'``,
 no global variables are set.
 
 The fix depends on if the error is happening in your code or inside some third-party
@@ -111,7 +111,7 @@ you try to require that module:
 
 .. code-block:: javascript
 
-    require('respond.js');
+    import 'respond.js';
 
 But, instead of working, you see an error:
 
@@ -121,14 +121,14 @@ But, instead of working, you see an error:
 
 Typically, a package will "advertise" its "main" file by adding a ``main`` key to
 its ``package.json``. But sometimes, old libraries won't have this. Instead, you'll
-need to specifically require the file you need. In this case, the file you should
-use is located at ``node_modules/respond.js/dest/respond.src.js``. You can require
+need to specifically import the file you need. In this case, the file you should
+use is located at ``node_modules/respond.js/dest/respond.src.js``. You can import
 this via:
 
 .. code-block:: javascript
 
-    // require a non-minified file whenever possible
-    require('respond.js/dest/respond.src.js');
+    // import a non-minified file whenever possible
+    import 'respond.js/dest/respond.src.js';
 
 I need to execute Babel on a third-party Module
 -----------------------------------------------
@@ -158,7 +158,7 @@ running it (e.g. when executing ``npx encore dev``). Fix this issue calling to
 .. code-block:: javascript
 
     // webpack.config.js
-    const Encore = require('@symfony/webpack-encore')
+    import Encore from '@symfony/webpack-encore';
 
     if (!Encore.isRuntimeEnvironmentConfigured()) {
         Encore.configureRuntimeEnvironment(process.env.NODE_ENV || 'dev');

--- a/frontend/encore/index.rst
+++ b/frontend/encore/index.rst
@@ -25,6 +25,7 @@ Optimizing
 ..........
 
 * :doc:`Versioning (and the entrypoints.json/manifest.json files) </frontend/encore/versioning>`
+* :doc:`Minifying JavaScript and CSS </frontend/encore/minification>`
 * :doc:`Using a CDN </frontend/encore/cdn>`
 * :doc:`/frontend/encore/code-splitting`
 * :doc:`/frontend/encore/split-chunks`

--- a/frontend/encore/installation.rst
+++ b/frontend/encore/installation.rst
@@ -4,6 +4,16 @@ Installing Encore
 First, make sure you `install Node.js`_. Then, follow the instructions below,
 which depend on whether you are installing Encore in a Symfony application or not.
 
+.. versionadded:: 7.0
+
+    Webpack Encore 7.0 made the package **ESM-only**. Before Encore 7.0,
+    ``webpack.config.js`` used CommonJS (``const Encore = require('@symfony/webpack-encore')``
+    and ``module.exports = Encore.getWebpackConfig()``) and ``getWebpackConfig()``
+    was synchronous. Starting with Encore 7.0 you must use ESM syntax (``import`` /
+    ``export``), add ``"type": "module"`` to your ``package.json`` (or rename the
+    file to ``webpack.config.mjs``), and ``getWebpackConfig()`` returns a ``Promise``
+    that must be awaited.
+
 Installing Encore in Symfony Applications
 -----------------------------------------
 
@@ -49,7 +59,7 @@ is the main config file for both Webpack and Webpack Encore:
 
 .. code-block:: javascript
 
-    const Encore = require('@symfony/webpack-encore');
+    import Encore from '@symfony/webpack-encore';
 
     // Manually configure the runtime environment if not already configured yet by the "encore" command.
     // It's useful when you use tools that rely on webpack.config.js file.
@@ -100,10 +110,9 @@ is the main config file for both Webpack and Webpack Encore:
             config.plugins.push('@babel/plugin-transform-class-properties');
         })
 
-        // enables @babel/preset-env polyfills
+        // configures @babel/preset-env
         .configureBabelPresetEnv((config) => {
-            config.useBuiltIns = 'usage';
-            config.corejs = 3;
+            // ...
         })
 
         // enables Sass/SCSS support
@@ -123,7 +132,17 @@ is the main config file for both Webpack and Webpack Encore:
         //.autoProvidejQuery()
     ;
 
-    module.exports = Encore.getWebpackConfig();
+    export default await Encore.getWebpackConfig();
+
+Since this config uses ESM syntax (``import`` / ``export``), your ``package.json``
+must declare the project as an ESM package by adding a ``"type": "module"`` entry
+(alternatively, rename the config file to ``webpack.config.mjs``):
+
+.. code-block:: json
+
+    {
+        "type": "module"
+    }
 
 Creating Other Supporting File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/frontend/encore/legacy-applications.rst
+++ b/frontend/encore/legacy-applications.rst
@@ -7,7 +7,7 @@ Instead, it just returns a value:
 .. code-block:: javascript
 
     // this loads jquery, but does *not* set a global $ or jQuery variable
-    const $ = require('jquery');
+    import $ from 'jquery';
 
 In practice, this will cause problems with some outside libraries that *rely* on
 jQuery to be global *or* if *your* JavaScript isn't being processed through Webpack
@@ -63,7 +63,7 @@ Accessing jQuery from outside of Webpack JavaScript Files
 
 If *your* code needs access to ``$`` or ``jQuery`` and you are inside of a file
 that's processed by Webpack/Encore, you should remove any "$ is not defined" errors
-by requiring jQuery: ``var $ = require('jquery')``.
+by importing jQuery: ``import $ from 'jquery'``.
 
 But if you also need to provide access to ``$`` and ``jQuery`` variables outside of
 JavaScript files processed by Webpack (e.g. JavaScript that still lives in your
@@ -77,8 +77,8 @@ page, add:
 
       // app.js
 
-      // require jQuery normally
-      const $ = require('jquery');
+      // import jQuery normally
+      import $ from 'jquery';
 
     + // create global $ and jQuery variables
     + global.$ = global.jQuery = $;

--- a/frontend/encore/minification.rst
+++ b/frontend/encore/minification.rst
@@ -1,0 +1,101 @@
+Minifying JavaScript and CSS with Webpack Encore
+================================================
+
+When building for production (``encore production``), Encore minifies your assets
+to make them as small as possible. Both JavaScript and CSS minification are backed
+by the unified `minimizer-webpack-plugin`_, which lets you pick and configure the
+underlying minifier through the ``minify`` option.
+
+.. versionadded:: 7.0
+
+    Before Encore 7.0, JavaScript minification was handled by
+    ``terser-webpack-plugin`` (configured via ``configureTerserPlugin()``) and CSS
+    minification by ``css-minimizer-webpack-plugin``. Both archived plugins were
+    replaced by the unified `minimizer-webpack-plugin`_ in Encore 7.0:
+
+    * ``configureTerserPlugin()`` was **removed**; use the new
+      :ref:`configureJsMinimizerPlugin() <encore-configure-js-minimizer>` instead
+      (it takes the same callback).
+    * **CSS minification is no longer enabled by default.** You must choose and
+      configure a CSS minifier (see :ref:`below <encore-configure-css-minimizer>`),
+      otherwise CSS is not minified in production.
+    * Minifier packages (``lightningcss``, ``cssnano``, ``csso``, ``clean-css``,
+      ``esbuild``, ``@swc/*``, ``uglify-js``) are now optional peer dependencies,
+      installed on demand. In particular ``cssnano``, previously pulled in
+      transitively by ``css-minimizer-webpack-plugin``, is no longer installed by
+      default. A clear error is thrown at build time if the package backing your
+      selected minifier is missing.
+
+.. _encore-configure-js-minimizer:
+
+Minifying JavaScript
+--------------------
+
+JavaScript is minified out of the box (no extra package required) using Terser,
+which is bundled inside ``minimizer-webpack-plugin``. Use
+``configureJsMinimizerPlugin()`` to tweak its options or switch to another
+minifier.
+
+The ``MinimizerPlugin`` class is passed as the second argument of the callback, so
+you don't need to import ``minimizer-webpack-plugin`` yourself (it would not
+resolve under pnpm, being a transitive dependency of Encore):
+
+.. code-block:: javascript
+
+    // webpack.config.js
+    // ...
+
+    // Tweak the default (Terser) options
+    Encore.configureJsMinimizerPlugin((options) => {
+        options.terserOptions = {
+            // ...
+        };
+    });
+
+    // Or switch the JS minimizer to esbuild (npm install --save-dev esbuild)
+    Encore.configureJsMinimizerPlugin((options, MinimizerPlugin) => {
+        options.minify = MinimizerPlugin.esbuildMinify;
+    });
+
+Available JS minimizers: ``terserMinify`` (default, bundled), ``uglifyJsMinify``,
+``swcMinify`` and ``esbuildMinify``. Install the package backing the minimizer you
+choose (e.g. ``npm install --save-dev uglify-js`` for ``uglifyJsMinify``); a clear
+error is thrown at build time if it is missing.
+
+.. _encore-configure-css-minimizer:
+
+Minifying CSS
+-------------
+
+Since Encore 7.0, CSS is **not** minified by default. Enable it by choosing a
+minifier via ``configureCssMinimizerPlugin()``. As above, the ``MinimizerPlugin``
+class is passed as the second argument of the callback:
+
+.. code-block:: javascript
+
+    // webpack.config.js
+    // ...
+
+    // Lightning CSS, a fast Rust-based minifier (npm install --save-dev lightningcss)
+    Encore.configureCssMinimizerPlugin((options, MinimizerPlugin) => {
+        options.minify = MinimizerPlugin.lightningCssMinify;
+    });
+
+    // cssnano, PostCSS-based, closest to the previous default
+    // (npm install --save-dev cssnano postcss)
+    Encore.configureCssMinimizerPlugin((options, MinimizerPlugin) => {
+        options.minify = MinimizerPlugin.cssnanoMinify;
+    });
+
+Other supported CSS minimizers: ``csso``, ``clean-css``, ``esbuild``
+(``esbuildMinifyCss``) and ``@swc/css`` (``swcMinifyCss``).
+
+.. tip::
+
+    If you are upgrading from Encore 6.0 and want to keep the previous behavior
+    (CSS minified with ``cssnano``), install ``cssnano`` and ``postcss``, then add
+    the ``cssnanoMinify`` configuration shown above.
+
+See the `minimizer-webpack-plugin`_ documentation for all the available options.
+
+.. _`minimizer-webpack-plugin`: https://github.com/webpack/minimizer-webpack-plugin

--- a/frontend/encore/postcss.rst
+++ b/frontend/encore/postcss.rst
@@ -29,15 +29,26 @@ Next, create a ``postcss.config.js`` file at the root of your project:
 
 .. code-block:: javascript
 
-    module.exports = {
-        plugins: {
+    // postcss.config.js
+    import autoprefixer from 'autoprefixer';
+
+    export default {
+        plugins: [
             // include whatever plugins you want
             // but make sure you install these via npm!
 
             // add browserslist config to package.json (see below)
-            autoprefixer: {}
-        }
-    }
+            autoprefixer(),
+        ],
+    };
+
+.. versionadded:: 7.0
+
+    Because projects using Webpack Encore 7.0 set ``"type": "module"`` in their
+    ``package.json``, configuration files like ``postcss.config.js`` must use ESM
+    syntax (``import`` / ``export default``). Before Encore 7.0, this file used
+    CommonJS (``module.exports = { ... }``). If you prefer to keep CommonJS syntax,
+    rename the file to ``postcss.config.cjs``.
 
 That's it! The ``postcss-loader`` will now be used for all CSS, Sass, etc files.
 You can also pass options to the `postcss-loader`_ by passing a callback:
@@ -45,14 +56,14 @@ You can also pass options to the `postcss-loader`_ by passing a callback:
 .. code-block:: diff
 
       // webpack.config.js
-    + const path = require('path');
+    + import path from 'path';
 
       Encore
           // ...
     +     .enablePostCssLoader((options) => {
     +         options.postcssOptions = {
     +             // the directory where the postcss.config.js file is stored
-    +             config: path.resolve(__dirname, 'sub-dir', 'custom.config.js'),
+    +             config: path.resolve(import.meta.dirname, 'sub-dir', 'custom.config.js'),
     +         };
     +     })
       ;

--- a/frontend/encore/simple-example.rst
+++ b/frontend/encore/simple-example.rst
@@ -33,7 +33,7 @@ of your project. It already holds the basic config you need:
 .. code-block:: javascript
 
     // webpack.config.js
-    const Encore = require('@symfony/webpack-encore');
+    import Encore from '@symfony/webpack-encore';
 
     Encore
         // directory where compiled assets will be stored
@@ -49,8 +49,18 @@ of your project. It already holds the basic config you need:
 
     // ...
 
+    export default await Encore.getWebpackConfig();
+
+.. versionadded:: 7.0
+
+    Since Webpack Encore 7.0 the configuration must use ESM syntax (``import`` /
+    ``export``) and ``Encore.getWebpackConfig()`` is asynchronous, so it must be
+    awaited. Before Encore 7.0, the file used CommonJS
+    (``const Encore = require('@symfony/webpack-encore')`` and
+    ``module.exports = Encore.getWebpackConfig()``).
+
 The *key* part is ``addEntry()``: this tells Encore to load the ``assets/app.js``
-file and follow *all* of the ``require()`` statements. It will then package everything
+file and follow *all* of the ``import`` statements. It will then package everything
 together and - thanks to the first ``app`` argument - output final ``app.js`` and
 ``app.css`` files into the ``public/build`` directory.
 
@@ -190,9 +200,9 @@ Great! Use ``import`` to import ``jquery`` and ``greet.js``:
     + // loads the jquery package from node_modules
     + import $ from 'jquery';
 
-    + // import the function from greet.js (the .js extension is optional)
+    + // import the function from greet.js
     + // ./ (or ../) means to look for a local file
-    + import greet from './greet';
+    + import greet from './greet.js';
 
     + $(document).ready(function() {
     +     $('body').prepend('<h1>'+greet('jill')+'</h1>');
@@ -201,6 +211,15 @@ Great! Use ``import`` to import ``jquery`` and ``greet.js``:
 That's it! If you previously ran ``encore dev --watch``, your final, built files
 have already been updated: jQuery and ``greet.js`` have been automatically
 added to the output file (``app.js``). Refresh to see the message!
+
+.. versionadded:: 7.0
+
+    Because Encore 7.0 projects use ``"type": "module"``, Webpack enables
+    `resolve.fullySpecified`_ by default. This means **the file extension is now
+    required** for relative imports (``import greet from './greet.js'``) and for
+    deep imports from packages without an ``"exports"`` field (e.g.
+    ``import 'jquery-ui/ui/widgets/progressbar.js'``). Before Encore 7.0, the
+    extension was optional.
 
 Stimulus & Symfony UX
 ---------------------
@@ -459,6 +478,7 @@ Keep Going!
 Encore supports many more features! For a full list of what you can do, see
 `Encore's index.js file`_. Or, go back to :ref:`list of Frontend articles <encore-toc>`.
 
+.. _`resolve.fullySpecified`: https://webpack.js.org/configuration/module/#resolvefullyspecified
 .. _`Encore's index.js file`: https://github.com/symfony/webpack-encore/blob/master/index.js
 .. _`WebpackEncoreBundle Configuration`: https://github.com/symfony/webpack-encore-bundle#configuration
 .. _`Stimulus`: https://stimulus.hotwired.dev/

--- a/frontend/encore/vuejs.rst
+++ b/frontend/encore/vuejs.rst
@@ -174,20 +174,29 @@ Using images
 ~~~~~~~~~~~~
 
 You can't use ``<img src="./image.png">`` in ``.jsx`` files. As a workaround,
-you can import them with ``require()`` function:
+you can ``import`` them:
 
 .. code-block:: jsx
+
+    import imageUrl from './image.png';
 
     export default {
         name: 'Component',
         render() {
             return (
                 <div>
-                    <img src={require("./image.png")}/>
+                    <img src={imageUrl}/>
                 </div>
             )
         }
     }
+
+.. versionadded:: 7.0
+
+    Since Webpack Encore 7.0 is ESM-only, the CommonJS ``require()`` function is no
+    longer available in your application code. Before Encore 7.0, you could inline
+    the image with ``<img src={require("./image.png")}/>``; use a top-level
+    ``import`` instead.
 
 Using Vue inside Twig templates
 -------------------------------


### PR DESCRIPTION
I'm planning to release Webpack Encore 7.0.0 tomorrow, a [big release](https://github.com/symfony/webpack-encore/compare/v6.0.0...main) that implies to correct some parts of the documentation.

Thanks!