### PR TITLE
 Fix invalid definition for the `excluded_http_codes` property

### DIFF
--- a/logging/monolog_exclude_http_codes.rst
+++ b/logging/monolog_exclude_http_codes.rst
@@ -16,7 +16,7 @@ logging these HTTP codes based on the MonologBundle configuration:
                     # ...
                     type: fingers_crossed
                     handler: ...
-                    excluded_http_codes: [403, 404, { 400: ['^/foo', '^/bar'] }]
+                    excluded_http_codes: [403, 404, { code: 400, urls: ['^/foo', '^/bar'] }]
 
     .. code-block:: php
 
@@ -30,7 +30,7 @@ logging these HTTP codes based on the MonologBundle configuration:
                         // ...
                         'type' => 'fingers_crossed',
                         'handler' => ...,
-                        'excluded_http_codes' => [403, 404, ['400' => ['^/foo', '^/bar']]],
+                        'excluded_http_codes' => [403, 404, ['code' => '400', 'urls' => ['^/foo', '^/bar']]],
                     ],
                 ],
             ],


### PR DESCRIPTION
That property is taking specific properties, the documentation wasn't up to date with the latest structure.

The `reference.php` file:

```
excluded_http_codes?: list<array{ // Default: []
    code?: scalar|Param|null,
    urls?: list<scalar|Param|null>,
}>,
```