### PR TITLE
[Security] Document that a firewall's CSRF token manager serves its token id

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -586,6 +586,29 @@ csrf_token_manager
 The ``id`` of the service used to generate the CSRF tokens. Symfony provides a
 default service whose ID is ``security.csrf.token_manager``.
 
+The manager configured here also serves the `csrf_token_id`_ of this firewall
+everywhere else, so a token asked for under that id is minted by this manager
+and accepted by this firewall. This applies to ``csrf_token()`` when a template
+asks for that id directly. Every other token id keeps using the default manager.
+
+This also wins over :ref:`stateless token ids <csrf-stateless-tokens>`: listing
+the same token id there while a firewall configures a manager for it would
+answer the id statelessly, while the firewall keeps validating it with the
+manager it was given.
+
+.. note::
+
+    Two firewalls cannot map the same ``csrf_token_id`` to two different
+    managers, since the token id is all ``csrf_token()`` has to tell them apart.
+    Doing so fails at compile time, and giving the firewalls distinct
+    ``csrf_token_id`` values solves it.
+
+.. versionadded:: 8.2
+
+    Serving the firewall's token id through the manager it configures was
+    introduced in Symfony 8.2. Before, a template could only reach the default
+    manager, so the token it minted was rejected by the firewall.
+
 csrf_token_id
 .............
 


### PR DESCRIPTION
Documents the change from symfony/symfony#65124, merged in 8.2.

A firewall configuring its own `csrf_token_manager` used to be the only thing given that manager. `csrf_token('logout')` in a template went through the default one, minting a token the firewall then rejected, so rendering the logout form the documented way produced a 403 with no way to reach the configured manager from a template.

The note goes under the `csrf_token_manager` option of the firewall's `logout` section, which is the only place documenting it today. It covers what the option now serves, that other token ids are unaffected, and the compile-time error when two firewalls map the same token id to different managers.

Routing checked against the 8.2 code, with a fake manager on each side:

```
id 'logout'                  -> firewall-token   (the firewall's manager)
id 'autre'                   -> fallback-token   (the decorated one)
fallback token on id logout  -> invalid          (the 403 this fixes)
firewall token on id logout  -> valid
```

Fixes #22533
