### PR TITLE
 Fix regex escape character in scheduler.rst

### DIFF
--- a/scheduler.rst
+++ b/scheduler.rst
@@ -139,7 +139,7 @@ on a particular schedule::
 .. tip::
 
     You can consume all your scheduler transports at once by using a regular expression
-    with the ``messenger:consume`` command (e.g. ``php bin/console messenger:consume scheduler_.*``).
+    with the ``messenger:consume`` command (e.g. ``php bin/console messenger:consume scheduler_.\*``).
 
 .. tip::
 


### PR DESCRIPTION
`*` must be escaped, if you don't want to, you can also use + which works as well.
<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
