### PR TITLE
[Mailer] Document the Gmail API transport

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -179,7 +179,7 @@ party provider:
 +------------------------+-------------------------------------------------------------------------------------------+
 | `Google Gmail`_        | - SMTP ``gmail+smtp://USERNAME:APP-PASSWORD@default``                                     |
 |                        | - HTTP n/a                                                                                |
-|                        | - API n/a                                                                                 |
+|                        | - API ``gmail+api://SERVICE-ACCOUNT:PRIVATE-KEY@default?user=USER-EMAIL``                 |
 +------------------------+-------------------------------------------------------------------------------------------+
 | `Infobip`_             | - SMTP ``infobip+smtp://KEY@default``                                                     |
 |                        | - HTTP n/a                                                                                |
@@ -278,12 +278,27 @@ party provider:
 
 .. note::
 
-    To use Google Gmail, you must have a Google Account with 2-Step-Verification (2FA)
-    enabled and you must use `App Password`_ to authenticate. Also note that Google
-    revokes your App Passwords when you change your Google Account password and then
-    you need to generate a new one.
-    Using other methods (like ``XOAUTH2`` or the ``Gmail API``) is not currently supported.
-    You should use Gmail for testing purposes only and use a real provider in production.
+    To use the ``gmail+smtp`` transport, you must have a Google Account with
+    2-Step-Verification (2FA) enabled and you must use `App Password`_ to
+    authenticate. Also note that Google revokes your App Passwords when you
+    change your Google Account password and then you need to generate a new one.
+    Using ``XOAUTH2`` is not currently supported. You should use this transport
+    for testing purposes only and use a real provider in production.
+
+.. note::
+
+    The ``gmail+api`` transport authenticates with a Google service account
+    using domain-wide delegation, so it needs a Google Workspace and the
+    ``openssl`` PHP extension. In its DSN, ``SERVICE-ACCOUNT`` is the email
+    address of the service account and ``PRIVATE-KEY`` is its RSA private key in
+    PEM format, base64-encoded so that it fits in the DSN. ``USER-EMAIL`` is the
+    address of the user to impersonate, which is also the address the messages
+    are sent from: the Gmail API always sends as the authenticated user, so a
+    custom envelope sender is not supported.
+
+.. versionadded:: 8.2
+
+    The ``gmail+api`` transport was introduced in Symfony 8.2.
 
 .. note::
 


### PR DESCRIPTION
Documents the Gmail API transport, added in Symfony 8.2 by symfony/symfony#63813.

Three changes:

- the table entry for Google Gmail said `API n/a`; it now carries the DSN, with placeholders shortened to fit the table width
- the existing Gmail note said "Using other methods (like `XOAUTH2` or the `Gmail API`) is not currently supported", which this feature makes wrong. It is now scoped to `gmail+smtp` and keeps only the `XOAUTH2` part
- a note describes the `gmail+api` DSN, since none of its parts is obvious: the password field holds a base64-encoded PEM key, and `user` is both the impersonated account and the sender

Checked against the bridge, with the fixture key of its test suite:

```
gmail+api://svc@project.iam.gserviceaccount.com:BASE64_KEY@default?user=sender@example.com
  -> transport created

same DSN without ?user      -> IncompleteDsnException
password not valid base64   -> IncompleteDsnException
```

`ext-openssl` is a hard requirement of `symfony/google-mailer`, used by `TokenManager` to sign the JWT, and the transport always sends as the impersonated user, so an envelope sender cannot be expressed.

Fixes #22524