### PR TITLE
 Fix the list of allowed admonitions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ The only exception is @reference/configuration/ files that use `~~~~~` (level 2)
 - Leave a **blank line** after the `::` marker before the content
 - Leave a **blank line** before and after every directive
 - Continuation lines of multi-line list items align with the text start (not the bullet)
-- Use these admonitions: `note`, `tip`, `warning`, `caution`, `seealso`
+- Use these admonitions: `note`, `tip`, `warning`, `danger`, `seealso` (`caution` is forbidden)
 - Use `versionadded` and `deprecated` directives:
   ```rst
   .. versionadded:: 7.2


### PR DESCRIPTION
`AGENTS.md` lists `caution` as an allowed admonition, but `.doctor-rst.yaml` forbids it via `forbidden_directives` and the CI fails on it, suggesting `.. warning::` or `.. danger::` instead. Following the file as written produces a red build.

`danger` was missing from the list although it is used 27 times in the docs, while `caution` is used nowhere.