### PR TITLE
 Document Telegram inline keyboard rows

### DIFF
--- a/notifier.rst
+++ b/notifier.rst
@@ -372,6 +372,11 @@ Service
     The ``sslmode`` DSN option for the Telegram bridge was introduced in
     Symfony 8.1.
 
+.. versionadded:: 8.2
+
+    The Telegram ``InlineKeyboardMarkup::inlineKeyboard()`` method can receive
+    multiple rows of inline keyboard buttons.
+
 .. warning::
 
     By default, if you have the :doc:`Messenger component </messenger>` installed,

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -36,10 +36,6 @@ for web assets. Read more about :ref:`Linking to CSS, JavaScript and Image Asset
 access_decision
 ~~~~~~~~~~~~~~~
 
-.. versionadded:: 7.4
-
-    The ``access_decision()`` function was introduced in Symfony 7.4.
-
 .. code-block:: twig
 
     {{ access_decision(role, object = null) }}
@@ -56,10 +52,6 @@ gives the reason of a denial (``message``). More information can be found in
 
 access_decision_for_user
 ~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 7.4
-
-    The ``access_decision_for_user()`` function was introduced in Symfony 7.4.
 
 .. code-block:: twig
 


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Feature PR   | symfony/symfony#65012
| License      | MIT

This documents that Telegram `InlineKeyboardMarkup::inlineKeyboard()` can receive multiple rows of inline keyboard buttons as of Symfony 8.2.

Validation:

* `git diff --check` passed.

