### PR TITLE
[Serializer] Use double backslashes in the ExtraAttributesException reference

### DIFF
--- a/serializer.rst
+++ b/serializer.rst
@@ -2123,7 +2123,7 @@ Collecting Extra Attributes Errors While Denormalizing
 
 When ``allow_extra_attributes`` is set to ``false``, denormalizing a payload that
 contains unknown attributes throws an
-:class:`Symfony\Component\Serializer\Exception\ExtraAttributesException` as soon as
+:class:`Symfony\\Component\\Serializer\\Exception\\ExtraAttributesException` as soon as
 the first object with extra attributes is found. If the payload contains nested
 objects, the extra attributes of those nested objects are never reported.
 


### PR DESCRIPTION
The `Lint (DOCtor-RST)` check is currently failing on the `8.1` and `8.2` branches:

```
serializer.rst
2126: Please use 2 backslashes when highlighting a namespace with single backticks: `Symfony\Component\Serializer\Exception\ExtraAttributesException`
```

The single backslashes were introduced in 7f36ca9ce (COLLECT_EXTRA_ATTRIBUTES_ERRORS documentation). This doubles them, which makes the branch lint green again (verified locally with `oskarstark/doctor-rst:1.78.0`).
