### PR TITLE
[Serializer] Document the XmlEncoder boolean representation option

### DIFF
--- a/serializer/encoders.rst
+++ b/serializer/encoders.rst
@@ -250,6 +250,10 @@ These are the options available on the :ref:`serializer context <serializer-cont
 ``preserve_numeric_keys`` (default: ``false``)
     If set to true, it keeps numeric array indexes (e.g. ``<item key="0">``)
     instead of collapsing them into ``<item>`` nodes.
+``xml_boolean_repr`` (default: ``null``)
+    A list of the two non-empty strings that represent ``true`` and ``false``,
+    in that order (e.g. ``['true', 'false']``). If set to ``null``, booleans
+    are written as ``1`` and ``0``.
 
 Example with a custom ``context``::
 
@@ -319,6 +323,49 @@ Example with ``preserve_numeric_keys``::
     //      </item>
     //  </person>
     //</response>
+
+.. _serializer-xml-boolean-repr:
+
+Encoding Booleans as Custom Strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``xml_boolean_repr`` option was introduced in Symfony 8.2.
+
+The ``XmlEncoder`` writes booleans as ``1`` and ``0``. The
+``xml_boolean_repr`` option replaces them with the pair of strings of your
+choice, which applies to element contents and to attributes alike::
+
+    $data = ['@active' => true, 'enabled' => false];
+
+    $xmlEncoder->encode($data, 'xml', [
+        'xml_format_output' => true,
+        'xml_boolean_repr' => ['true', 'false'],
+    ]);
+    // outputs:
+    // <?xml version="1.0"?>
+    // <response active="true">
+    //   <enabled>false</enabled>
+    // </response>
+
+Any pair works, such as ``['yes', 'no']`` or ``['Y', 'N']``. Set the option
+in the constructor to apply it to every call of that encoder::
+
+    use Symfony\Component\Serializer\Encoder\XmlEncoder;
+
+    $xmlEncoder = new XmlEncoder(['xml_boolean_repr' => ['true', 'false']]);
+
+Passing ``null`` in the context of a single call restores the ``1`` and ``0``
+output for that call. Any value other than a list of two non-empty strings
+throws an
+:class:`Symfony\\Component\\Serializer\\Exception\\InvalidArgumentException`.
+
+The option only affects encoding. Decoding is unchanged, so
+``<enabled>true</enabled>`` decodes to the string ``'true'``, in the same way
+as ``<enabled>1</enabled>`` decodes to ``'1'``. Attributes keep following the
+``xml_type_cast_attributes`` option, which casts ``active="1"`` to the
+integer ``1`` but leaves ``active="true"`` as a string.
 
 The ``YamlEncoder``
 -------------------


### PR DESCRIPTION
Fixes #22521

Documents the `xml_boolean_repr` context option added in symfony/symfony#63803: the pair of strings replacing the default `1` and `0`, its effect on both element contents and attributes, setting it on the constructor or per call, disabling it with `null`, and the fact that decoding is unchanged.