### PR TITLE
 Mention that building the docs is not supported on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Build Documentation Locally
 This is not needed for contributing, but it's useful if you would like to debug some
 issue in the docs or if you want to read Symfony Documentation offline.
 
+> [!NOTE]
+> The application that builds the Symfony Docs does not support Windows. Windows
+> users should build the docs using a Linux distribution via [WSL](https://learn.microsoft.com/windows/wsl/).
+
 ```bash
 $ git clone git@github.com:symfony/symfony-docs.git
 


### PR DESCRIPTION
Adds a note in the *Build Documentation Locally* section that the build is not supported on Windows and that WSL should be used, matching the runtime error message.

Closes #22421