### PR TITLE
 Document failed message id ranges

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1445,17 +1445,28 @@ to retry them:
     # retry specific messages
     $ php bin/console messenger:failed:retry 20 30 --force
 
+    # retry all messages from ID 20 to ID 30
+    $ php bin/console messenger:failed:retry --from=20 --until=30 --force
+
     # remove a message without retrying it
     $ php bin/console messenger:failed:remove 20
 
     # remove messages without retrying them and show each message before removing it
     $ php bin/console messenger:failed:remove 20 30 --show-messages
 
+    # remove all messages from ID 20 to ID 30
+    $ php bin/console messenger:failed:remove --from=20 --until=30
+
     # remove all messages in the failure transport
     $ php bin/console messenger:failed:remove --all
 
     # remove only App\Message\MyMessage messages
     $ php bin/console messenger:failed:remove --class-filter='App\Message\MyMessage'
+
+.. versionadded:: 8.2
+
+    The ``--from`` and ``--until`` options were introduced in Symfony 8.2 for
+    the ``messenger:failed:retry`` and ``messenger:failed:remove`` commands.
 
 If the message fails again, it will be re-sent back to the failure transport
 due to the normal :ref:`retry rules <messenger-retries-failures>`. Once the max

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -36,10 +36,6 @@ for web assets. Read more about :ref:`Linking to CSS, JavaScript and Image Asset
 access_decision
 ~~~~~~~~~~~~~~~
 
-.. versionadded:: 7.4
-
-    The ``access_decision()`` function was introduced in Symfony 7.4.
-
 .. code-block:: twig
 
     {{ access_decision(role, object = null) }}
@@ -56,10 +52,6 @@ gives the reason of a denial (``message``). More information can be found in
 
 access_decision_for_user
 ~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 7.4
-
-    The ``access_decision_for_user()`` function was introduced in Symfony 7.4.
 
 .. code-block:: twig
 


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Feature PR   | symfony/symfony#65031
| License      | MIT

This documents the `--from` and `--until` options added to `messenger:failed:retry` and `messenger:failed:remove` by symfony/symfony#65031.

Validation:

* `git diff --check` passed.

