### PR TITLE
[DependencyInjection] Document the RequiredBundle attribute and the ConsoleBundle

### DIFF
--- a/bundles.rst
+++ b/bundles.rst
@@ -86,6 +86,57 @@ of the bundle. Now that you've created the bundle, enable it::
 
 And while it doesn't do anything yet, AcmeBlogBundle is now ready to be used.
 
+.. _bundles-required-bundles:
+
+Requiring Other Bundles
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.1
+
+    The ``#[RequiredBundle]`` attribute was introduced in Symfony 8.1.
+
+If your bundle needs one or more other bundles to work (e.g. to reuse their
+services or compiler passes), add the
+:class:`Symfony\\Component\\DependencyInjection\\Kernel\\RequiredBundle`
+attribute to your bundle class to declare each dependency::
+
+    // src/AcmeBlogBundle.php
+    namespace Acme\BlogBundle;
+
+    use Acme\CoreBundle\AcmeCoreBundle;
+    use Acme\MarkdownBundle\AcmeMarkdownBundle;
+    use Symfony\Component\DependencyInjection\Kernel\RequiredBundle;
+    use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+
+    #[RequiredBundle(AcmeCoreBundle::class)]
+    #[RequiredBundle(AcmeMarkdownBundle::class, ignoreOnInvalid: true)]
+    class AcmeBlogBundle extends AbstractBundle
+    {
+    }
+
+When the kernel initializes the bundles, the required bundles are registered
+automatically, right before the bundle that requires them. This way, users of
+your bundle only need to enable your bundle in their ``config/bundles.php``
+file. Required bundles are resolved recursively (a required bundle can itself
+require other bundles) and each bundle is only registered once.
+
+The attribute accepts two arguments:
+
+* ``class``: the bundle class to require;
+* ``ignoreOnInvalid``: if set to ``true``, the dependency is silently skipped
+  when its class does not exist. Use this for optional dependencies that are
+  only loaded when the related package is installed.
+
+Bundles registered this way are enabled in the same environments as the
+bundle that requires them. If the application also registers a required
+bundle explicitly in ``config/bundles.php``, the explicit configuration (and
+its environments) takes precedence.
+
+Symfony itself uses this feature: ``FrameworkBundle`` declares
+``#[RequiredBundle(ServicesBundle::class)]`` and
+``#[RequiredBundle(ConsoleBundle::class, ignoreOnInvalid: true)]``, so its
+console integration is only loaded when the Console component is installed.
+
 .. _bundles-legacy-directory-structure:
 .. _bundles-directory-structure:
 

--- a/components/console.rst
+++ b/components/console.rst
@@ -105,6 +105,78 @@ all existing behavior::
     $application = new Application('my-cli', '1.0', $container);
     $application->run();
 
+Bootstrapping an Application with the ConsoleBundle
+---------------------------------------------------
+
+.. versionadded:: 8.1
+
+    The ``ConsoleBundle`` was introduced in Symfony 8.1.
+
+Registering services and commands by hand works, but the Console component
+also ships a ``ConsoleBundle`` that brings service autodiscovery,
+autoconfiguration and autowiring to console applications, still without
+requiring HttpKernel or FrameworkBundle.
+
+Combined with the kernel infrastructure provided by the DependencyInjection
+component, a DI-enabled console application boils down to a
+``config/bundles.php`` file::
+
+    // config/bundles.php
+    return [
+        Symfony\Component\Console\ConsoleBundle::class => ['all' => true],
+    ];
+
+and a small executable script (this example also uses the
+:doc:`Runtime component </components/runtime>`)::
+
+    #!/usr/bin/env php
+    <?php
+
+    require __DIR__.'/vendor/autoload_runtime.php';
+
+    use Symfony\Component\Console\Application;
+    use Symfony\Component\DependencyInjection\Kernel\AbstractKernel;
+    use Symfony\Component\DependencyInjection\Kernel\KernelTrait;
+
+    return static function (array $context) {
+        $env = $context['APP_ENV'] ?? 'dev';
+        $debug = (bool) ($context['APP_DEBUG'] ?? true);
+
+        $kernel = new class($env, $debug) extends AbstractKernel {
+            use KernelTrait;
+        };
+
+        $kernel->boot();
+
+        return new Application('demo', '1.0', $kernel->getContainer());
+    };
+
+The kernel follows the same conventions as full Symfony applications:
+``config/bundles.php`` to register bundles, ``config/packages/`` for package
+configuration and ``config/services.yaml`` (or ``.php``) to register your own
+services and commands.
+
+The ConsoleBundle provides:
+
+* autoconfiguration for commands: any service extending ``Command`` or using
+  the ``#[AsCommand]`` attribute is registered in the application and loaded
+  lazily through the command loader;
+* the built-in :doc:`argument value resolvers </console/value_resolver>`;
+* an ``event_dispatcher`` service wired to the console events (if the
+  EventDispatcher component is installed);
+* the ``dotenv:debug`` command (if the Dotenv component is installed).
+
+The ConsoleBundle itself declares the ``ServicesBundle`` of the
+DependencyInjection component as a :ref:`required bundle
+<bundles-required-bundles>`. That bundle supplies the core infrastructure
+services (``parameter_bag``, ``event_dispatcher``, ``filesystem``, ``clock``,
+the config cache, etc.), so you don't need to register it explicitly.
+
+.. tip::
+
+    Anything HTTP-related in your app? Use FrameworkBundle. An app that is
+    unrelated to server-side HTTP? The ConsoleBundle might be a fit.
+
 Learn more
 ----------
 


### PR DESCRIPTION
Fix #22223

Documents the feature introduced in symfony/symfony#63880 (merged in 8.1):

* `bundles.rst`: a new "Requiring Other Bundles" section (with a `bundles-required-bundles` anchor) covering the `#[RequiredBundle]` attribute: automatic and recursive registration of required bundles, the `ignoreOnInvalid` argument for optional dependencies, environment inheritance and the precedence of explicit `config/bundles.php` entries, plus the real-world example of FrameworkBundle requiring ServicesBundle and ConsoleBundle.
* `components/console.rst`: a new "Bootstrapping an Application with the ConsoleBundle" section, right after the existing "Using a PSR Container" one. It shows the minimal DI-enabled console application (kernel based on `AbstractKernel` + `KernelTrait`, `config/bundles.php`, Runtime-based executable, adapted from the example in symfony/symfony#63715), lists what the bundle provides, and explains that ServicesBundle is pulled in automatically as a required bundle.

All behavior claims were checked against the merged diff (bundle resolution in `KernelTrait`, `ConsoleBundle`/`ServicesBundle` sources and tests).

Note: this complements #22218, which documents the underlying HTTP-less kernel infrastructure. Both PRs touch different sections (the cross-reference used here points to an anchor added by this PR itself, so there is no merge dependency between them).
