### PR TITLE
 Sort Twig reference items alphabetically

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -17,89 +17,63 @@ components with Twig templates. This article explains them all.
 Functions
 ---------
 
-.. _reference-twig-function-render:
+.. _reference-twig-function-absolute-url:
 
-render
-~~~~~~
-
-.. code-block:: twig
-
-    {{ render(uri, options = []) }}
-
-``uri``
-    **type**: ``string`` | ``ControllerReference``
-``options`` *(optional)*
-    **type**: ``array`` **default**: ``[]``
-
-Makes a request to the given internal URI or controller and returns the result.
-The render strategy can be specified in the ``strategy`` key of the options.
-It's commonly used to :ref:`embed controllers in templates <templates-embed-controllers>`.
-
-.. _reference-twig-function-render-esi:
-
-render_esi
-~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ render_esi(uri, options = []) }}
-
-``uri``
-    **type**: ``string`` | ``ControllerReference``
-``options`` *(optional)*
-    **type**: ``array`` **default**: ``[]``
-
-It's similar to the `render`_ function and defines the same arguments. However,
-it generates an ESI tag when :doc:`ESI support </http_cache/esi>` is enabled or
-falls back to the behavior of `render`_ otherwise.
-
-.. tip::
-
-    The ``render_esi()`` function is an example of the shortcut functions
-    of ``render``. It automatically sets the strategy based on what's given
-    in the function name, e.g. ``render_hinclude()`` will use the hinclude.js
-    strategy. This works for all ``render_*()`` functions.
-
-fragment_uri
+absolute_url
 ~~~~~~~~~~~~
 
 .. code-block:: twig
 
-    {{ fragment_uri(controller, absolute = false, strict = true, sign = true) }}
+    {{ absolute_url(path) }}
 
-``controller``
-    **type**: ``ControllerReference``
-``absolute`` *(optional)*
-    **type**: ``boolean`` **default**: ``false``
-``strict`` *(optional)*
-    **type**: ``boolean`` **default**: ``true``
-``sign`` *(optional)*
-    **type**: ``boolean`` **default**: ``true``
-
-Generates the URI of :ref:`a fragment <fragments-path-config>`.
-
-controller
-~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ controller(controller, attributes = [], query = []) }}
-
-``controller``
+``path``
     **type**: ``string``
-``attributes`` *(optional)*
-    **type**: ``array`` **default**: ``[]``
-``query`` *(optional)*
-    **type**: ``array`` **default**: ``[]``
 
-Returns an instance of ``ControllerReference`` to be used with functions
-like :ref:`render() <reference-twig-function-render>` and
-:ref:`render_esi() <reference-twig-function-render-esi>`.
+Returns the absolute URL (with scheme and host) from the passed relative path. Combine it with the
+:ref:`asset() function <reference-twig-function-asset>` to generate absolute URLs
+for web assets. Read more about :ref:`Linking to CSS, JavaScript and Image Assets <templates-link-to-assets>`.
+
+access_decision
+~~~~~~~~~~~~~~~
+
+.. versionadded:: 7.4
+
+    The ``access_decision()`` function was introduced in Symfony 7.4.
 
 .. code-block:: twig
 
