### PR TITLE
[Lock] remove duplicated announcing of automatic scoping

### DIFF
--- a/lock.rst
+++ b/lock.rst
@@ -42,11 +42,6 @@ this behavior by using the ``lock`` key as follows:
     scoped by ``kernel.project_id``, preventing lock collisions between multiple
     applications running on the same server.
 
-.. versionadded:: 8.1
-
-    Automatic scoping of ``flock`` and ``semaphore`` stores by
-    ``kernel.project_id`` was introduced in Symfony 8.1.
-
 .. configuration-block::
 
     .. code-block:: yaml


### PR DESCRIPTION
Removes the _`versionadded`_ block that simply repeats the same info in the `note` above it

<img width="807" height="196" alt="image" src="https://github.com/user-attachments/assets/c52575f5-1002-42fa-bef6-ea5b9392d3f3" />

