### PR TITLE
[Framework] Mentioning `ide` deprecation

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2351,6 +2351,11 @@ ide
 
 **type**: ``string`` **default**: ``%env(default::SYMFONY_IDE)%``
 
+.. deprecated:: 8.2
+
+    The ``ide`` option is deprecated since Symfony 8.2, and already stopped
+    working in lower versions. Use the ``SYMFONY_IDE`` environment variable instead.
+
 Symfony turns file paths seen in variable dumps and exception messages into
 links that open those files right inside your browser. If you prefer to open
 those files in your favorite IDE or text editor, set this option to any of the


### PR DESCRIPTION
Page: https://symfony.com/doc/8.2/reference/configuration/framework.html#ide

As promised in https://github.com/symfony/symfony/pull/64018#issuecomment-4302953040

Since this option already isn't working anymore, IMO it could also be added to a lower version, with slight rewording, like:

> The `ide` option isn't working anymore since version [don't know], and is deprecated in Symfony 8.2.