-    {{ render(controller('App\\Controller\\BlogController:latest', {max: 3})) }}
-    {# output: the content returned by the controller method; e.g. a rendered Twig template #}
+    {{ access_decision(role, object = null) }}
+
+``role``
+    **type**: ``string``
+``object`` *(optional)*
+    **type**: ``object``
+
+Returns an :class:`Symfony\\Component\\Security\\Core\\Authorization\\AccessDecision`
+object, which tells whether the current user has the given role (``isGranted``) and
+gives the reason of a denial (``message``). More information can be found in
+:ref:`security-template`.
+
+access_decision_for_user
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 7.4
+
+    The ``access_decision_for_user()`` function was introduced in Symfony 7.4.
+
+.. code-block:: twig
+
+    {{ access_decision_for_user(user, attribute, subject = null) }}
+
+``user``
+    **type**: ``object``
+``attribute``
+    **type**: ``string``
+``subject`` *(optional)*
+    **type**: ``object``
+
+Same as ``access_decision()``, but it checks the authorization of the given user
+instead of the current one.
 
 .. _reference-twig-function-asset:
 
@@ -161,6 +135,29 @@ asset_version
 Returns the current version of the package, more information in
 :ref:`templates-link-to-assets`.
 
+controller
+~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ controller(controller, attributes = [], query = []) }}
+
+``controller``
+    **type**: ``string``
+``attributes`` *(optional)*
+    **type**: ``array`` **default**: ``[]``
+``query`` *(optional)*
+    **type**: ``array`` **default**: ``[]``
+
+Returns an instance of ``ControllerReference`` to be used with functions
+like :ref:`render() <reference-twig-function-render>` and
+:ref:`render_esi() <reference-twig-function-render-esi>`.
+
+.. code-block:: twig
+
+    {{ render(controller('App\\Controller\\BlogController:latest', {max: 3})) }}
+    {# output: the content returned by the controller method; e.g. a rendered Twig template #}
+
 .. _reference-twig-function-csrf-token:
 
 csrf_token
@@ -181,6 +178,136 @@ in a regular HTML form not managed by the Symfony Form component.
     {{ csrf_token('my_form') }}
     {# output: a random alphanumeric string like:
        a.YOosAd0fhT7BEuUCFbROzrvgkW8kpEmBDQ_DKRMUi2o.Va8ZQKt5_2qoa7dLW-02_PLYwDBx9nnWOluUHUFCwC5Zo0VuuVfQCqtngg #}
+
+dns_prefetch
+~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ dns_prefetch(uri, attributes = []) }}
+
+``uri``
+    **type**: ``string``
+``attributes`` *(optional)*
+    **type**: ``array`` **default**: ``[]``
+
+Resource hint that indicates an origin (e.g. ``https://foo.cloudfront.net``)
+that will be used to fetch required resources, and that the user agent should
+resolve as early as possible. Read more about :doc:`/web_link`.
+
+expression
+~~~~~~~~~~
+
+Creates an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` related
+to the :doc:`ExpressionLanguage component </components/expression_language>`.
+
+.. code-block:: twig
+
+    {{ expression(1 + 2) }}
+    {# output: 3 #}
+
+Form Related Functions
+~~~~~~~~~~~~~~~~~~~~~~
+
+The following functions related to Symfony Forms are also available. They are
+explained in the article about :doc:`customizing form rendering </form/form_customization>`:
+
+* :ref:`form() <reference-forms-twig-form>`
+* :ref:`form_start() <reference-forms-twig-start>`
+* :ref:`form_end() <reference-forms-twig-end>`
+* :ref:`form_widget() <reference-forms-twig-widget>`
+* :ref:`form_errors() <reference-forms-twig-errors>`
+* :ref:`form_label() <reference-forms-twig-label>`
+* :ref:`form_help() <reference-forms-twig-help>`
+* :ref:`form_row() <reference-forms-twig-row>`
+* :ref:`form_rest() <reference-forms-twig-rest>`
+* :ref:`field_name() <reference-forms-twig-field-helpers>`
+* :ref:`field_id() <reference-forms-twig-field-helpers>`
+* :ref:`field_value() <reference-forms-twig-field-helpers>`
+* :ref:`field_label() <reference-forms-twig-field-helpers>`
+* :ref:`field_help() <reference-forms-twig-field-helpers>`
+* :ref:`field_errors() <reference-forms-twig-field-helpers>`
+* :ref:`field_choices() <reference-forms-twig-field-helpers>`
+
+fragment_uri
+~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ fragment_uri(controller, absolute = false, strict = true, sign = true) }}
+
+``controller``
+    **type**: ``ControllerReference``
+``absolute`` *(optional)*
+    **type**: ``boolean`` **default**: ``false``
+``strict`` *(optional)*
+    **type**: ``boolean`` **default**: ``true``
+``sign`` *(optional)*
+    **type**: ``boolean`` **default**: ``true``
+
+Generates the URI of :ref:`a fragment <fragments-path-config>`.
+
+impersonation_exit_path
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ impersonation_exit_path(exitTo = null) }}
+
+``exitTo`` *(optional)*
+    **type**: ``string``
+
+Generates a URL that you can visit to exit :doc:`user impersonation </security/impersonating_user>`.
+After exiting impersonation, the user is redirected to the current URI. If you
+prefer to redirect to a different URI, define its value in the ``exitTo`` argument.
+
+If no user is being impersonated, the function returns an empty string.
+
+impersonation_exit_url
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ impersonation_exit_url(exitTo = null) }}
+
+``exitTo`` *(optional)*
+    **type**: ``string``
+
+It's similar to the `impersonation_exit_path`_ function, but it generates
+absolute URLs instead of relative URLs.
+
+impersonation_path
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ impersonation_path(identifier) }}
+
+``identifier``
+    **type**: ``string``
+
+Generates a URL that you can visit to
+:doc:`impersonate a user </security/impersonating_user>`, identified by the
+``identifier`` argument.
+
+impersonation_url
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ impersonation_url(identifier) }}
+
+``identifier``
+    **type**: ``string``
+
+It's similar to the `impersonation_path`_ function, but it generates
+absolute URLs instead of relative URLs.
+
+importmap
+~~~~~~~~~
+
+Outputs the ``importmap`` & a few other items when using
+:doc:`the Asset component </frontend/asset_mapper>`.
 
 is_granted
 ~~~~~~~~~~
@@ -222,47 +349,23 @@ Returns ``true`` if the user is authorized for the specified attribute.
 Optionally, an object can be passed to be used by the voter. More information
 can be found in :ref:`security-template`.
 
-access_decision
-~~~~~~~~~~~~~~~
-
-.. versionadded:: 7.4
-
-    The ``access_decision()`` function was introduced in Symfony 7.4.
+link
+~~~~
 
 .. code-block:: twig
 
-    {{ access_decision(role, object = null) }}
+    {{ link(uri, rel, attributes = []) }}
 
-``role``
+``uri``
     **type**: ``string``
-``object`` *(optional)*
-    **type**: ``object``
-
-Returns an :class:`Symfony\\Component\\Security\\Core\\Authorization\\AccessDecision`
-object, which tells whether the current user has the given role (``isGranted``) and
-gives the reason of a denial (``message``). More information can be found in
-:ref:`security-template`.
-
-access_decision_for_user
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 7.4
-
-    The ``access_decision_for_user()`` function was introduced in Symfony 7.4.
-
-.. code-block:: twig
-
-    {{ access_decision_for_user(user, attribute, subject = null) }}
-
-``user``
-    **type**: ``object``
-``attribute``
+``rel``
     **type**: ``string``
-``subject`` *(optional)*
-    **type**: ``object``
+``attributes`` *(optional)*
+    **type**: ``array`` **default**: ``[]``
 
-Same as ``access_decision()``, but it checks the authorization of the given user
-instead of the current one.
+Adds a ``Link`` HTTP header to the current response for the given link relation
+type (``rel``). It can be used for any link implementing the PSR-13 standard.
+Read more about :doc:`/web_link`.
 
 logout_path
 ~~~~~~~~~~~
@@ -370,53 +473,74 @@ If ``relative`` is enabled, it'll create a path relative to the current path.
     Read more about :doc:`Symfony routing </routing>` and about
     :ref:`creating links in Twig templates <templates-link-to-pages>`.
 
-url
-~~~
+preconnect
+~~~~~~~~~~
 
 .. code-block:: twig
 
-    {{ url(route_name, route_parameters = [], schemeRelative = false) }}
+    {{ preconnect(uri, attributes = []) }}
 
-``name``
+``uri``
     **type**: ``string``
-``parameters`` *(optional)*
+``attributes`` *(optional)*
     **type**: ``array`` **default**: ``[]``
-``schemeRelative`` *(optional)*
-    **type**: ``boolean`` **default**: ``false``
 
-Returns the absolute URL (with scheme and host) for the given route. If
-``schemeRelative`` is enabled, it'll create a scheme-relative URL.
+Resource hint that indicates an origin (e.g.
+``https://www.google-analytics.com``) that will be used to fetch required
+resources, initiating an early connection (DNS lookup, TCP handshake and
+optional TLS negotiation) to mask the high latency costs of establishing a
+connection. Read more about :doc:`/web_link`.
 
-.. code-block:: twig
-
-    {# consider that the app defines an 'app_blog' route with the path '/blog/{page}' #}
-
-    {{ url(name = 'app_blog', parameters = {page: 3}, schemeRelative = false) }}
-    {# output: http://example.org/blog/3 #}
-
-    {{ url(name = 'app_blog', parameters = {page: 3}, schemeRelative = true) }}
-    {# output: //example.org/blog/3 #}
-
-.. seealso::
-
-    Read more about :doc:`Symfony routing </routing>` and about
-    :ref:`creating links in Twig templates <templates-link-to-pages>`.
-
-.. _reference-twig-function-absolute-url:
-
-absolute_url
-~~~~~~~~~~~~
+prefetch
+~~~~~~~~
 
 .. code-block:: twig
 
-    {{ absolute_url(path) }}
+    {{ prefetch(uri, attributes = []) }}
 
-``path``
+``uri``
     **type**: ``string``
+``attributes`` *(optional)*
+    **type**: ``array`` **default**: ``[]``
 
-Returns the absolute URL (with scheme and host) from the passed relative path. Combine it with the
-:ref:`asset() function <reference-twig-function-asset>` to generate absolute URLs
-for web assets. Read more about :ref:`Linking to CSS, JavaScript and Image Assets <templates-link-to-assets>`.
+Resource hint that identifies a resource that might be required by the next
+navigation, and that the user agent should fetch so it can deliver a faster
+response once the resource is requested in the future. Read more about
+:doc:`/web_link`.
+
+preload
+~~~~~~~
+
+.. code-block:: twig
+
+    {{ preload(uri, attributes = []) }}
+
+``uri``
+    **type**: ``string``
+``attributes`` *(optional)*
+    **type**: ``array`` **default**: ``[]``
+
+Preloads a resource by adding a ``Link`` HTTP header with the ``preload`` link
+relation, telling the browser to download it as soon as possible. Read more
+about :doc:`/web_link`.
+
+prerender
+~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ prerender(uri, attributes = []) }}
+
+``uri``
+    **type**: ``string``
+``attributes`` *(optional)*
+    **type**: ``array`` **default**: ``[]``
+
+Resource hint that identifies a resource that might be required by the next
+navigation, and that the user agent should fetch and execute so it can deliver
+a faster response once the resource is requested later. This hint is
+**deprecated** and superseded by the Speculation Rules API. Read more about
+:doc:`/web_link`.
 
 .. _reference-twig-function-relative-path:
 
@@ -442,72 +566,48 @@ you're on the following page in your app:
     {{ relative_path('http://example.com/products/products_icon.png') }}
     {# products_icon.png #}
 
-expression
+.. _reference-twig-function-render:
+
+render
+~~~~~~
+
+.. code-block:: twig
+
+    {{ render(uri, options = []) }}
+
+``uri``
+    **type**: ``string`` | ``ControllerReference``
+``options`` *(optional)*
+    **type**: ``array`` **default**: ``[]``
+
+Makes a request to the given internal URI or controller and returns the result.
+The render strategy can be specified in the ``strategy`` key of the options.
+It's commonly used to :ref:`embed controllers in templates <templates-embed-controllers>`.
+
+.. _reference-twig-function-render-esi:
+
+render_esi
 ~~~~~~~~~~
 
-Creates an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` related
-to the :doc:`ExpressionLanguage component </components/expression_language>`.
-
 .. code-block:: twig
 
-    {{ expression(1 + 2) }}
-    {# output: 3 #}
+    {{ render_esi(uri, options = []) }}
 
-impersonation_path
-~~~~~~~~~~~~~~~~~~
+``uri``
+    **type**: ``string`` | ``ControllerReference``
+``options`` *(optional)*
+    **type**: ``array`` **default**: ``[]``
 
-.. code-block:: twig
+It's similar to the `render`_ function and defines the same arguments. However,
+it generates an ESI tag when :doc:`ESI support </http_cache/esi>` is enabled or
+falls back to the behavior of `render`_ otherwise.
 
-    {{ impersonation_path(identifier) }}
+.. tip::
 
-``identifier``
-    **type**: ``string``
-
-Generates a URL that you can visit to
-:doc:`impersonate a user </security/impersonating_user>`, identified by the
-``identifier`` argument.
-
-impersonation_url
-~~~~~~~~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ impersonation_url(identifier) }}
-
-``identifier``
-    **type**: ``string``
-
-It's similar to the `impersonation_path`_ function, but it generates
-absolute URLs instead of relative URLs.
-
-impersonation_exit_path
-~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ impersonation_exit_path(exitTo = null) }}
-
-``exitTo`` *(optional)*
-    **type**: ``string``
-
-Generates a URL that you can visit to exit :doc:`user impersonation </security/impersonating_user>`.
-After exiting impersonation, the user is redirected to the current URI. If you
-prefer to redirect to a different URI, define its value in the ``exitTo`` argument.
-
-If no user is being impersonated, the function returns an empty string.
-
-impersonation_exit_url
-~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ impersonation_exit_url(exitTo = null) }}
-
-``exitTo`` *(optional)*
-    **type**: ``string``
-
-It's similar to the `impersonation_exit_path`_ function, but it generates
-absolute URLs instead of relative URLs.
+    The ``render_esi()`` function is an example of the shortcut functions
+    of ``render``. It automatically sets the strategy based on what's given
+    in the function name, e.g. ``render_hinclude()`` will use the hinclude.js
+    strategy. This works for all ``render_*()`` functions.
 
 .. _reference-twig-function-t:
 
