### PR TITLE
[AssetMapper] Document requiring non-ESM packages

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -338,6 +338,57 @@ Now you can import the package as usual:
     the registered directory includes every file the package needs for its
     browser imports.
 
+Requiring Non-ESM Packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``--no-esm`` option was introduced in Symfony 8.2.
+
+Remote packages are downloaded as the ESM build that the ``jsDelivr`` CDN
+generates for them (by appending ``/+esm`` to the package URL). That build is
+broken for some packages, and you may prefer to download the files the package
+actually publishes instead. Pass the ``--no-esm`` option to do so, together with
+the exact path of the file to download:
+
+.. code-block:: terminal
+
+    $ php bin/console importmap:require "fullcalendar/index.global.js=fullcalendar" --no-esm
+
+This downloads ``index.global.js`` as published (instead of its ``/+esm`` build)
+and writes the following into ``importmap.php``::
+
+    // importmap.php
+    return [
+        // ...
+        'fullcalendar' => [
+            'version' => '7.0.0',
+            'package_specifier' => 'fullcalendar/index.global.js',
+            'esm' => false,
+        ],
+    ];
+
+The file is stored untouched. Any *relative* imports it declares are downloaded
+next to it and added to the import map too, so imports like
+``import "./chunk/calendar.js"`` inside the package keep working.
+
+Keep the following limitations in mind when using ``--no-esm``:
+
+* You must pass the path to the file (as in ``fullcalendar/index.global.js``).
+  A bare package name like ``fullcalendar`` is refused, because the relative
+  imports inside the file are resolved against its directory, which is unknown
+  when the CDN is the one choosing the file from the package's ``main`` entry;
+* ``--no-esm`` cannot be combined with the ``--path`` option, which declares a
+  local file that is never downloaded;
+* *Bare* imports inside a raw file (such as ``import { h } from "preact"``) are
+  not resolved. The ESM build rewrites those into further CDN URLs that
+  AssetMapper follows, but a raw file is taken as-is, so you must require those
+  packages yourself.
+
+The ``esm`` key is only written when it is ``false``, so existing
+``importmap.php`` files are left untouched, and running ``importmap:update``
+preserves the flag.
+
 Removing JavaScript Packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Documents the `--no-esm` option added in symfony/symfony#65075 (Symfony 8.2): requiring a remote package's published file instead of the `jsDelivr` `/+esm` build, the `esm` key written in `importmap.php`, when to reach for it, and the path requirement plus bare-import limitation.

Fixes #22565.
