### PR TITLE
[ExpressionLanguage] Document the count() function

### DIFF
--- a/reference/formats/expression_language.rst
+++ b/reference/formats/expression_language.rst
@@ -156,6 +156,7 @@ following functions by default:
 * ``enum()``
 * ``min()``
 * ``max()``
+* ``count()``
 
 ``constant()`` function
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -236,6 +237,23 @@ PHP function to find the highest value::
     ));
 
 This will print out ``3``.
+
+``count()`` function
+~~~~~~~~~~~~~~~~~~~~
+
+This function will return the number of elements of the given array or
+``Countable`` object. Internally it uses the :phpfunction:`count` PHP
+function::
+
+    var_dump($expressionLanguage->evaluate(
+        'count([1, 2, 3])'
+    ));
+
+This will print out ``3``.
+
+.. versionadded:: 8.2
+
+    The ``count()`` function was introduced in Symfony 8.2.
 
 .. tip::
 


### PR DESCRIPTION
Fix #22463

Documents the native PHP `count()` function added to the ExpressionLanguage component in symfony/symfony#64870 (merged in 8.2).

The new section follows the same structure as the existing `min()` and `max()` sections, and `count()` is also added to the list of default functions.
