### PR TITLE
[Doctrine] Explain the 127.0.0.1 vs localhost database host choice

### DIFF
--- a/doctrine.rst
+++ b/doctrine.rst
@@ -58,6 +58,14 @@ The database connection information is stored as an environment variable called
     # to use oracle:
     # DATABASE_URL="oci8://db_user:db_password@127.0.0.1:1521/db_name"
 
+.. tip::
+
+    These examples use ``127.0.0.1`` as the host because it behaves consistently
+    across environments (Docker, CI, Windows, etc.). On Unix systems, if the
+    database server runs on the same machine, you can use ``localhost`` instead:
+    most drivers then connect through a local Unix domain socket, which can be
+    slightly faster than a TCP/IP connection.
+
 .. warning::
 
     If the username, password, host or database name contain any character considered


### PR DESCRIPTION
Fix #21918

The `DATABASE_URL` examples use `127.0.0.1`, and #21918 asked why, noting that `localhost` would use a faster Unix domain socket. This adds a short tip documenting the trade-off: `127.0.0.1` is used for consistent behavior across environments (Docker, CI, Windows), while `localhost` on Unix connects through a local socket that can be slightly faster when the database runs on the same machine.

The examples are left unchanged (the portable default); the tip just explains the choice so readers who want the socket path know it is available.
