### PR TITLE
[DependencyInjection] Document the $priority argument of the #[Required] attribute

### DIFF
--- a/service_container/autowiring.rst
+++ b/service_container/autowiring.rst
@@ -1477,6 +1477,50 @@ attribute, autowiring each argument. If you need to manually wire some of the
 arguments to a method, you can always explicitly
 :ref:`configure the method call <injection-types-setter>`.
 
+If a class declares several ``#[Required]`` methods, the container calls them
+in the order in which they are declared. Use the ``priority`` argument to change
+that order: methods with a higher priority are called first and methods with
+the same priority keep their declaration order::
+
+    // src/Formatter/TextFormatter.php
+    namespace App\Formatter;
+
+    use Psr\Log\LoggerInterface;
+    use Symfony\Contracts\Service\Attribute\Required;
+    use Symfony\Contracts\Translation\TranslatorInterface;
+
+    class TextFormatter
+    {
+        private LoggerInterface $logger;
+        private TranslatorInterface $translator;
+
+        // the default priority is 0, so this method is called after setLogger()
+        #[Required]
+        public function setTranslator(TranslatorInterface $translator): void
+        {
+            $this->translator = $translator;
+        }
+
+        // this method is called first because it has a higher priority
+        #[Required(priority: 10)]
+        public function setLogger(LoggerInterface $logger): void
+        {
+            $this->logger = $logger;
+        }
+    }
+
+.. versionadded:: 8.2
+
+    The ``priority`` argument of ``#[Required]`` was introduced in Symfony 8.2.
+    It requires ``symfony/service-contracts`` 3.7 or later.
+
+.. note::
+
+    :ref:`Immutable setters <injection-types-immutable-setter>` (``#[Required]``
+    methods that return ``static``) are always called before the other required
+    methods, regardless of their priority. The ``priority`` argument only sorts
+    them relative to each other.
+
 Despite :ref:`property injection <property-injection>` having some drawbacks,
 autowiring with ``#[Required]`` can also be applied to public typed properties.
 The service to inject is resolved in the same way as a constructor argument:
@@ -1505,6 +1549,9 @@ service directly to the property::
             // ...
         }
     }
+
+The ``priority`` argument has no effect on properties: the container always
+sets them in the order in which they are declared.
 
 Performance Consequences
 ------------------------

--- a/service_container/injection_types.rst
+++ b/service_container/injection_types.rst
@@ -161,6 +161,8 @@ The **disadvantages** of setter injection are:
 * You cannot be sure the setter will be called and so you need to add checks
   that any required dependencies are injected.
 
+.. _injection-types-immutable-setter:
+
 Immutable Setter Injection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes #22488

Documents the `priority` argument added in symfony/symfony#64980.

Covers the three behaviors of the pass: methods are sorted by descending priority, ties keep the declaration order, and withers are still called first as a group and only sorted among themselves. Also notes that the argument has no effect on public typed properties, which the properties pass ignores.

The `versionadded` mentions the `symfony/service-contracts` 3.7 requirement, since DependencyInjection 8.2 only requires `^3.6` and the pass reads the property with `?? 0`.