@@ -564,142 +664,280 @@ Using the filter will be rendered as:
     {{ t(message = 'message', parameters = {'%name%': 'John'}, domain = 'blog')|trans }}
     {# output: Hello John #}
 
-importmap
-~~~~~~~~~
-
-Outputs the ``importmap`` & a few other items when using
-:doc:`the Asset component </frontend/asset_mapper>`.
-
-link
-~~~~
+url
+~~~
 
 .. code-block:: twig
 
-    {{ link(uri, rel, attributes = []) }}
+    {{ url(route_name, route_parameters = [], schemeRelative = false) }}
 
-``uri``
+``name``
     **type**: ``string``
-``rel``
-    **type**: ``string``
-``attributes`` *(optional)*
+``parameters`` *(optional)*
     **type**: ``array`` **default**: ``[]``
+``schemeRelative`` *(optional)*
+    **type**: ``boolean`` **default**: ``false``
 
-Adds a ``Link`` HTTP header to the current response for the given link relation
-type (``rel``). It can be used for any link implementing the PSR-13 standard.
-Read more about :doc:`/web_link`.
-
-preload
-~~~~~~~
+Returns the absolute URL (with scheme and host) for the given route. If
+``schemeRelative`` is enabled, it'll create a scheme-relative URL.
 
 .. code-block:: twig
 
-    {{ preload(uri, attributes = []) }}
+    {# consider that the app defines an 'app_blog' route with the path '/blog/{page}' #}
 
-``uri``
-    **type**: ``string``
-``attributes`` *(optional)*
-    **type**: ``array`` **default**: ``[]``
+    {{ url(name = 'app_blog', parameters = {page: 3}, schemeRelative = false) }}
+    {# output: http://example.org/blog/3 #}
 
-Preloads a resource by adding a ``Link`` HTTP header with the ``preload`` link
-relation, telling the browser to download it as soon as possible. Read more
-about :doc:`/web_link`.
+    {{ url(name = 'app_blog', parameters = {page: 3}, schemeRelative = true) }}
+    {# output: //example.org/blog/3 #}
 
-dns_prefetch
-~~~~~~~~~~~~
+.. seealso::
 
-.. code-block:: twig
-
-    {{ dns_prefetch(uri, attributes = []) }}
-
-``uri``
-    **type**: ``string``
-``attributes`` *(optional)*
-    **type**: ``array`` **default**: ``[]``
-
-Resource hint that indicates an origin (e.g. ``https://foo.cloudfront.net``)
-that will be used to fetch required resources, and that the user agent should
-resolve as early as possible. Read more about :doc:`/web_link`.
-
-preconnect
-~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ preconnect(uri, attributes = []) }}
-
-``uri``
-    **type**: ``string``
-``attributes`` *(optional)*
-    **type**: ``array`` **default**: ``[]``
-
-Resource hint that indicates an origin (e.g.
-``https://www.google-analytics.com``) that will be used to fetch required
-resources, initiating an early connection (DNS lookup, TCP handshake and
-optional TLS negotiation) to mask the high latency costs of establishing a
-connection. Read more about :doc:`/web_link`.
-
-prefetch
-~~~~~~~~
-
-.. code-block:: twig
-
-    {{ prefetch(uri, attributes = []) }}
-
-``uri``
-    **type**: ``string``
-``attributes`` *(optional)*
-    **type**: ``array`` **default**: ``[]``
-
-Resource hint that identifies a resource that might be required by the next
-navigation, and that the user agent should fetch so it can deliver a faster
-response once the resource is requested in the future. Read more about
-:doc:`/web_link`.
-
-prerender
-~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ prerender(uri, attributes = []) }}
-
-``uri``
-    **type**: ``string``
-``attributes`` *(optional)*
-    **type**: ``array`` **default**: ``[]``
-
-Resource hint that identifies a resource that might be required by the next
-navigation, and that the user agent should fetch and execute so it can deliver
-a faster response once the resource is requested later. This hint is
-**deprecated** and superseded by the Speculation Rules API. Read more about
-:doc:`/web_link`.
-
-Form Related Functions
-~~~~~~~~~~~~~~~~~~~~~~
-
-The following functions related to Symfony Forms are also available. They are
-explained in the article about :doc:`customizing form rendering </form/form_customization>`:
-
-* :ref:`form() <reference-forms-twig-form>`
-* :ref:`form_start() <reference-forms-twig-start>`
-* :ref:`form_end() <reference-forms-twig-end>`
-* :ref:`form_widget() <reference-forms-twig-widget>`
-* :ref:`form_errors() <reference-forms-twig-errors>`
-* :ref:`form_label() <reference-forms-twig-label>`
-* :ref:`form_help() <reference-forms-twig-help>`
-* :ref:`form_row() <reference-forms-twig-row>`
-* :ref:`form_rest() <reference-forms-twig-rest>`
-* :ref:`field_name() <reference-forms-twig-field-helpers>`
-* :ref:`field_id() <reference-forms-twig-field-helpers>`
-* :ref:`field_value() <reference-forms-twig-field-helpers>`
-* :ref:`field_label() <reference-forms-twig-field-helpers>`
-* :ref:`field_help() <reference-forms-twig-field-helpers>`
-* :ref:`field_errors() <reference-forms-twig-field-helpers>`
-* :ref:`field_choices() <reference-forms-twig-field-helpers>`
+    Read more about :doc:`Symfony routing </routing>` and about
+    :ref:`creating links in Twig templates <templates-link-to-pages>`.
 
 .. _reference-twig-filters:
 
 Filters
 -------
+
+abbr_class
+~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ class|abbr_class }}
+
+``class``
+    **type**: ``string``
+
+Generates an ``<abbr>`` element with the short name of a PHP class (the
+FQCN will be shown in a tooltip when a user hovers over the element).
+
+.. code-block:: twig
+
+    {{ 'App\\Entity\\Product'|abbr_class }}
+
+The above example will be rendered as:
+
+.. code-block:: html
+
+    <abbr title="App\Entity\Product">Product</abbr>
+
+abbr_method
+~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ method|abbr_method }}
+
+``method``
+    **type**: ``string``
+
+Generates an ``<abbr>`` element using the ``FQCN::method()`` syntax. If
+``method`` is ``Closure``, ``Closure`` will be used instead and if ``method``
+doesn't have a class name, it's shown as a function (``method()``).
+
+.. code-block:: twig
+
+    {{ 'App\\Controller\\ProductController::list'|abbr_method }}
+
+The above example will be rendered as:
+
+.. code-block:: html
+
+    <abbr title="App\Controller\ProductController">ProductController</abbr>::list()
+
+.. _reference-twig-filter-emojify:
+
+emojify
+~~~~~~~
+
+.. versionadded:: 7.1
+
+    The ``emojify`` filter was introduced in Symfony 7.1.
+
+.. code-block:: twig
+
+    {{ text|emojify(catalog = null) }}
+
+``text``
+    **type**: ``string``
+
+``catalog`` *(optional)*
+    **type**: ``string`` | ``null``
+
+    The emoji set used to generate the textual representation (``slack``,
+    ``github``, ``gitlab``, etc.)
+
+It transforms the textual representation of an emoji (e.g. ``:wave:``) into the
+actual emoji (👋):
+
+.. code-block:: twig
+
+    {{ ':+1:'|emojify }}                 {# renders: 👍 #}
+    {{ ':+1:'|emojify('github') }}       {# renders: 👍 #}
+    {{ ':thumbsup:'|emojify('gitlab') }} {# renders: 👍 #}
+
+file_excerpt
+~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ file|file_excerpt(line, srcContext = 3) }}
+
+``file``
+    **type**: ``string``
+``line``
+    **type**: ``integer``
+``srcContext`` *(optional)*
+    **type**: ``integer``
+
+Generates an excerpt of a code file around the given ``line`` number. The
+``srcContext`` argument defines the total number of lines to display around the
+given line number (use ``-1`` to display the whole file).
+
+Consider the following as the content of ``file.txt``:
+
+.. code-block:: text
+
+    a
+    b
+    c
+    d
+    e
+
+.. code-block:: html+twig
+
+    {{ '/path/to/file.txt'|file_excerpt(line = 4, srcContext = 1) }}
+    {# output: #}
+    <ol start="3">
+        <li><a class="anchor" id="line3"></a><code>c</code></li>
+        <li class="selected"><a class="anchor" id="line4"></a><code>d</code></li>
+        <li><a class="anchor" id="line5"></a><code>e</code></li>
+    </ol>
+
+    {{ '/path/to/file.txt'|file_excerpt(line = 1, srcContext = 0) }}
+    {# output: #}
+    <ol start="1">
+        <li class="selected"><a class="anchor" id="line1"></a><code>a</code></li>
+    </ol>
+
+file_link
+~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ file|file_link(line) }}
+
+``file``
+    **type**: ``string``
+``line``
+    **type**: ``integer``
+
+Generates a link to the provided file and line number using
+a preconfigured scheme.
+
+.. code-block:: twig
+
+    {{ 'path/to/file/file.txt'|file_link(line = 3) }}
+    {# output: file://path/to/file/file.txt#L3 #}
+
+file_relative
+~~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ file|file_relative }}
+
+``file``
+    **type**: ``string``
+
+It transforms the given absolute file path into a new file path relative to
+project's root directory:
+
+.. code-block:: twig
+
+    {{ '/var/www/blog/templates/admin/index.html.twig'|file_relative }}
+    {# if project root dir is '/var/www/blog/', it returns 'templates/admin/index.html.twig' #}
+
+If the given file path is out of the project directory, a ``null`` value
+will be returned.
+
+format_args
+~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ args|format_args }}
+
+``args``
+    **type**: ``array``
+
+Generates a string with the arguments and their types (within ``<em>`` elements).
+
+format_args_as_text
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ args|format_args_as_text }}
+
+``args``
+    **type**: ``array``
+
+Equal to the `format_args`_ filter, but without using HTML tags.
+
+format_file
+~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ file|format_file(line, text = null) }}
+
+``file``
+    **type**: ``string``
+``line``
+    **type**: ``integer``
+``text`` *(optional)*
+    **type**: ``string`` **default**: ``null``
+
+Generates the file path inside an ``<a>`` element. If the path is inside
+the kernel root directory, the kernel root directory path is replaced by
+``kernel.project_dir`` (showing the full path in a tooltip on hover).
+
+.. code-block:: html+twig
+
+    {{ '/path/to/file.txt'|format_file(line = 1, text = "my_text") }}
+    {# output: #}
+    <a href="/path/to/file.txt#L1"
+        title="Click to open this file" class="file_link">my_text at line 1
+    </a>
+
+    {{ "/path/to/file.txt"|format_file(line = 3) }}
+    {# output: #}
+    <a href="/path/to/file.txt&amp;line=3"
+        title="Click to open this file" class="file_link">/path/to/file.txt at line 3
+    </a>
+
+.. tip::
+
+    If you set the :ref:`framework.ide <reference-framework-ide>` option, the
+    generated links will change to open the file in that IDE/editor. For example,
+    when using PhpStorm, the ``<a href="/path/to/file.txt&amp;line=3"`` link will
+    become ``<a href="phpstorm://open?file=/path/to/file.txt&amp;line=3"``.
+
+format_file_from_text
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ text|format_file_from_text }}
+
+``text``
+    **type**: ``string``
+
+Uses `format_file`_ to improve the output of default PHP errors.
 
 .. _reference-twig-humanize-filter:
 
