### PR TITLE
[Security] Document the access_decision() Twig functions in the reference

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -222,6 +222,48 @@ Returns ``true`` if the user is authorized for the specified attribute.
 Optionally, an object can be passed to be used by the voter. More information
 can be found in :ref:`security-template`.
 
+access_decision
+~~~~~~~~~~~~~~~
+
+.. versionadded:: 7.4
+
+    The ``access_decision()`` function was introduced in Symfony 7.4.
+
+.. code-block:: twig
+
+    {{ access_decision(role, object = null) }}
+
+``role``
+    **type**: ``string``
+``object`` *(optional)*
+    **type**: ``object``
+
+Returns an :class:`Symfony\\Component\\Security\\Core\\Authorization\\AccessDecision`
+object, which tells whether the current user has the given role (``isGranted``) and
+gives the reason of a denial (``message``). More information can be found in
+:ref:`security-template`.
+
+access_decision_for_user
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 7.4
+
+    The ``access_decision_for_user()`` function was introduced in Symfony 7.4.
+
+.. code-block:: twig
+
+    {{ access_decision_for_user(user, attribute, subject = null) }}
+
+``user``
+    **type**: ``object``
+``attribute``
+    **type**: ``string``
+``subject`` *(optional)*
+    **type**: ``object``
+
+Same as ``access_decision()``, but it checks the authorization of the given user
+instead of the current one.
+
 logout_path
 ~~~~~~~~~~~
 

--- a/security.rst
+++ b/security.rst
@@ -2751,7 +2751,7 @@ permission in :ref:`your custom security voters <creating-the-custom-voter>`:
         <p>{{ voter_decision.message }}</p>
     {% endif %}
 
-    {% set voter_decision = access_decision('post_edit', post, anotherUser) %}
+    {% set voter_decision = access_decision_for_user(anotherUser, 'post_edit', post) %}
     {% if voter_decision.isGranted %}
         {# ... #}
     {% else %}


### PR DESCRIPTION
The `access_decision()` and `access_decision_for_user()` Twig functions were only documented in `security.rst`. This adds them to the Twig Extensions Reference, right after `is_granted_for_user()` so the security functions stay grouped.

Fix #21788

They were introduced in 7.4: `access_decision` is absent from `SecurityExtension` on `7.3` and present on `7.4`, hence the base branch and the `versionadded` directives.

### One extra change

While checking the signatures against `Symfony\Bridge\Twig\Extension\SecurityExtension`, I noticed the second example in `security.rst` is wrong:

```twig
{% set voter_decision = access_decision('post_edit', post, anotherUser) %}
```

`getAccessDecision(mixed $role, mixed $object = null, ?string $field = null)` — the third argument is a field name, so passing a user object there raises a `TypeError`. The surrounding paragraph announces `access_decision_for_user()` but never shows it, so the example was clearly meant to demonstrate that function. I changed it to:

```twig
{% set voter_decision = access_decision_for_user(anotherUser, 'post_edit', post) %}
```

which matches `getAccessDecisionForUser(UserInterface $user, mixed $attribute, mixed $subject = null)`. Happy to split that into its own PR if you prefer.