### PR TITLE
[Mime] Document binary content transfer encoding

### DIFF
--- a/components/mime.rst
+++ b/components/mime.rst
@@ -187,6 +187,20 @@ email multiparts::
 
     $email = new Message($headers, $messageParts);
 
+You can choose the content transfer encoding used by ``TextPart`` and
+``DataPart``. Use ``binary`` when the message part must be sent with its bytes
+unchanged::
+
+    use Symfony\Component\Mime\Part\DataPart;
+    use Symfony\Component\Mime\Part\TextPart;
+
+    $textContent = new TextPart($rawText, null, 'plain', 'binary');
+    $attachedFile = new DataPart($rawBytes, 'report.bin', 'application/octet-stream', 'binary');
+
+.. versionadded:: 8.2
+
+    The ``binary`` content transfer encoding was introduced in Symfony 8.2.
+
 Serializing Email Messages
 --------------------------
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -36,10 +36,6 @@ for web assets. Read more about :ref:`Linking to CSS, JavaScript and Image Asset
 access_decision
 ~~~~~~~~~~~~~~~
 
-.. versionadded:: 7.4
-
-    The ``access_decision()`` function was introduced in Symfony 7.4.
-
 .. code-block:: twig
 
     {{ access_decision(role, object = null) }}
@@ -56,10 +52,6 @@ gives the reason of a denial (``message``). More information can be found in
 
 access_decision_for_user
 ~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 7.4
-
-    The ``access_decision_for_user()`` function was introduced in Symfony 7.4.
 
 .. code-block:: twig
 


### PR DESCRIPTION
Fixes #22496.

This documents the `binary` content transfer encoding introduced by symfony/symfony#64066 for low-level MIME message parts.