### PR TITLE
[DependencyInjection] Document lazy proxy arguments

### DIFF
--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -130,6 +130,98 @@ It defines an optional parameter used to define interfaces for proxy and interse
     ) {
     }
 
+.. _lazy-services-per-argument:
+
+Injecting a Service as a Lazy Proxy
+-----------------------------------
+
+Marking a service ``lazy`` defers its instantiation for every consumer. When
+only one injection point needs that, inject a lazy proxy on that argument
+instead. The target service is left alone, so its other consumers still
+receive the real instance:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        services:
+            App\Consumer:
+                arguments:
+                    # '@~' wraps the reference in a lazy proxy
+                    - '@~App\HeavyService'
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Consumer;
+        use App\HeavyService;
+
+        return function (ContainerConfigurator $container): void {
+            $container->services()
+                ->set(Consumer::class)
+                    ->args([lazy_proxy(HeavyService::class)]);
+        };
+
+The ``@~`` prefix composes with the ones controlling the behavior of invalid
+references, so ``'@~?App\Maybe'`` injects a proxy of an optional service, and
+resolves to ``null`` when that service does not exist. In PHP, ``lazy_proxy()``
+returns a reference configurator, so ``ignoreOnInvalid()``, ``nullOnInvalid()``
+and ``ignoreOnUninitialized()`` apply, as they do for ``service_closure()``.
+
+To proxy specific interfaces rather than the target's own class, use the
+``!lazy_proxy`` tag, which accepts a reference or a mapping:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        services:
+            App\Consumer:
+                arguments:
+                    - !lazy_proxy '@App\HeavyService'
+                    - !lazy_proxy
+                        service: '@App\HeavyService'
+                        interface: 'App\HeavyInterface'
+                    - !lazy_proxy
+                        service: '@App\HeavyService'
+                        interface: ['App\HeavyInterface', 'App\OtherInterface']
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\Consumer;
+        use App\HeavyInterface;
+        use App\HeavyService;
+        use App\OtherInterface;
+
+        return function (ContainerConfigurator $container): void {
+            $container->services()
+                ->set(Consumer::class)
+                    ->args([
+                        lazy_proxy(HeavyService::class),
+                        lazy_proxy(HeavyService::class, HeavyInterface::class),
+                        lazy_proxy(HeavyService::class, [
+                            HeavyInterface::class,
+                            OtherInterface::class,
+                        ]),
+                    ]);
+        };
+
+Naming one or more interfaces produces a proxy implementing only those, which is
+what a consumer type-hinting the interface needs. Read more about this in
+:ref:`Interface Proxifying <lazy-services-interface-proxifying>`.
+
+.. versionadded:: 8.2
+
+    The ``@~`` prefix, the ``!lazy_proxy`` tag and the ``lazy_proxy()`` function
+    were introduced in Symfony 8.2.
+
 .. _lazy-services-interface-proxifying:
 
 Interface Proxifying

--- a/service_container/lazy_services.rst
+++ b/service_container/lazy_services.rst
@@ -142,6 +142,23 @@ receive the real instance:
 
 .. configuration-block::
 
+    .. code-block:: php-attributes
+
+        // src/Consumer.php
+        namespace App;
+
+        use Symfony\Component\DependencyInjection\Attribute\Lazy;
+
+        class Consumer
+        {
+            public function __construct(
+                #[Lazy]
+                // this is equivalent: #[Autowire(lazy: true)]
+                HeavyService $heavyService,
+            ) {
+            }
+        }
+
     .. code-block:: yaml
 
         # config/services.yaml


### PR DESCRIPTION
Documents injecting a service as a lazy proxy on a single argument, added in Symfony 8.2 by symfony/symfony#65103.

The page already covers `#[Lazy]` and `#[Autowire(lazy: ...)]`, which do this from attributes; the new section covers the YAML and PHP-DSL equivalents that were missing.

Behaviour checked against the 8.2 code, with a service whose constructor prints when it runs:

```
'@~App\Heavy'                                    -> proxy, target not built
!lazy_proxy '@App\Heavy'                         -> proxy, target not built
!lazy_proxy {service, interface}                 -> proxy implementing the interface
'@~?App\Missing'                                 -> null
one plain '@App\Heavy' argument alongside        -> target built
```

That last line is the difference from `lazy: true` on the definition, which the section opens on: the target keeps serving its other consumers eagerly.

Fixes #22527
