### PR TITLE
[Console] Improve information on signal handling followup

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -154,7 +154,7 @@ Listeners receive a
 
     Additionally, the event is dispatched when the command is being exited on
     a signal. You can learn more about signals in the
-    :ref:`the dedicated section <console-events_signal>`.
+    :ref:`the dedicated section <console-signal-handling>`.
 
 .. _console-events_signal:
 
@@ -207,8 +207,7 @@ The ``ConsoleAlarmEvent``
 (e.g. database connection keepalive, extending lock TTLs, heartbeat checks).
 
 When a command calls :method:`Symfony\\Component\\Console\\Application::setAlarmInterval`,
-the application sets a recurring alarm interval, causing the OS to deliver a
-``SIGALRM`` signal at the given interval (in seconds). Each time the signal fires,
+the application sets a recurring alarm interval. Each time the ``SIGALRM`` signal fires,
 a ``ConsoleAlarmEvent`` is dispatched, allowing listeners to run periodic logic::
 
     // src/Command/LongRunningCommand.php
@@ -252,6 +251,9 @@ actions on each alarm::
         public function __invoke(ConsoleAlarmEvent $event): void
         {
             // e.g. ping the database to keep the connection alive
+
+            // keep the command running after handling the alarm
+            $event->abortExit();
         }
     }
 

--- a/console.rst
+++ b/console.rst
@@ -613,6 +613,8 @@ Using Console Events
 When a command is running, many events are dispatched, one of them allows you to
 react to signals, read more in :doc:`this section </components/console/events>`.
 
+.. _console-signal-handling:
+
 Handling Signals
 ----------------
 
@@ -663,6 +665,45 @@ subscribing to one or more signals::
 
 This registers a signal handler for that command only. To run the same handler
 for all commands, use :ref:`events <console-events_signal>` instead.
+
+You can also use :method:`Symfony\\Component\\Console\\Application::setAlarmInterval`
+to trigger a recurring alarm interval, causing the OS to deliver a ``SIGALRM`` signal
+at the given interval (in seconds). Use these signals to perform periodic tasks during
+long-running commands::
+
+    // src/Command/LongRunningCommand.php
+    namespace App\Command;
+
+    use Symfony\Component\Console\Application;
+    use Symfony\Component\Console\Attribute\AsCommand;
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Command\SignalableCommandInterface;
+
+    #[AsCommand(name: 'app:long-running')]
+    class LongRunningCommand implements SignalableCommandInterface
+    {
+        public function __invoke(Application $application): int
+        {
+            // trigger an alarm every 10 seconds
+            $application->setAlarmInterval(10);
+
+            // long-running processing...
+
+            return Command::SUCCESS;
+        }
+
+        public function getSubscribedSignals(): array
+        {
+            return [\SIGALRM];
+        }
+
+        public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+        {
+            // e.g. ping the database to keep the connection alive
+
+            return false;
+        }
+    }
 
 Symfony doesn't handle any signal received by the command (not even ``SIGKILL``,
 ``SIGTERM``, etc). This behavior is intended, as it gives you the flexibility to


### PR DESCRIPTION
A follow-up to #22454.

It makes sense to mention the information about alarms in the new signal handling section as well. This also adds an example showing how to call `setAlarmInterval()` in invokable commands.
