### PR TITLE
[Security] Document the logout_form() helper

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -389,6 +389,40 @@ Adds a ``Link`` HTTP header to the current response for the given link relation
 type (``rel``). It can be used for any link implementing the PSR-13 standard.
 Read more about :doc:`/web_link`.
 
+logout_form
+~~~~~~~~~~~
+
+.. code-block:: twig
+
+    {{ logout_form(key = null) }}
+
+``key`` *(optional)*
+    **type**: ``string``
+
+Returns the ``action`` and the ``fields`` needed to log out with a form, so the
+logout route can be restricted to ``POST``. If no key is provided, they are
+generated for the current firewall the user is logged into.
+
+.. code-block:: html+twig
+
+    {% set logout = logout_form() %}
+
+    <form method="post" action="{{ logout.action }}">
+        {% for name, value in logout.fields %}
+            <input type="hidden" name="{{ name }}" value="{{ value }}">
+        {% endfor %}
+
+        <button>Log out</button>
+    </form>
+
+``fields`` contains the CSRF token under its configured parameter name, and is
+empty when the firewall does not enable CSRF protection. Read more about
+:ref:`logging out with a form <security-logout-form>`.
+
+.. versionadded:: 8.2
+
+    The ``logout_form()`` function was introduced in Symfony 8.2.
+
 logout_path
 ~~~~~~~~~~~
 

--- a/security.rst
+++ b/security.rst
@@ -1690,6 +1690,106 @@ you have imported the logout route loader in your routes:
             ],
         ]);
 
+.. _security-logout-form:
+
+Logging Out with a Form
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A logout link is a ``GET`` request, which browsers, crawlers, corporate proxies
+and link-preview bots follow on their own, logging users out without them asking
+for it. Restricting the logout route to ``POST`` prevents this.
+
+Declare the route yourself, with the methods you want to allow, and point the
+``path`` option at it by name. Otherwise the route generated from the ``path``
+option accepts every method, and the ``GET`` remains available:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/routes.yaml
+        app_logout:
+            path: /logout
+            methods: [POST]
+
+    .. code-block:: php
+
+        // config/routes.php
+        namespace Symfony\Component\Routing\Loader\Configurator;
+
+        return Routes::config([
+            'app_logout' => [
+                'path' => '/logout',
+                'methods' => ['POST'],
+            ],
+        ]);
+
+Then point the ``path`` option at that route:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/security.yaml
+        security:
+            # ...
+
+            firewalls:
+                main:
+                    # ...
+                    logout:
+                        path: app_logout
+
+    .. code-block:: php
+
+        // config/packages/security.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'security' => [
+                'firewalls' => [
+                    'main' => [
+                        'logout' => [
+                            'path' => 'app_logout',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+The ``logout_form()`` Twig function returns the ``action`` and the ``fields`` to
+render, so the form carries what the logout listener expects:
+
+.. code-block:: html+twig
+
+    {% set logout = logout_form() %}
+
+    <form method="post" action="{{ logout.action }}">
+        {% for name, value in logout.fields %}
+            <input type="hidden" name="{{ name }}" value="{{ value }}">
+        {% endfor %}
+
+        <button>Log out</button>
+    </form>
+
+The parameter name comes from the ``csrf_parameter`` option and the token from
+the firewall's ``csrf_token_manager``, so neither has to be hardcoded in the
+template. When the firewall does not set
+:ref:`enable_csrf <reference-security-logout-csrf>`, ``fields`` is empty and the
+form still submits the configured path over ``POST``.
+
+The function takes the same optional firewall key as ``logout_path()``.
+
+.. note::
+
+    ``logout_path()`` and ``logout_url()`` are unchanged and still suit a link
+    on a route that accepts ``GET``. When CSRF protection is enabled they carry
+    the token in the query string, which a form sends as a hidden field instead.
+
+.. versionadded:: 8.2
+
+    The ``logout_form()`` function was introduced in Symfony 8.2.
+
 .. _security-logout-without-redirect:
 
 Building the Logout Response Yourself


### PR DESCRIPTION
Documents the `logout_form()` Twig function, added in Symfony 8.2 by symfony/symfony#65129.

Two places:

- `security.rst` gains a *Logging Out with a Form* section, since the point of the helper is to let the logout route be restricted to `POST`. It shows the route configuration, the form, and where the parameter name and the token come from.
- `reference/twig_reference.rst` gains the `logout_form` entry, in alphabetical order before `logout_path`, linking to the section above.

Behaviour checked against the 8.2 code rather than restated from the feature PR:

```
firewall without CSRF : {"action":"/logout","fields":[]}
firewall with CSRF    : action=/logout, fields={_csrf_token: <token>}
logout_path() for comparison : /logout?_csrf_token=3e056f841e237f1e...
```

That last line is what the section builds on: `logout_path()` carries the token in the query string, which only a `GET` can send, while `logout_form()` hands it over as a hidden field.

Fixes #22538
