### PR TITLE
[Console] Improve information about signal handling

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -163,10 +163,6 @@ The ``ConsoleEvents::SIGNAL`` Event
 
 **Typical Purposes**: To perform some actions after the command execution was interrupted.
 
-`Signals`_ are asynchronous notifications sent to a process in order to notify
-it of an event that occurred. For example, when you press ``Ctrl + C`` in a
-command, the operating system sends the ``SIGINT`` signal to it.
-
 When a command is interrupted, Symfony dispatches the ``ConsoleEvents::SIGNAL``
 event. Listen to this event so you can perform some actions (e.g. logging some
 results, cleaning some temporary files, etc.) before finishing the command execution.
@@ -201,53 +197,6 @@ method::
     $dispatcher->addListener(ConsoleEvents::SIGNAL, function (ConsoleSignalEvent $event) {
         $event->abortExit();
     });
-
-.. tip::
-
-    All the available signals (``SIGINT``, ``SIGQUIT``, etc.) are defined as
-    `constants of the PCNTL PHP extension`_. The extension has to be installed
-    for these constants to be available.
-
-If you use the Console component inside a Symfony application, commands can
-handle signals themselves by subscribing to the :class:`Symfony\\Component\\Console\\Event\\ConsoleSignalEvent` event::
-
-    // src/Command/MyCommand.php
-    namespace App\Command;
-
-    use Symfony\Component\Console\Attribute\AsCommand;
-    use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-
-    #[AsCommand(name: 'app:my-command')]
-    class MyCommand
-    {
-        // ...
-
-        #[AsEventListener(ConsoleSignalEvent::class)]
-        public function handleSignal(ConsoleSignalEvent $event): void
-        {
-            // set here any of the constants defined by PCNTL extension
-            if (in_array($event->getHandlingSignal(), [\SIGINT, \SIGTERM], true)) {
-                // ...
-            }
-
-            // ...
-
-            // set an integer exit code, or
-            // false to continue normal execution
-            $event->setExitCode(0);
-        }
-    }
-
-Symfony doesn't handle any signal received by the command (not even ``SIGKILL``,
-``SIGTERM``, etc). This behavior is intended, as it gives you the flexibility to
-handle all signals e.g. to do some tasks before terminating the command.
-
-.. tip::
-
-    If you need to fetch the signal name from its integer value (e.g. for logging),
-    you can use the
-    :method:`Symfony\\Component\\Console\\SignalRegistry\\SignalMap::getSignalName`
-    method.
 
 .. _the-consoleevents-alarm-event:
 
@@ -317,5 +266,3 @@ actions on each alarm::
     Symfony 7.2.
 
 .. _`reserved exit codes`: https://www.tldp.org/LDP/abs/html/exitcodes.html
-.. _`Signals`: https://en.wikipedia.org/wiki/Signal_(IPC)
-.. _`constants of the PCNTL PHP extension`: https://www.php.net/manual/en/pcntl.constants.php

--- a/console.rst
+++ b/console.rst
@@ -607,11 +607,73 @@ registers an :doc:`event subscriber </event_dispatcher>` to listen to the
 :ref:`ConsoleEvents::TERMINATE event <console-events-terminate>` and adds a log
 message whenever a command doesn't finish with the ``0`` `exit status`_.
 
-Using Events And Handling Signals
----------------------------------
+Using Events
+------------
 
 When a command is running, many events are dispatched, one of them allows you to
 react to signals, read more in :doc:`this section </components/console/events>`.
+
+Handling Signals
+----------------
+
+`Signals`_ are asynchronous notifications sent to a process in order to notify
+it of an event that occurred. For example, when you press ``Ctrl + C`` in a
+command, the operating system sends the ``SIGINT`` signal to it.
+
+.. tip::
+
+    All the available signals (``SIGINT``, ``SIGQUIT``, etc.) are defined as
+    `constants of the PCNTL PHP extension`_. The extension has to be installed
+    for these constants to be available.
+
+In a Symfony application, a command can handle these signals by implementing the
+:class:`Symfony\\Component\\Console\\Command\\SignalableCommandInterface` and
+subscribing to one or more signals::
+
+    // src/Command/MyCommand.php
+    namespace App\Command;
+
+    use Symfony\Component\Console\Attribute\AsCommand;
+    use Symfony\Component\Console\Command\SignalableCommandInterface;
+
+    #[AsCommand(name: 'app:my-command')]
+    class MyCommand implements SignalableCommandInterface
+    {
+        // ...
+
+        public function getSubscribedSignals(): array
+        {
+            // return here any of the constants defined by PCNTL extension
+            return [\SIGINT, \SIGTERM];
+        }
+
+        public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+        {
+            if (\SIGINT === $signal) {
+                // ...
+            }
+
+            // ...
+
+            // return an integer to set the exit code, or
+            // false to continue normal execution
+            return 0;
+        }
+    }
+
+This registers a signal handler for that command only. To run the same handler
+for all commands, use :ref:`events <console-events_signal>` instead.
+
+Symfony doesn't handle any signal received by the command (not even ``SIGKILL``,
+``SIGTERM``, etc). This behavior is intended, as it gives you the flexibility to
+handle all signals e.g. to do some tasks before terminating the command.
+
+.. tip::
+
+    If you need to fetch the signal name from its integer value (e.g. for logging),
+    you can use the
+    :method:`Symfony\\Component\\Console\\SignalRegistry\\SignalMap::getSignalName`
+    method.
 
 Profiling Commands
 ------------------
@@ -757,3 +819,5 @@ tools capable of helping you with different tasks:
 * :doc:`/components/console/helpers/tree`: displays tree-like structures
 
 .. _`exit status`: https://en.wikipedia.org/wiki/Exit_status
+.. _`Signals`: https://en.wikipedia.org/wiki/Signal_(IPC)
+.. _`constants of the PCNTL PHP extension`: https://www.php.net/manual/en/pcntl.constants.php


### PR DESCRIPTION
Originally, the signal handling documentation used `SignalableCommandInterface` in the example. This was later changed in #20932 to an example using `#[AsEventListener(ConsoleSignalEvent::class)]`.

However, these two approaches are **not** equivalent.

`SignalableCommandInterface` registers signal handlers **only for the command that implements the interface**, whereas an event listener for `ConsoleSignalEvent` is registered globally and is triggered for **every** command.

For example:

```php
#[AsCommand(name: 'app:my-command')]
class MyCommand
{
    // ...

    #[AsEventListener(ConsoleSignalEvent::class)]
    public function handleSignal(ConsoleSignalEvent $event): void
    {
        if (\in_array($event->getHandlingSignal(), [\SIGINT, \SIGTERM], true)) {
            // ...
        }

        // ...
    }
}
```

Although the listener is defined inside `MyCommand`, it is **not** scoped to that command. It will be invoked whenever **any** console command receives one of the configured signals.

As part of this change, all mentions of `SignalableCommandInterface` were also removed from the documentation, making it appear as though event listeners are the recommended replacement, even though they serve a different purpose.

This PR tries to create the distinction between per-command signal handlers and global signal handlers.
