### PR TITLE
[Security] Document disabling the redirect on logout

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -551,6 +551,15 @@ The relative path (if the value starts with ``/``), or absolute URL (if it
 starts with ``http://`` or ``https://``) or the route name (otherwise) to
 redirect after logout.
 
+Set this option to ``null`` to not redirect after logout. The request then
+continues to the controller of the route referenced by the logout ``path``,
+which allows you to return your own response. See
+:ref:`Building the Logout Response Yourself <security-logout-without-redirect>`.
+
+.. versionadded:: 8.2
+
+    The support for the ``null`` value was introduced in Symfony 8.2.
+
 .. _reference-security-logout-csrf:
 
 enable_csrf

--- a/security.rst
+++ b/security.rst
@@ -1690,6 +1690,85 @@ you have imported the logout route loader in your routes:
             ],
         ]);
 
+.. _security-logout-without-redirect:
+
+Building the Logout Response Yourself
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Set the ``target`` option to ``null`` to disable the redirection. Symfony still
+un-authenticates the user, but it lets the request continue, so you can return
+any response you want.
+
+In this case, the ``path`` option must reference one of your own routes, because
+Symfony needs a controller to build the response. This is convenient when logging
+out from an API, where the logout response is defined next to the login one:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/security.yaml
+        security:
+            # ...
+
+            firewalls:
+                main:
+                    json_login:
+                        check_path: app_login
+                    logout:
+                        path: app_logout
+                        target: null
+
+    .. code-block:: php
+
+        // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'json_login' => [
+                            'check_path' => 'app_login',
+                        ],
+                        'logout' => [
+                            'path' => 'app_logout',
+                            'target' => null,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+Then, return the response from the controller of the logout route::
+
+    // src/Controller/AuthController.php
+    namespace App\Controller;
+
+    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\JsonResponse;
+    use Symfony\Component\Routing\Attribute\Route;
+
+    class AuthController extends AbstractController
+    {
+        #[Route('/logout', name: 'app_logout')]
+        public function logout(): JsonResponse
+        {
+            return $this->json(null);
+        }
+    }
+
+.. warning::
+
+    When ``target`` is ``null``, no response is set on the
+    :class:`Symfony\\Component\\Security\\Http\\Event\\LogoutEvent`, so the other
+    logout listeners cannot modify it.
+
+.. versionadded:: 8.2
+
+    The support for the ``null`` value of the ``target`` option was introduced
+    in Symfony 8.2.
+
 Logout programmatically
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Documents the new `logout.target: null` option introduced in symfony/symfony#46320 (merged in 8.2).

Fix #22449

Two places:

- `security.rst`: a new "Building the Logout Response Yourself" subsection, showing the JSON API use case from the feature PR (customizing the logout response in a controller, next to the login one).
- `reference/configuration/security.rst`: the `target` option now mentions the `null` value and links to that subsection.

Two points I made explicit while reading the feature PR, since neither is obvious:

- the logout `path` must reference one of your own routes. The route registered by `security.route_loader.logout` is created with `new Route($logoutPath)` and carries no `_controller`, so without a redirect there would be nothing to build the response.
- when `target` is `null`, no response is set on the `LogoutEvent`, so the other logout listeners can no longer modify it. The feature PR author flags this as the trade-off of the option.