@@ -798,60 +1036,41 @@ sanitize_html
 Sanitizes the text using the HTML Sanitizer component. More information in
 :ref:`HTML Sanitizer <html-sanitizer-twig>`.
 
-yaml_encode
-~~~~~~~~~~~
+.. _reference-twig-filter-serialize:
+
+serialize
+~~~~~~~~~
 
 .. code-block:: twig
 
-    {{ input|yaml_encode(inline = 0, dumpObjects = false) }}
+    {{ object|serialize(format = 'json', context = []) }}
 
-``input``
+``object``
     **type**: ``mixed``
-``inline`` *(optional)*
-    **type**: ``integer`` **default**: ``0``
-``dumpObjects`` *(optional)*
-    **type**: ``boolean`` **default**: ``false``
 
-Transforms the input into YAML syntax.
+``format`` *(optional)*
+    **type**: ``string``
 
-The ``inline`` argument is the level where the generated output switches to inline YAML:
+``context`` *(optional)*
+    **type**: ``array``
 
-.. code-block:: twig
+Accepts any data that can be serialized by the :doc:`Serializer component </serializer>`
+and returns a serialized string in the specified ``format``.
 
-    {% set array = {
-        'a': {
-            'c': 'e'
-        },
-        'b': {
-            'd': 'f'
-        }
-    } %}
+For example::
 
