### PR TITLE
[Doctrine] Recommend mapping ENUM to text so it works with DBAL 3 and 4

### DIFF
--- a/doctrine/dbal.rst
+++ b/doctrine/dbal.rst
@@ -117,8 +117,8 @@ The SchemaTool is used to inspect the database to compare the schema. To
 achieve this task, it needs to know which mapping type needs to be used
 for each database type. Registering new ones can be done through the configuration.
 
-Now, map the ENUM type (not supported by DBAL by default) to the ``string``
-mapping type:
+Now, map the ENUM type (not supported by Doctrine DBAL by default) to the
+``text`` mapping type:
 
 .. configuration-block::
 
@@ -128,7 +128,7 @@ mapping type:
         doctrine:
             dbal:
                 mapping_types:
-                    enum: string
+                    enum: text
 
     .. code-block:: xml
 
@@ -143,7 +143,7 @@ mapping type:
 
             <doctrine:config>
                 <doctrine:dbal>
-                    <doctrine:mapping-type name="enum">string</doctrine:mapping-type>
+                    <doctrine:mapping-type name="enum">text</doctrine:mapping-type>
                 </doctrine:dbal>
             </doctrine:config>
         </container>
@@ -156,8 +156,21 @@ mapping type:
         return static function (DoctrineConfig $doctrine): void {
             $dbalDefault = $doctrine->dbal()
                 ->connection('default');
-            $dbalDefault->mappingType('enum', 'string');
+            $dbalDefault->mappingType('enum', 'text');
         };
+
+.. note::
+
+    On Doctrine DBAL 3 you can also map ``enum`` to ``string``, but that no
+    longer works on DBAL 4, where ``string`` columns require an explicit
+    length. Mapping to ``text`` works on both versions.
+
+.. tip::
+
+    Doctrine DBAL 4.2 added native support for the ``ENUM`` type of MySQL
+    and MariaDB. When using DBAL 4.2 or newer, ``ENUM`` columns are
+    introspected natively, so you don't need to register any custom mapping
+    type for them.
 
 .. _`PDO`: https://www.php.net/pdo
 .. _`Doctrine`: https://www.doctrine-project.org/


### PR DESCRIPTION
Fix #22243

The "Registering custom Mapping Types in the SchemaTool" section mapped the `ENUM` database type to the `string` mapping type. That only works with Doctrine DBAL 3: on DBAL 4, `string` columns require an explicit length, so schema introspection produces an invalid `VARCHAR(0)` (and fails outright from DBAL 4.3 on). Since Symfony 6.4 supports both DBAL 3 and 4, the example should work on both.

Following @MrYamous' review, this simplifies the section to recommend mapping `enum` to `text`, which regenerates as `LONGTEXT` on every DBAL version I tested (3.9 through 4.3, MySQL 8.0). A short note mentions that `string` is still fine on DBAL 3, and a tip points to the native `ENUM` support added in DBAL 4.2 (doctrine/dbal#6536), which makes the custom mapping unnecessary there.