### PR TITLE
 Document readable JsonStreamer output

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -36,10 +36,6 @@ for web assets. Read more about :ref:`Linking to CSS, JavaScript and Image Asset
 access_decision
 ~~~~~~~~~~~~~~~
 
-.. versionadded:: 7.4
-
-    The ``access_decision()`` function was introduced in Symfony 7.4.
-
 .. code-block:: twig
 
     {{ access_decision(role, object = null) }}
@@ -56,10 +52,6 @@ gives the reason of a denial (``message``). More information can be found in
 
 access_decision_for_user
 ~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 7.4
-
-    The ``access_decision_for_user()`` function was introduced in Symfony 7.4.
 
 .. code-block:: twig
 

--- a/serializer/streaming_json.rst
+++ b/serializer/streaming_json.rst
@@ -373,6 +373,15 @@ The ``include_null_properties`` option controls whether properties with ``null``
 values are included in the encoded JSON output. When set to ``true``, properties
 with ``null`` values are included; when ``false`` (the default), they are omitted.
 
+.. versionadded:: 8.2
+
+    JsonStreamer uses ``JSON_UNESCAPED_SLASHES`` and
+    ``JSON_UNESCAPED_UNICODE`` by default when encoding JSON streams.
+
+By default, JsonStreamer keeps slashes and Unicode characters readable in the
+encoded JSON output. For example, ``https://symfony.com/école`` is encoded with
+its original slashes and Unicode characters instead of escaped sequences.
+
 You can also pass custom options that will be available in your value transformers
 via the ``$options`` argument.
 


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Feature PR   | symfony/symfony#65032
| License      | MIT

This documents that JsonStreamer writes JSON with `JSON_UNESCAPED_SLASHES` and `JSON_UNESCAPED_UNICODE` by default as added by symfony/symfony#65032.

Validation:

* `git diff --check` passed.

