### PR TITLE
[Form] fix the note about setting the form event table

### DIFF
--- a/form/events.rst
+++ b/form/events.rst
@@ -81,8 +81,6 @@ Form view data        ``null``
     See all form events at a glance in the
     :ref:`Form Events Information Table <component-form-event-table>`.
 
-    instead.
-
 .. sidebar:: ``FormEvents::PRE_SET_DATA`` in the Form component
 
     The ``Symfony\Component\Form\Extension\Core\Type\CollectionType`` form type relies


### PR DESCRIPTION
Having a paragraph with just `instead.` in it looks weird.

I removed the word entirely, making this note consistent with similar notes in other sections of the same page.