### PR TITLE
[Messenger] Fix outdated description of PostgreSqlConnection::get() blocking

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2038,12 +2038,14 @@ in the table.
 ``get_notify_timeout`` (default: ``60000``)
     The maximum time to wait for a NOTIFY, in milliseconds.
 
-When a Messenger worker consumes from multiple PostgreSQL-backed queues, the
-default LISTEN/NOTIFY blocking inside ``PostgreSqlConnection::get()`` blocks on
-one transport, preventing the other transports from being polled. This breaks
-priority-based multi-queue consumption.
+``PostgreSqlConnection::get()`` never blocks waiting for a notification: it
+issues the ``LISTEN`` command and collects any notifications that already
+arrived, then returns immediately. This way, a worker that consumes from
+multiple PostgreSQL-backed queues (or from a mix of PostgreSQL and other
+transports) keeps polling every transport in priority order on each loop
+iteration instead of being parked on a single one.
 
-To fix this, the blocking is moved to a
+Waiting while the worker is idle is the job of a
 :class:`Symfony\\Component\\Messenger\\Bridge\\Doctrine\\EventListener\\PostgreSqlNotifyOnIdleListener`
 event subscriber that is registered automatically when using the Doctrine
 transport with PostgreSQL. The listener hooks into the worker lifecycle:


### PR DESCRIPTION
The Doctrine transport / LISTEN-NOTIFY section describes `PostgreSqlConnection::get()` as blocking the worker loop on a notification. That blocking was removed in symfony/symfony#65085 (fixing symfony/symfony#65079): `get()` now issues `LISTEN`, collects any notifications that already arrived with a zero timeout, and returns immediately, so a worker consuming a mix of PostgreSQL and other transports keeps polling every transport each loop iteration.

Waiting while the worker is idle remains the job of `PostgreSqlNotifyOnIdleListener`, which is unchanged, so the rest of the section stays accurate.

This description only exists on the 8.2 docs branch, so this PR targets 8.2.

Refs symfony/symfony#65085, symfony/symfony#65079.