### PR TITLE
[Mailer][BrevoMailer] Allow configuring the SMTP port through the DSN

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -168,7 +168,7 @@ party provider:
 |                        | - HTTP n/a                                                                                |
 |                        | - API ``azure+api://ACS_RESOURCE_NAME:KEY@default``                                       |
 +------------------------+-------------------------------------------------------------------------------------------+
-| `Brevo`_               | - SMTP ``brevo+smtp://USERNAME:PASSWORD@default``                                         |
+| `Brevo`_               | - SMTP ``brevo+smtp://USERNAME:PASSWORD@default:PORT``                                         |
 |                        | - HTTP n/a                                                                                |
 |                        | - API ``brevo+api://KEY@default``                                                         |
 +------------------------+-------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This PR documents the new Mailer feature introduced in Symfony 8.2 for Brevo bridge. In the table that shows the full list of available DSN formats for each third party provider I added PORT to the DSN. It is the same as in other DSN format like for Amazon SES.

brevo+smtp://USERNAME:PASSWORD@default:**PORT**

As asked in #22474 
