### PR TITLE
[Frontend] Update Symfony Reprise documentation link

### DIFF
--- a/frontend.rst
+++ b/frontend.rst
@@ -212,6 +212,6 @@ Other Front-End Articles
 .. _`API Platform screencast series`: https://symfonycasts.com/screencast/api-platform
 .. _`CssMinimizerPlugin`: https://webpack.js.org/plugins/css-minimizer-webpack-plugin
 .. _`Symfony Reprise`: https://github.com/symfony/reprise
-.. _`Symfony Reprise documentation`: https://github.com/symfony/reprise/blob/main/doc/index.rst
+.. _`Symfony Reprise documentation`: https://symfony.com/bundles/reprise/current/index.html
 .. _`Vite`: https://vite.dev/
 .. _`Rsbuild`: https://rsbuild.dev/


### PR DESCRIPTION
Since https://symfony.com/bundles/reprise/current/index.html is now accessible, let's update it here. 

Thanks!

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
