### PR TITLE
[Ldap] Document the `ldap_users_only` option

### DIFF
--- a/reference/configuration/security.rst
+++ b/reference/configuration/security.rst
@@ -696,7 +696,7 @@ You can authenticate to an LDAP server using the LDAP variants of the
 attempt to ``bind`` against an LDAP server instead of using password comparison.
 
 Both authentication providers have the same arguments as their normal
-counterparts, with the addition of two configuration keys:
+counterparts, with the addition of the following configuration keys:
 
 service
 .......
@@ -725,6 +725,21 @@ placeholder will be replaced with the user-provided value (their login).
 Depending on your LDAP server's configuration, you will need to override
 this value. This setting is only necessary if the user's DN cannot be derived
 statically using the ``dn_string`` config option.
+
+ldap_users_only
+...............
+
+**type**: ``boolean`` **default**: ``false``
+
+.. versionadded:: 8.2
+
+    The ``ldap_users_only`` option was introduced in Symfony 8.2.
+
+Set this option to ``true`` to bind only the LDAP users against the LDAP
+server and to check every other user against the password stored in your
+application. This allows an LDAP firewall to use a
+:ref:`chain user provider <security-chain-user-provider>`. See
+:ref:`ldap_users_only <security-ldap-users-only>` for more details.
 
 **User provider**
 

--- a/security/ldap.rst
+++ b/security/ldap.rst
@@ -332,7 +332,7 @@ Authenticating against an LDAP server can be done using either the form
 login or the HTTP Basic authentication providers.
 
 They are configured exactly as their non-LDAP counterparts, with the
-addition of two configuration keys and one optional key:
+addition of the following configuration keys:
 
 service
 .......
@@ -377,6 +377,36 @@ your users have the following two DN: ``dc=companyA,dc=example,dc=com`` and
 Note that usernames must be unique across both DN, as the authentication
 provider won't be able to select the correct user for the bind process if more
 than one is found.
+
+.. _security-ldap-users-only:
+
+ldap_users_only
+...............
+
+**type**: ``boolean`` **default**: ``false``
+
+.. versionadded:: 8.2
+
+    The ``ldap_users_only`` option was introduced in Symfony 8.2.
+
+By default, the firewall binds every user against the LDAP server, including
+the users that don't come from the directory. Set this key to ``true`` to bind
+only the users the user provider returns as
+:class:`Symfony\\Component\\Ldap\\Security\\LdapUser` instances, and to check
+the other users against the password stored in your application.
+
+This is what makes a :ref:`chain user provider <security-chain-user-provider>`
+work on an LDAP firewall. Without it, Symfony sends the password of a local
+user to the LDAP server, which rejects it.
+
+To set this up, chain the
+:ref:`LDAP user provider <security-ldap-user-provider>` with the provider that
+loads your local users, point the firewall at that chain and turn this key on.
+
+The firewall must use a user provider that returns ``LdapUser`` instances.
+Otherwise, Symfony throws an exception when compiling the container, rather
+than letting the application start with a firewall that trusts a locally
+stored password.
 
 Examples are provided below, for both ``form_login_ldap`` and
 ``http_basic_ldap``.


### PR DESCRIPTION
Fixes #22486

Documents the `ldap_users_only` option added in symfony/symfony#64976 for `form_login_ldap`, `http_basic_ldap` and `json_login_ldap`.

The option only makes sense together with a chain user provider, so the reference entry links to the full explanation in `security/ldap.rst`, which shows that setup and states that the container refuses to compile when no provider returns `LdapUser` instances.

Also drops the "two configuration keys" wording in both files, which already undercounted the existing keys.