### PR TITLE
[Validator] Document the restrictGroups option of the Valid constraint

### DIFF
--- a/reference/constraints/Valid.rst
+++ b/reference/constraints/Valid.rst
@@ -258,6 +258,45 @@ Options
 
 .. include:: /reference/constraints/_payload-option.rst.inc
 
+``restrictGroups``
+~~~~~~~~~~~~~~~~~~
+
+**type**: ``boolean`` **default**: ``true``
+
+The ``groups`` option of this constraint means two things at once: which groups
+trigger the cascade, and which groups the nested object is validated against.
+Set this option to ``false`` to keep only the first meaning, so the nested
+object is validated against the groups being validated::
+
+    // src/Entity/Order.php
+    namespace App\Entity;
+
+    use Symfony\Component\Validator\Constraints as Assert;
+
+    class Order
+    {
+        #[Assert\Valid(groups: ['alternateInvoiceAddress'], restrictGroups: false)]
+        public Address $invoiceAddress;
+    }
+
+Validating an ``Order`` against ``['Default', 'alternateInvoiceAddress']``
+cascades to ``$invoiceAddress``, because ``alternateInvoiceAddress`` is one of
+the groups being validated, and the ``Address`` is then validated against both
+of them. Validating without ``alternateInvoiceAddress`` skips the nested object
+entirely.
+
+With the default value, the ``Address`` would instead be validated against
+``alternateInvoiceAddress`` alone, so its constraints in other groups would
+never run. Turning the option off keeps a nested class reusable, as its parent
+no longer decides which of its constraints apply.
+
+The `traverse`_ option applies with either value. Read more about groups in
+:doc:`/validation/groups`.
+
+.. versionadded:: 8.2
+
+    The ``restrictGroups`` option was introduced in Symfony 8.2.
+
 ``traverse``
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Documents the `restrictGroups` option of the `Valid` constraint, added in Symfony 8.2 by symfony/symfony#65104.

The option is inserted between `payload` and `traverse`, keeping the alphabetical order of the page.

Behaviour checked against the 8.2 code, with an `Address` carrying one `Default` constraint and one `cityAddress` constraint, referenced by a `Valid(groups: ['alt'])`:

```
restrictGroups: true (default)  validating Default,alt,cityAddress -> no violation
restrictGroups: true (default)  validating Default,cityAddress     -> no violation
restrictGroups: false           validating Default,alt,cityAddress -> addr:Default, addr:cityAddress
restrictGroups: false           validating Default,cityAddress     -> no violation
```

The first line is what makes the option useful: the cascade does happen, but the nested object is validated against `alt` alone, where it has no constraint. The last line shows the cascade still depends on the groups, in both cases.

Fixes #22525
