### PR TITLE
[Mailer] Document the Azure mailer webhook parser

### DIFF
--- a/webhook.rst
+++ b/webhook.rst
@@ -436,6 +436,7 @@ Receive delivery and engagement notifications from third-party mailers:
 Mailer Service  Parser service name
 ==============  ============================================
 AhaSend         ``mailer.webhook.request_parser.ahasend``
+Azure           ``mailer.webhook.request_parser.azure``
 Brevo           ``mailer.webhook.request_parser.brevo``
 Mandrill        ``mailer.webhook.request_parser.mailchimp``
 MailerSend      ``mailer.webhook.request_parser.mailersend``
@@ -454,6 +455,32 @@ Sweego          ``mailer.webhook.request_parser.sweego``
     Install the third-party mailer provider you want to use as described in
     the documentation of the :ref:`Mailer component <mailer_3rd_party_transport>`.
     Mailgun is used as the provider in this document as an example.
+
+.. note::
+
+    Azure Event Grid does not sign its payloads. It authenticates itself either
+    with a Microsoft Entra bearer token, or by repeating the query parameters of
+    the subscription URL on every delivery. The Azure parser uses the second
+    mechanism, so the subscription URL must carry a ``secret`` query parameter
+    holding the configured webhook secret:
+
+    .. code-block:: text
+
+        https://example.com/webhook/mailer_azure?secret=THE_WEBHOOK_SECRET
+
+    Requests are rejected when that parameter is missing or does not match. If
+    you protect the endpoint with Microsoft Entra ID instead, the parser still
+    performs this check, so the URL and the configuration must agree on some
+    value even though the bearer token is what secures the endpoint.
+
+    Register the endpoint with Event Grid's manual validation flow: its
+    automatic subscription handshake echoes a validation code in the response
+    body, which the webhook controller does not do. The parser reads the Event
+    Grid schema, not the CloudEvents one.
+
+.. versionadded:: 8.2
+
+    The Azure mailer webhook parser was introduced in Symfony 8.2.
 
 Configure the routing:
 


### PR DESCRIPTION
Documents the Azure mailer webhook parser, added in Symfony 8.2 by symfony/symfony#63802.

`Azure` is added to the parser table, in alphabetical order, and a note covers what makes this parser different from the others.

That note is the point of the PR: Event Grid signs nothing, so authenticity rests on a `secret` query parameter that has to be part of the subscription URL. Someone configuring the routing like the Mailgun example next to it, without adding that parameter, gets a 401 on every delivery with nothing in the docs to explain it.

Checked against the bridge:

- `AzureRequestParser::doParse()` compares `$request->query->get('secret')` with the configured secret using `hash_equals()`, and throws `RejectWebhookException(401, 'Invalid secret.')` otherwise
- malformed payloads are rejected with 406
- the class docblock states the Event Grid schema (not CloudEvents) and that the automatic subscription handshake is unsupported, since it requires echoing a validation code in the response body

The example URL uses `mailer_azure` rather than `azure`, to match the `mailer_mailgun` routing name convention used a few lines below in the same page.

Fixes #22523
