### PR TITLE
[Webhook] Explain which mailer events each bridge supports

### DIFF
--- a/webhook.rst
+++ b/webhook.rst
@@ -499,15 +499,15 @@ Mailer Webhooks
 
 Receive delivery and engagement notifications from third-party mailers:
 
-==============  ==========================================
-Mailer Service  Parser service name
-==============  ==========================================
-Brevo           ``mailer.webhook.request_parser.brevo``
-Mailgun         ``mailer.webhook.request_parser.mailgun``
-Mailjet         ``mailer.webhook.request_parser.mailjet``
-Postmark        ``mailer.webhook.request_parser.postmark``
-Sendgrid        ``mailer.webhook.request_parser.sendgrid``
-==============  ==========================================
+==============  ==========================================  ==========================
+Mailer Service  Parser service name                         Supported events
+==============  ==========================================  ==========================
+Brevo           ``mailer.webhook.request_parser.brevo``     `BrevoPayloadConverter`_
+Mailgun         ``mailer.webhook.request_parser.mailgun``   `MailgunPayloadConverter`_
+Mailjet         ``mailer.webhook.request_parser.mailjet``   `MailjetPayloadConverter`_
+Postmark        ``mailer.webhook.request_parser.postmark``  `PostmarkPayloadConverter`_
+Sendgrid        ``mailer.webhook.request_parser.sendgrid``  `SendgridPayloadConverter`_
+==============  ==========================================  ==========================
 
 .. versionadded:: 6.4
 
@@ -561,6 +561,15 @@ The routing name becomes part of your webhook URL (e.g.,
 ``https://example.com/webhook/mailer_mailgun``). Configure this URL at your
 mailer provider and store the webhook secret in your environment (via the
 :doc:`secrets management system </configuration/secrets>` or in a ``.env`` file).
+
+.. warning::
+
+    At your mailer provider, subscribe only to the events supported by the
+    Symfony bridge you use, instead of subscribing to all of them. Mailer
+    providers may add new event types, and the webhook endpoint answers with a
+    ``406`` HTTP status code for any event the bridge cannot convert into a
+    :class:`Symfony\\Component\\RemoteEvent\\RemoteEvent` object. The payload
+    converter of each bridge lists the events it supports (see the table above).
 
 Then create a consumer to handle delivery and engagement events::
 
@@ -731,5 +740,10 @@ For advanced use cases, you can implement custom sending logic using
 :class:`Symfony\\Component\\Webhook\\Server\\TransportInterface` to control
 header generation, signing, and HTTP transport.
 
+.. _`BrevoPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Brevo/RemoteEvent/BrevoPayloadConverter.php
+.. _`MailgunPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Mailgun/RemoteEvent/MailgunPayloadConverter.php
+.. _`MailjetPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Mailjet/RemoteEvent/MailjetPayloadConverter.php
 .. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
+.. _`PostmarkPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Postmark/RemoteEvent/PostmarkPayloadConverter.php
+.. _`SendgridPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Sendgrid/RemoteEvent/SendgridPayloadConverter.php
 .. _`Webhook Component for Email Events screencast`: https://symfonycasts.com/screencast/mailtrap/email-event-webhook

--- a/webhook.rst
+++ b/webhook.rst
@@ -499,15 +499,15 @@ Mailer Webhooks
 
 Receive delivery and engagement notifications from third-party mailers:
 
-==============  ==========================================  ==========================
+==============  ==========================================  ============================================================================================
 Mailer Service  Parser service name                         Supported events
-==============  ==========================================  ==========================
-Brevo           ``mailer.webhook.request_parser.brevo``     `BrevoPayloadConverter`_
-Mailgun         ``mailer.webhook.request_parser.mailgun``   `MailgunPayloadConverter`_
-Mailjet         ``mailer.webhook.request_parser.mailjet``   `MailjetPayloadConverter`_
-Postmark        ``mailer.webhook.request_parser.postmark``  `PostmarkPayloadConverter`_
-Sendgrid        ``mailer.webhook.request_parser.sendgrid``  `SendgridPayloadConverter`_
-==============  ==========================================  ==========================
+==============  ==========================================  ============================================================================================
+Brevo           ``mailer.webhook.request_parser.brevo``     :class:`Symfony\\Component\\Mailer\\Bridge\\Brevo\\RemoteEvent\\BrevoPayloadConverter`
+Mailgun         ``mailer.webhook.request_parser.mailgun``   :class:`Symfony\\Component\\Mailer\\Bridge\\Mailgun\\RemoteEvent\\MailgunPayloadConverter`
+Mailjet         ``mailer.webhook.request_parser.mailjet``   :class:`Symfony\\Component\\Mailer\\Bridge\\Mailjet\\RemoteEvent\\MailjetPayloadConverter`
+Postmark        ``mailer.webhook.request_parser.postmark``  :class:`Symfony\\Component\\Mailer\\Bridge\\Postmark\\RemoteEvent\\PostmarkPayloadConverter`
+Sendgrid        ``mailer.webhook.request_parser.sendgrid``  :class:`Symfony\\Component\\Mailer\\Bridge\\Sendgrid\\RemoteEvent\\SendgridPayloadConverter`
+==============  ==========================================  ============================================================================================
 
 .. versionadded:: 6.4
 
@@ -740,10 +740,5 @@ For advanced use cases, you can implement custom sending logic using
 :class:`Symfony\\Component\\Webhook\\Server\\TransportInterface` to control
 header generation, signing, and HTTP transport.
 
-.. _`BrevoPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Brevo/RemoteEvent/BrevoPayloadConverter.php
-.. _`MailgunPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Mailgun/RemoteEvent/MailgunPayloadConverter.php
-.. _`MailjetPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Mailjet/RemoteEvent/MailjetPayloadConverter.php
 .. _`MakerBundle`: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
-.. _`PostmarkPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Postmark/RemoteEvent/PostmarkPayloadConverter.php
-.. _`SendgridPayloadConverter`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Sendgrid/RemoteEvent/SendgridPayloadConverter.php
 .. _`Webhook Component for Email Events screencast`: https://symfonycasts.com/screencast/mailtrap/email-event-webhook


### PR DESCRIPTION
## Summary

Mailer providers add new webhook event types over time. When an application subscribes to all events at the provider, every event a Symfony bridge cannot convert to a `RemoteEvent` makes the webhook endpoint answer with a `406` HTTP status code, and the application has to wait for a new Symfony release to handle it.

This adds a warning telling readers to subscribe only to the events their bridge supports, plus a `Supported events` column in the mailer parsers table linking to each bridge's payload converter, which is where the supported event names live.

Follow-up of the discussion in https://github.com/symfony/symfony/discussions/65119, where stof favored documenting explicit subscriptions over silently ignoring unknown events.

---

Following steps:

- once this PR will be merged, add links for other providers, e.g. Resend was added on Symfony 7.1. So a similar update will be required for the 7.4 branch.
- do the same thing for Notifier? See https://symfony.com/doc/current/webhook.html#notifier-webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