-    {{ array|yaml_encode(inline = 0) }}
-    {# output:
-       { a: { c: e }, b: { d: f } } #}
-
-    {{ array|yaml_encode(inline = 1) }}
-    {# output:
-       a: { c: e }
-       b: { d: f } #}
-
-The ``dumpObjects`` argument enables the dumping of PHP objects::
-
-    // ...
     $object = new \stdClass();
     $object->foo = 'bar';
-    // ...
+    $object->content = [];
+    $object->createdAt = new \DateTime('2024-11-30');
 
 .. code-block:: twig
 
-    {{ object|yaml_encode(dumpObjects = false) }}
-    {# output: null #}
-
-    {{ object|yaml_encode(dumpObjects = true) }}
-    {# output: !php/object 'O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}' #}
-
-See :ref:`components-yaml-dump` for more information.
+    {{ object|serialize(format = 'json', context = {
+        'datetime_format': 'D, Y-m-d',
+        'empty_array_as_object': true,
+    }) }}
+    {# output: {"foo":"bar","content":{},"createdAt":"Sat, 2024-11-30"} #}
 
 yaml_dump
 ~~~~~~~~~
@@ -907,279 +1126,60 @@ The ``dumpObjects`` argument enables the dumping of PHP objects::
     {{ object|yaml_dump(dumpObjects = true) }}
     {# output: %object% !php/object 'O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}' #}
 
-abbr_class
-~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ class|abbr_class }}
-
-``class``
-    **type**: ``string``
-
-Generates an ``<abbr>`` element with the short name of a PHP class (the
-FQCN will be shown in a tooltip when a user hovers over the element).
-
-.. code-block:: twig
-
-    {{ 'App\\Entity\\Product'|abbr_class }}
-
-The above example will be rendered as:
-
-.. code-block:: html
-
-    <abbr title="App\Entity\Product">Product</abbr>
-
-abbr_method
+yaml_encode
 ~~~~~~~~~~~
 
 .. code-block:: twig
 
-    {{ method|abbr_method }}
+    {{ input|yaml_encode(inline = 0, dumpObjects = false) }}
 
-``method``
-    **type**: ``string``
-
-Generates an ``<abbr>`` element using the ``FQCN::method()`` syntax. If
-``method`` is ``Closure``, ``Closure`` will be used instead and if ``method``
-doesn't have a class name, it's shown as a function (``method()``).
-
-.. code-block:: twig
-
-    {{ 'App\\Controller\\ProductController::list'|abbr_method }}
-
-The above example will be rendered as:
-
-.. code-block:: html
-
-    <abbr title="App\Controller\ProductController">ProductController</abbr>::list()
-
-format_args
-~~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ args|format_args }}
-
-``args``
-    **type**: ``array``
-
-Generates a string with the arguments and their types (within ``<em>`` elements).
-
-format_args_as_text
-~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ args|format_args_as_text }}
-
-``args``
-    **type**: ``array``
-
-Equal to the `format_args`_ filter, but without using HTML tags.
-
-file_excerpt
-~~~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ file|file_excerpt(line, srcContext = 3) }}
-
-``file``
-    **type**: ``string``
-``line``
-    **type**: ``integer``
-``srcContext`` *(optional)*
-    **type**: ``integer``
-
-Generates an excerpt of a code file around the given ``line`` number. The
-``srcContext`` argument defines the total number of lines to display around the
-given line number (use ``-1`` to display the whole file).
-
-Consider the following as the content of ``file.txt``:
-
-.. code-block:: text
-
-    a
-    b
-    c
-    d
-    e
-
-.. code-block:: html+twig
-
-    {{ '/path/to/file.txt'|file_excerpt(line = 4, srcContext = 1) }}
-    {# output: #}
-    <ol start="3">
-        <li><a class="anchor" id="line3"></a><code>c</code></li>
-        <li class="selected"><a class="anchor" id="line4"></a><code>d</code></li>
-        <li><a class="anchor" id="line5"></a><code>e</code></li>
-    </ol>
-
-    {{ '/path/to/file.txt'|file_excerpt(line = 1, srcContext = 0) }}
-    {# output: #}
-    <ol start="1">
-        <li class="selected"><a class="anchor" id="line1"></a><code>a</code></li>
-    </ol>
-
-format_file
-~~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ file|format_file(line, text = null) }}
-
-``file``
-    **type**: ``string``
-``line``
-    **type**: ``integer``
-``text`` *(optional)*
-    **type**: ``string`` **default**: ``null``
-
-Generates the file path inside an ``<a>`` element. If the path is inside
-the kernel root directory, the kernel root directory path is replaced by
-``kernel.project_dir`` (showing the full path in a tooltip on hover).
-
-.. code-block:: html+twig
-
-    {{ '/path/to/file.txt'|format_file(line = 1, text = "my_text") }}
-    {# output: #}
-    <a href="/path/to/file.txt#L1"
-        title="Click to open this file" class="file_link">my_text at line 1
-    </a>
-
-    {{ "/path/to/file.txt"|format_file(line = 3) }}
-    {# output: #}
-    <a href="/path/to/file.txt&amp;line=3"
-        title="Click to open this file" class="file_link">/path/to/file.txt at line 3
-    </a>
-
-.. tip::
-
-    If you set the :ref:`framework.ide <reference-framework-ide>` option, the
-    generated links will change to open the file in that IDE/editor. For example,
-    when using PhpStorm, the ``<a href="/path/to/file.txt&amp;line=3"`` link will
-    become ``<a href="phpstorm://open?file=/path/to/file.txt&amp;line=3"``.
-
-format_file_from_text
-~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ text|format_file_from_text }}
-
-``text``
-    **type**: ``string``
-
-Uses `format_file`_ to improve the output of default PHP errors.
-
-file_link
-~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ file|file_link(line) }}
-
-``file``
-    **type**: ``string``
-``line``
-    **type**: ``integer``
-
-Generates a link to the provided file and line number using
-a preconfigured scheme.
-
-.. code-block:: twig
-
-    {{ 'path/to/file/file.txt'|file_link(line = 3) }}
-    {# output: file://path/to/file/file.txt#L3 #}
-
-file_relative
-~~~~~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ file|file_relative }}
-
-``file``
-    **type**: ``string``
-
-It transforms the given absolute file path into a new file path relative to
-project's root directory:
-
-.. code-block:: twig
-
-    {{ '/var/www/blog/templates/admin/index.html.twig'|file_relative }}
-    {# if project root dir is '/var/www/blog/', it returns 'templates/admin/index.html.twig' #}
-
-If the given file path is out of the project directory, a ``null`` value
-will be returned.
-
-.. _reference-twig-filter-serialize:
-
-serialize
-~~~~~~~~~
-
-.. code-block:: twig
-
-    {{ object|serialize(format = 'json', context = []) }}
-
-``object``
+``input``
     **type**: ``mixed``
+``inline`` *(optional)*
+    **type**: ``integer`` **default**: ``0``
+``dumpObjects`` *(optional)*
+    **type**: ``boolean`` **default**: ``false``
 
-``format`` *(optional)*
-    **type**: ``string``
+Transforms the input into YAML syntax.
 
-``context`` *(optional)*
-    **type**: ``array``
+The ``inline`` argument is the level where the generated output switches to inline YAML:
 
-Accepts any data that can be serialized by the :doc:`Serializer component </serializer>`
-and returns a serialized string in the specified ``format``.
+.. code-block:: twig
 
-For example::
+    {% set array = {
+        'a': {
+            'c': 'e'
+        },
+        'b': {
+            'd': 'f'
+        }
+    } %}
 
+    {{ array|yaml_encode(inline = 0) }}
+    {# output:
+       { a: { c: e }, b: { d: f } } #}
+
+    {{ array|yaml_encode(inline = 1) }}
+    {# output:
+       a: { c: e }
+       b: { d: f } #}
+
+The ``dumpObjects`` argument enables the dumping of PHP objects::
+
+    // ...
     $object = new \stdClass();
     $object->foo = 'bar';
-    $object->content = [];
-    $object->createdAt = new \DateTime('2024-11-30');
+    // ...
 
 .. code-block:: twig
 
-    {{ object|serialize(format = 'json', context = {
-        'datetime_format': 'D, Y-m-d',
-        'empty_array_as_object': true,
-    }) }}
-    {# output: {"foo":"bar","content":{},"createdAt":"Sat, 2024-11-30"} #}
+    {{ object|yaml_encode(dumpObjects = false) }}
+    {# output: null #}
 
-.. _reference-twig-filter-emojify:
+    {{ object|yaml_encode(dumpObjects = true) }}
+    {# output: !php/object 'O:8:"stdClass":1:{s:5:"foo";s:7:"bar";}' #}
 
-emojify
-~~~~~~~
-
-.. versionadded:: 7.1
-
-    The ``emojify`` filter was introduced in Symfony 7.1.
-
-.. code-block:: twig
-
-    {{ text|emojify(catalog = null) }}
-
-``text``
-    **type**: ``string``
-
-``catalog`` *(optional)*
-    **type**: ``string`` | ``null``
-
-    The emoji set used to generate the textual representation (``slack``,
-    ``github``, ``gitlab``, etc.)
-
-It transforms the textual representation of an emoji (e.g. ``:wave:``) into the
-actual emoji (👋):
-
-.. code-block:: twig
-
-    {{ ':+1:'|emojify }}                 {# renders: 👍 #}
-    {{ ':+1:'|emojify('github') }}       {# renders: 👍 #}
-    {{ ':thumbsup:'|emojify('gitlab') }} {# renders: 👍 #}
+See :ref:`components-yaml-dump` for more information.
 
 .. _reference-twig-tags:
 
@@ -1203,6 +1203,18 @@ form_theme
 Sets the resources to override the form theme for the given form view instance.
 You can use ``_self`` as resources to set it to the current resource. More
 information in :doc:`/form/form_customization`.
+
+.. _reference-twig-tag-stopwatch:
+
+stopwatch
+~~~~~~~~~
+
+.. code-block:: twig
+
+    {% stopwatch 'event_name' %}...{% endstopwatch %}
+
+This measures the time and memory used to execute some code in the template and
+displays it in the Symfony profiler. See :ref:`how to profile Symfony applications <profiling-applications>`.
 
 trans
 ~~~~~
@@ -1231,18 +1243,6 @@ trans_default_domain
     **type**: ``string``
 
 This will set the default domain in the current template.
-
-.. _reference-twig-tag-stopwatch:
-
-stopwatch
-~~~~~~~~~
-
-.. code-block:: twig
-
-    {% stopwatch 'event_name' %}...{% endstopwatch %}
-
-This measures the time and memory used to execute some code in the template and
-displays it in the Symfony profiler. See :ref:`how to profile Symfony applications <profiling-applications>`.
 
 .. _reference-twig-tests:
 


### PR DESCRIPTION
After merging #22452, I realized that the contents of this reference are not sorted alphabetically, which complicates scanning the contents on the page or the sidebar menu.