### PR TITLE
[Tui] Add the component documentation

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -56,6 +56,7 @@ Topics
     service_container
     testing
     translation
+    tui
     validation
     web_link
     webhook

--- a/tui/cheat_sheet.rst
+++ b/tui/cheat_sheet.rst
@@ -1,0 +1,175 @@
+Interactive Widgets Cheat Sheet
+===============================
+
+A quick reference of all keyboard shortcuts and
+interactive features for every focusable widget.
+
+.. tip::
+
+    **F6** / **Shift+F6** cycle focus between widgets in any
+    application. See :doc:`topics/focus` for details.
+
+Bracketed Paste
+---------------
+
+When you paste text into a terminal (``Cmd+V`` on macOS,
+``Ctrl+Shift+V`` on Linux), most modern terminals use a protocol
+called **bracketed paste mode**. The terminal wraps the pasted
+content between two special escape sequences so the application can
+tell the difference between text you typed and text you pasted.
+
+Why does it matter? Without this protocol, pasting a multi-line
+block into an editor would be indistinguishable from typing each
+character one by one. Every newline would trigger the "submit"
+action, every ``Escape`` character would cancel, and so on. With
+bracketed paste, the application receives the entire block as a
+single paste event and inserts it at the cursor without triggering
+any shortcut.
+
+Both ``InputWidget`` and ``EditorWidget`` support bracketed paste.
+The details are noted in each widget's section below.
+
+InputWidget
+-----------
+
+Single-line text field with horizontal scrolling and paste support.
+
+**Keyboard:**
+
+============================  ==============================
+Key                           Action
+============================  ==============================
+Enter                         Submit
+Escape, Ctrl+C                Cancel
+Left, Ctrl+B                  Move cursor left
+Right, Ctrl+F                 Move cursor right
+Alt+Left, Ctrl+Left, Alt+B    Move word left
+Alt+Right, Ctrl+Right, Alt+F  Move word right
+Home, Ctrl+A                  Move to start of line
+End, Ctrl+E                   Move to end of line
+Backspace, Shift+Backspace    Delete character backward
+Delete, Ctrl+D, Shift+Delete  Delete character forward
+Ctrl+W, Alt+Backspace         Delete word backward
+Ctrl+U                        Delete to start of line
+Ctrl+K                        Delete to end of line
+============================  ==============================
+
+**Paste:**
+
+* `Bracketed paste`_ is supported. Pasted text is inserted at the
+  cursor; newlines are stripped since this is a single-line widget.
+
+EditorWidget
+------------
+
+Multi-line text editor with word wrap, scrolling, undo/redo, kill
+ring and autocomplete.
+
+**Keyboard:**
+
+============================  ==============================
+Key                           Action
+============================  ==============================
+Enter                         Submit
+Shift+Enter                   Insert newline
+Escape, Ctrl+C                Cancel (or close autocomplete)
+Tab                           Trigger autocomplete
+Shift+Space                   Insert a space
+Up                            Move cursor up (or start of
+                              line when on first line)
+Down                          Move cursor down (or end of
+                              line when on last line)
+Left, Ctrl+B                  Move cursor left
+Right, Ctrl+F                 Move cursor right
+Alt+Left, Ctrl+Left, Alt+B    Move word left
+Alt+Right, Ctrl+Right, Alt+F  Move word right
+Home, Ctrl+A                  Move to start of line
+End, Ctrl+E                   Move to end of line
+Page Up                       Scroll up by page
+Page Down                     Scroll down by page
+Ctrl+]                        Jump forward to a character
+Ctrl+Alt+]                    Jump backward to a character
+Backspace, Shift+Backspace    Delete character backward
+Delete, Ctrl+D, Shift+Delete  Delete character forward
+Ctrl+W, Alt+Backspace         Delete word backward
+Alt+D, Alt+Delete             Delete word forward
+Ctrl+Shift+K                  Delete entire line
+Ctrl+U                        Delete to start of line
+Ctrl+K                        Delete to end of line
+Ctrl+- (minus)                Undo
+Ctrl+Shift+Z                  Redo
+Ctrl+Y                        Yank (paste from kill ring)
+Alt+Y                         Yank pop (cycle kill ring)
+============================  ==============================
+
+**Autocomplete (when the dropdown is open):**
+
+====================  ==============================
+Key                   Action
+====================  ==============================
+Up                    Previous suggestion
+Down                  Next suggestion
+Page Up               Page up through suggestions
+Page Down             Page down through suggestions
+Enter                 Accept suggestion
+Escape                Close dropdown
+====================  ==============================
+
+**Paste:**
+
+* `Bracketed paste`_ is supported. Pasted text is inserted at the
+  cursor with newlines preserved.
+* Large pastes (more than 10 lines) are collapsed into a compact
+  marker; the full content is available via ``getPasteMarkers()``.
+
+SelectListWidget
+----------------
+
+Scrollable list with single-item selection.
+
+**Keyboard:**
+
+==========================  ==============================
+Key                         Action
+==========================  ==============================
+Up                          Move selection up (wraps)
+Down                        Move selection down (wraps)
+Page Up, Left, Ctrl+B       Page up
+Page Down, Right, Ctrl+F    Page down
+Enter                       Confirm selection
+Escape, Ctrl+C              Cancel
+==========================  ==============================
+
+SettingsListWidget
+------------------
+
+Navigable settings panel with value cycling and submenus.
+
+**Keyboard:**
+
+========================  ==============================
+Key                       Action
+========================  ==============================
+Up                        Move selection up
+Down                      Move selection down
+Page Up                   Page up
+Page Down                 Page down
+Enter, Space              Activate (cycle value or open
+                          submenu)
+Right, Ctrl+F             Cycle value forward
+Left, Ctrl+B              Cycle value backward
+Escape, Ctrl+C            Cancel
+========================  ==============================
+
+CancellableLoaderWidget
+-----------------------
+
+Animated spinner that can be interrupted by the user.
+
+**Keyboard:**
+
+====================  ==============================
+Key                   Action
+====================  ==============================
+Escape, Ctrl+C        Cancel the operation
+====================  ==============================

--- a/tui/cheat_sheet.rst
+++ b/tui/cheat_sheet.rst
@@ -7,7 +7,7 @@ interactive features for every focusable widget.
 .. tip::
 
     **F6** / **Shift+F6** cycle focus between widgets in any
-    application. See :doc:`topics/focus` for details.
+    application. See :doc:`/tui/topics/focus` for details.
 
 Bracketed Paste
 ---------------
@@ -75,10 +75,8 @@ Shift+Enter                   Insert newline
 Escape, Ctrl+C                Cancel (or close autocomplete)
 Tab                           Trigger autocomplete
 Shift+Space                   Insert a space
-Up                            Move cursor up (or start of
-                              line when on first line)
-Down                          Move cursor down (or end of
-                              line when on last line)
+Up                            Move up (start of first line)
+Down                          Move down (end of last line)
 Left, Ctrl+B                  Move cursor left
 Right, Ctrl+F                 Move cursor right
 Alt+Left, Ctrl+Left, Alt+B    Move word left

--- a/tui/cheat_sheet.rst
+++ b/tui/cheat_sheet.rst
@@ -97,6 +97,7 @@ Ctrl+- (minus)                Undo
 Ctrl+Shift+Z                  Redo
 Ctrl+Y                        Yank (paste from kill ring)
 Alt+Y                         Yank pop (cycle kill ring)
+Ctrl+C                        Copy (left to the parent)
 ============================  ==============================
 
 **Paste:**

--- a/tui/cheat_sheet.rst
+++ b/tui/cheat_sheet.rst
@@ -62,8 +62,8 @@ Ctrl+K                        Delete to end of line
 EditorWidget
 ------------
 
-Multi-line text editor with word wrap, scrolling, undo/redo, kill
-ring and autocomplete.
+Multi-line text editor with word wrap, scrolling, undo/redo and a
+kill ring.
 
 **Keyboard:**
 
@@ -72,8 +72,7 @@ Key                           Action
 ============================  ==============================
 Enter                         Submit
 Shift+Enter                   Insert newline
-Escape, Ctrl+C                Cancel (or close autocomplete)
-Tab                           Trigger autocomplete
+Escape                        Cancel
 Shift+Space                   Insert a space
 Up                            Move up (start of first line)
 Down                          Move down (end of last line)
@@ -99,19 +98,6 @@ Ctrl+Shift+Z                  Redo
 Ctrl+Y                        Yank (paste from kill ring)
 Alt+Y                         Yank pop (cycle kill ring)
 ============================  ==============================
-
-**Autocomplete (when the dropdown is open):**
-
-====================  ==============================
-Key                   Action
-====================  ==============================
-Up                    Previous suggestion
-Down                  Next suggestion
-Page Up               Page up through suggestions
-Page Down             Page down through suggestions
-Enter                 Accept suggestion
-Escape                Close dropdown
-====================  ==============================
 
 **Paste:**
 

--- a/tui/cheat_sheet.rst
+++ b/tui/cheat_sheet.rst
@@ -170,3 +170,5 @@ Key                   Action
 ====================  ==============================
 Escape, Ctrl+C        Cancel the operation
 ====================  ==============================
+
+.. _`Bracketed paste`: https://en.wikipedia.org/wiki/Bracketed-paste

--- a/tui/cheat_sheet.rst
+++ b/tui/cheat_sheet.rst
@@ -145,19 +145,18 @@ Navigable settings panel with value cycling and submenus.
 
 **Keyboard:**
 
-========================  ==============================
+========================  =========================================
 Key                       Action
-========================  ==============================
+========================  =========================================
 Up                        Move selection up
 Down                      Move selection down
 Page Up                   Page up
 Page Down                 Page down
-Enter, Space              Activate (cycle value or open
-                          submenu)
+Enter, Space              Activate (cycle value or open submenu)
 Right, Ctrl+F             Cycle value forward
 Left, Ctrl+B              Cycle value backward
 Escape, Ctrl+C            Cancel
-========================  ==============================
+========================  =========================================
 
 CancellableLoaderWidget
 -----------------------

--- a/tui/getting_started.rst
+++ b/tui/getting_started.rst
@@ -13,14 +13,24 @@ one, add widgets and run the event loop::
     use Symfony\Component\Tui\Tui;
     use Symfony\Component\Tui\Widget\TextWidget;
 
+    use Symfony\Component\Tui\Event\InputEvent;
+    use Symfony\Component\Tui\Input\Keybindings;
+
     $tui = new Tui();
     $tui->add(new TextWidget('Hello, terminal!'));
-    $tui->quitOn('ctrl+c');
+
+    $keys = new Keybindings(['quit' => ['ctrl+c']]);
+    $tui->on(InputEvent::class, static function (InputEvent $event) use ($tui, $keys): void {
+        if ($keys->matches($event->getData(), 'quit')) {
+            $tui->stop();
+        }
+    });
+
     $tui->run();
 
 ``run()`` blocks until you call ``stop()``. The Tui does not
-impose any default quit shortcut; ``quitOn()`` registers key
-patterns that call ``stop()`` automatically.
+impose any default quit shortcut; listen for ``InputEvent`` to
+intercept keys and call ``stop()`` when appropriate.
 
 The Tui takes ownership of the terminal: it hides the cursor,
 enables raw mode and restores everything when it stops.
@@ -138,6 +148,8 @@ A Complete Example
 
 Putting it all together::
 
+    use Symfony\Component\Tui\Event\InputEvent;
+    use Symfony\Component\Tui\Input\Keybindings;
     use Symfony\Component\Tui\Style\Style;
     use Symfony\Component\Tui\Style\StyleSheet;
     use Symfony\Component\Tui\Tui;
@@ -147,7 +159,13 @@ Putting it all together::
     $tui = new Tui(new StyleSheet([
         ':root' => new Style(gap: 1),
     ]));
-    $tui->quitOn('ctrl+c');
+
+    $keys = new Keybindings(['quit' => ['ctrl+c']]);
+    $tui->on(InputEvent::class, static function (InputEvent $event) use ($tui, $keys): void {
+        if ($keys->matches($event->getData(), 'quit')) {
+            $tui->stop();
+        }
+    });
 
     $input = new InputWidget();
     $input->setPrompt('Name: ');

--- a/tui/getting_started.rst
+++ b/tui/getting_started.rst
@@ -8,9 +8,7 @@ Creating a Tui
 --------------
 
 The ``Tui`` class is the entry point for every application. Create
-one, add widgets and run the event loop:
-
-.. code-block:: php
+one, add widgets and run the event loop::
 
     use Symfony\Component\Tui\Tui;
     use Symfony\Component\Tui\Widget\TextWidget;
@@ -31,9 +29,7 @@ Building the Widget Tree
 ------------------------
 
 The Tui manages a root ``ContainerWidget`` internally. Use ``add()``,
-``remove()`` and ``clear()`` to build the widget tree:
-
-.. code-block:: php
+``remove()`` and ``clear()`` to build the widget tree::
 
     use Symfony\Component\Tui\Widget\ContainerWidget;
     use Symfony\Component\Tui\Widget\InputWidget;
@@ -50,9 +46,7 @@ The Tui manages a root ``ContainerWidget`` internally. Use ``add()``,
     // Remove all widgets
     $tui->clear();
 
-You can retrieve any widget by its id:
-
-.. code-block:: php
+You can retrieve any widget by its id::
 
     $input->setId('name-input');
     $tui->add($input);
@@ -65,22 +59,18 @@ Setting Focus
 Widgets that accept keyboard input (``InputWidget``,
 ``EditorWidget``, ``SelectListWidget``, etc.) implement
 ``FocusableInterface``. Only the focused widget receives keyboard
-events. Set focus with ``setFocus()``:
-
-.. code-block:: php
+events. Set focus with ``setFocus()``::
 
     $tui->setFocus($input);
 
 When your application has multiple focusable widgets, see
-:doc:`topics/focus` for how to manage focus cycling.
+:doc:`/tui/topics/focus` for how to manage focus cycling.
 
 Reacting to Events
 ------------------
 
 Widgets dispatch events when the user interacts with them. The most
-common pattern is to register a callback on the widget directly:
-
-.. code-block:: php
+common pattern is to register a callback on the widget directly::
 
     use Symfony\Component\Tui\Event\SubmitEvent;
 
@@ -94,16 +84,14 @@ common pattern is to register a callback on the widget directly:
     });
 
 For more advanced event handling (global listeners, filtering by
-source widget), see :doc:`topics/events`.
+source widget), see :doc:`/tui/topics/events`.
 
 Styling the Root Container
 --------------------------
 
 The root container is matched by the ``:root`` pseudo-class
 selector, like in CSS. Style it through a stylesheet to control
-the global layout:
-
-.. code-block:: php
+the global layout::
 
     use Symfony\Component\Tui\Style\Style;
     use Symfony\Component\Tui\Style\StyleSheet;
@@ -118,31 +106,25 @@ the global layout:
     $tui = new Tui($stylesheet);
 
 Pass the stylesheet to the constructor, or add it later with
-``addStyleSheet()``. See :doc:`style/index` for the full styling
-documentation.
+``addStyleSheet()``. See :doc:`/tui/style/index` for the full
+styling documentation.
 
 Stopping the Tui
 ----------------
 
 Call ``stop()`` to exit the event loop, restore the terminal and
-return control to the caller:
-
-.. code-block:: php
+return control to the caller::
 
     $tui->stop();
 
-This is typically done inside an event callback:
-
-.. code-block:: php
+This is typically done inside an event callback::
 
     $input->onSubmit(function () use ($tui) {
         $tui->stop();
     });
 
 After ``stop()`` returns, the terminal is back to its normal state.
-You can query widget values and write to the terminal:
-
-.. code-block:: php
+You can query widget values and write to the terminal::
 
     $tui->run();
 
@@ -154,9 +136,7 @@ You can query widget values and write to the terminal:
 A Complete Example
 ------------------
 
-Putting it all together:
-
-.. code-block:: php
+Putting it all together::
 
     use Symfony\Component\Tui\Style\Style;
     use Symfony\Component\Tui\Style\StyleSheet;
@@ -186,10 +166,10 @@ Putting it all together:
 Next Steps
 ----------
 
-* :doc:`widgets/index` for all available widgets.
-* :doc:`style/index` for colors, borders, padding and stylesheets.
-* :doc:`topics/focus` for focus cycling between multiple widgets.
-* :doc:`topics/events` for advanced event handling.
-* :doc:`topics/keybindings` for customizing keyboard shortcuts.
-* :doc:`topics/tick_loop` for async work and the tick callback.
-* :doc:`topics/templates` for declarative widget trees with Twig.
+* :doc:`/tui/widgets/index` for all available widgets.
+* :doc:`/tui/style/index` for colors, borders, padding and stylesheets.
+* :doc:`/tui/topics/focus` for focus cycling between multiple widgets.
+* :doc:`/tui/topics/events` for advanced event handling.
+* :doc:`/tui/topics/keybindings` for customizing keyboard shortcuts.
+* :doc:`/tui/topics/tick_loop` for async work and the tick callback.
+* :doc:`/tui/topics/templates` for declarative widget trees with Twig.

--- a/tui/getting_started.rst
+++ b/tui/getting_started.rst
@@ -172,4 +172,3 @@ Next Steps
 * :doc:`/tui/topics/events` for advanced event handling.
 * :doc:`/tui/topics/keybindings` for customizing keyboard shortcuts.
 * :doc:`/tui/topics/tick_loop` for async work and the tick callback.
-* :doc:`/tui/topics/templates` for declarative widget trees with Twig.

--- a/tui/getting_started.rst
+++ b/tui/getting_started.rst
@@ -10,11 +10,10 @@ Creating a Tui
 The ``Tui`` class is the entry point for every application. Create
 one, add widgets and run the event loop::
 
-    use Symfony\Component\Tui\Tui;
-    use Symfony\Component\Tui\Widget\TextWidget;
-
     use Symfony\Component\Tui\Event\InputEvent;
     use Symfony\Component\Tui\Input\Keybindings;
+    use Symfony\Component\Tui\Tui;
+    use Symfony\Component\Tui\Widget\TextWidget;
 
     $tui = new Tui();
     $tui->add(new TextWidget('Hello, terminal!'));

--- a/tui/getting_started.rst
+++ b/tui/getting_started.rst
@@ -99,8 +99,9 @@ source widget), see :doc:`topics/events`.
 Styling the Root Container
 --------------------------
 
-The root container has the style class ``root``. Style it through a
-stylesheet to control the global layout:
+The root container is matched by the ``:root`` pseudo-class
+selector, like in CSS. Style it through a stylesheet to control
+the global layout:
 
 .. code-block:: php
 
@@ -109,7 +110,7 @@ stylesheet to control the global layout:
     use Symfony\Component\Tui\Style\VerticalAlign;
 
     $stylesheet = new StyleSheet();
-    $stylesheet->addRule('.root', new Style(
+    $stylesheet->addRule(':root', new Style(
         gap: 1,
         verticalAlign: VerticalAlign::Bottom,
     ));
@@ -164,7 +165,7 @@ Putting it all together:
     use Symfony\Component\Tui\Widget\TextWidget;
 
     $tui = new Tui(new StyleSheet([
-        '.root' => new Style(gap: 1),
+        ':root' => new Style(gap: 1),
     ]));
     $tui->quitOn('ctrl+c');
 

--- a/tui/getting_started.rst
+++ b/tui/getting_started.rst
@@ -1,0 +1,194 @@
+Getting Started
+===============
+
+This guide walks you through building your first terminal UI
+application with Tui.
+
+Creating a Tui
+--------------
+
+The ``Tui`` class is the entry point for every application. Create
+one, add widgets and run the event loop:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Tui;
+    use Symfony\Component\Tui\Widget\TextWidget;
+
+    $tui = new Tui();
+    $tui->add(new TextWidget('Hello, terminal!'));
+    $tui->quitOn('ctrl+c');
+    $tui->run();
+
+``run()`` blocks until you call ``stop()``. The Tui does not
+impose any default quit shortcut; ``quitOn()`` registers key
+patterns that call ``stop()`` automatically.
+
+The Tui takes ownership of the terminal: it hides the cursor,
+enables raw mode and restores everything when it stops.
+
+Building the Widget Tree
+------------------------
+
+The Tui manages a root ``ContainerWidget`` internally. Use ``add()``,
+``remove()`` and ``clear()`` to build the widget tree:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Widget\ContainerWidget;
+    use Symfony\Component\Tui\Widget\InputWidget;
+    use Symfony\Component\Tui\Widget\TextWidget;
+
+    $tui->add(new TextWidget('Enter your name:'));
+
+    $input = new InputWidget();
+    $tui->add($input);
+
+    // Remove a widget
+    $tui->remove($input);
+
+    // Remove all widgets
+    $tui->clear();
+
+You can retrieve any widget by its id:
+
+.. code-block:: php
+
+    $input->setId('name-input');
+    $tui->add($input);
+
+    $widget = $tui->getById('name-input');
+
+Setting Focus
+-------------
+
+Widgets that accept keyboard input (``InputWidget``,
+``EditorWidget``, ``SelectListWidget``, etc.) implement
+``FocusableInterface``. Only the focused widget receives keyboard
+events. Set focus with ``setFocus()``:
+
+.. code-block:: php
+
+    $tui->setFocus($input);
+
+When your application has multiple focusable widgets, see
+:doc:`topics/focus` for how to manage focus cycling.
+
+Reacting to Events
+------------------
+
+Widgets dispatch events when the user interacts with them. The most
+common pattern is to register a callback on the widget directly:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Event\SubmitEvent;
+
+    $input->onSubmit(function (SubmitEvent $event) {
+        $value = $event->getValue();
+        // process the submitted text
+    });
+
+    $input->onCancel(function () use ($tui) {
+        $tui->stop();
+    });
+
+For more advanced event handling (global listeners, filtering by
+source widget), see :doc:`topics/events`.
+
+Styling the Root Container
+--------------------------
+
+The root container has the style class ``root``. Style it through a
+stylesheet to control the global layout:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Style\Style;
+    use Symfony\Component\Tui\Style\StyleSheet;
+    use Symfony\Component\Tui\Style\VerticalAlign;
+
+    $stylesheet = new StyleSheet();
+    $stylesheet->addRule('.root', new Style(
+        gap: 1,
+        verticalAlign: VerticalAlign::Bottom,
+    ));
+
+    $tui = new Tui($stylesheet);
+
+Pass the stylesheet to the constructor, or add it later with
+``addStyleSheet()``. See :doc:`style/index` for the full styling
+documentation.
+
+Stopping the Tui
+----------------
+
+Call ``stop()`` to exit the event loop, restore the terminal and
+return control to the caller:
+
+.. code-block:: php
+
+    $tui->stop();
+
+This is typically done inside an event callback:
+
+.. code-block:: php
+
+    $input->onSubmit(function () use ($tui) {
+        $tui->stop();
+    });
+
+After ``stop()`` returns, the terminal is back to its normal state.
+You can query widget values and write to the terminal:
+
+.. code-block:: php
+
+    $tui->run();
+
+    // After the loop exits
+    if ($input->wasSubmitted()) {
+        echo 'You entered: '.$input->getValue()."\n";
+    }
+
+A Complete Example
+------------------
+
+Putting it all together:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Style\Style;
+    use Symfony\Component\Tui\Style\StyleSheet;
+    use Symfony\Component\Tui\Tui;
+    use Symfony\Component\Tui\Widget\InputWidget;
+    use Symfony\Component\Tui\Widget\TextWidget;
+
+    $tui = new Tui(new StyleSheet([
+        '.root' => new Style(gap: 1),
+    ]));
+    $tui->quitOn('ctrl+c');
+
+    $input = new InputWidget();
+    $input->setPrompt('Name: ');
+    $input->onSubmit(fn () => $tui->stop());
+
+    $tui->add(new TextWidget('Enter your name and press Enter:'));
+    $tui->add($input);
+    $tui->setFocus($input);
+
+    $tui->run();
+
+    if ($input->wasSubmitted()) {
+        echo 'Hello, '.$input->getValue()."!\n";
+    }
+
+Next Steps
+----------
+
+* :doc:`widgets/index` for all available widgets.
+* :doc:`style/index` for colors, borders, padding and stylesheets.
+* :doc:`topics/focus` for focus cycling between multiple widgets.
+* :doc:`topics/events` for advanced event handling.
+* :doc:`topics/keybindings` for customizing keyboard shortcuts.
+* :doc:`topics/tick_loop` for async work and the tick callback.
+* :doc:`topics/templates` for declarative widget trees with Twig.

--- a/tui/getting_started.rst
+++ b/tui/getting_started.rst
@@ -20,7 +20,7 @@ one, add widgets and run the event loop::
     $tui->add(new TextWidget('Hello, terminal!'));
 
     $keys = new Keybindings(['quit' => ['ctrl+c']]);
-    $tui->on(InputEvent::class, static function (InputEvent $event) use ($tui, $keys): void {
+    $tui->addListener(static function (InputEvent $event) use ($tui, $keys): void {
         if ($keys->matches($event->getData(), 'quit')) {
             $tui->stop();
         }
@@ -161,7 +161,7 @@ Putting it all together::
     ]));
 
     $keys = new Keybindings(['quit' => ['ctrl+c']]);
-    $tui->on(InputEvent::class, static function (InputEvent $event) use ($tui, $keys): void {
+    $tui->addListener(static function (InputEvent $event) use ($tui, $keys): void {
         if ($keys->matches($event->getData(), 'quit')) {
             $tui->stop();
         }

--- a/tui/index.rst
+++ b/tui/index.rst
@@ -1,0 +1,16 @@
+Tui
+===
+
+Tui is a PHP library for building rich, interactive terminal user
+interfaces. It provides a widget toolkit, a CSS-like styling system
+and an event-driven architecture.
+
+.. toctree::
+    :maxdepth: 2
+
+    getting_started
+    widgets/index
+    style/index
+    topics/index
+    integrations/index
+    cheat_sheet

--- a/tui/index.rst
+++ b/tui/index.rst
@@ -5,6 +5,25 @@ Tui is a PHP library for building rich, interactive terminal user
 interfaces. It provides a widget toolkit, a CSS-like styling system
 and an event-driven architecture.
 
+.. warning::
+
+    The Tui component is **experimental**: its API and behavior may still
+    change, sometimes drastically.
+
+Installation
+------------
+
+In applications using :ref:`Symfony Flex <symfony-flex>`, run this command
+to install the Tui component before using it:
+
+.. code-block:: terminal
+
+    $ composer require symfony/tui
+
+The component requires PHP 8.4.1 or later.
+
+.. include:: /components/require_autoload.rst.inc
+
 .. toctree::
     :maxdepth: 2
 

--- a/tui/integrations/index.rst
+++ b/tui/integrations/index.rst
@@ -1,0 +1,10 @@
+Integrations
+============
+
+Guides for using Tui with other libraries and frameworks.
+
+.. toctree::
+    :maxdepth: 1
+
+    symfony_console
+    revolt

--- a/tui/integrations/revolt.rst
+++ b/tui/integrations/revolt.rst
@@ -1,0 +1,106 @@
+Revolt and Amp
+==============
+
+Tui runs on the Revolt event loop. This means all I/O performed
+while the Tui is running must be non-blocking. Blocking calls
+(``file_get_contents()``, ``proc_open()``, ``sleep()``, etc.)
+freeze the entire UI: no rendering, no input handling, no
+animations.
+
+Why Non-Blocking Matters
+------------------------
+
+The Tui shares a single thread with your application code. The
+event loop alternates between reading terminal input, running your
+tick callback and rendering the screen. A blocking call stalls the
+entire cycle: the screen stops updating, keyboard input queues up
+and animations freeze until the call returns.
+
+Use Amp Libraries
+-----------------
+
+The Amp ecosystem provides non-blocking replacements for common
+blocking operations. Since Amp is built on Revolt (the same event
+loop Tui uses), they integrate without any glue code.
+
+**Processes**: use ``amphp/process`` instead of ``proc_open()`` or
+Symfony Process:
+
+.. code-block:: php
+
+    use Amp\Process\Process;
+
+    $process = Process::start('ls -la');
+    $stdout = $process->getStdout()->read();
+
+**HTTP**: use Symfony HttpClient with its Amp integration
+(``symfony/http-client`` + ``amphp/http-client``):
+
+.. code-block:: php
+
+    use Symfony\Component\HttpClient\AmpHttpClient;
+
+    $client = new AmpHttpClient();
+    $response = $client->request('GET', 'https://example.com');
+    $body = $response->getContent();
+
+**Timers and delays**: use ``Amp\delay()`` instead of ``sleep()``:
+
+.. code-block:: php
+
+    \Amp\delay(2); // yields to the event loop for 2 seconds
+
+Running Async Work
+------------------
+
+Use ``Amp\async()`` to run work in a fiber. The fiber yields to the
+event loop whenever it performs I/O, keeping the UI responsive:
+
+.. code-block:: php
+
+    use Amp\Process\Process;
+    use function Amp\async;
+
+    $future = async(function () {
+        $process = Process::start('composer install');
+        $output = $process->getStdout()->read();
+        $exitCode = $process->join();
+
+        return $output;
+    });
+
+Check whether the future is complete in your tick callback:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Event\TickEvent;
+
+    $tui->onTick(function (TickEvent $event) use ($future, $tui) {
+        if ($future->isComplete()) {
+            $result = $future->await();
+            $tui->stop();
+        }
+
+        return !$future->isComplete();
+    });
+
+The tick callback returns ``true`` while work is in progress (the
+Tui ticks at high frequency) and ``false`` when idle. See
+:doc:`/topics/tick_loop` for the full tick loop API.
+
+Common Pitfalls
+---------------
+
+**Symfony Process is blocking.** ``Process::run()`` and
+``Process::wait()`` block the event loop. Use ``amphp/process``
+instead.
+
+**PDO and database queries are blocking.** Use an async database
+library or run queries inside ``Amp\async()`` with
+``Amp\Parallel\Worker`` if you need long-running queries.
+
+**``sleep()`` blocks.** Use ``\Amp\delay()`` for non-blocking
+delays.
+
+**``file_get_contents()`` with URLs blocks.** Use
+``AmpHttpClient`` for HTTP requests.

--- a/tui/integrations/revolt.rst
+++ b/tui/integrations/revolt.rst
@@ -24,9 +24,7 @@ blocking operations. Since Amp is built on Revolt (the same event
 loop Tui uses), they integrate without any glue code.
 
 **Processes**: use ``amphp/process`` instead of ``proc_open()`` or
-Symfony Process:
-
-.. code-block:: php
+Symfony Process::
 
     use Amp\Process\Process;
 
@@ -34,9 +32,7 @@ Symfony Process:
     $stdout = $process->getStdout()->read();
 
 **HTTP**: use Symfony HttpClient with its Amp integration
-(``symfony/http-client`` + ``amphp/http-client``):
-
-.. code-block:: php
+(``symfony/http-client`` + ``amphp/http-client``)::
 
     use Symfony\Component\HttpClient\AmpHttpClient;
 
@@ -44,9 +40,7 @@ Symfony Process:
     $response = $client->request('GET', 'https://example.com');
     $body = $response->getContent();
 
-**Timers and delays**: use ``Amp\delay()`` instead of ``sleep()``:
-
-.. code-block:: php
+**Timers and delays**: use ``Amp\delay()`` instead of ``sleep()``::
 
     \Amp\delay(2); // yields to the event loop for 2 seconds
 
@@ -54,9 +48,7 @@ Running Async Work
 ------------------
 
 Use ``Amp\async()`` to run work in a fiber. The fiber yields to the
-event loop whenever it performs I/O, keeping the UI responsive:
-
-.. code-block:: php
+event loop whenever it performs I/O, keeping the UI responsive::
 
     use Amp\Process\Process;
     use function Amp\async;
@@ -69,9 +61,7 @@ event loop whenever it performs I/O, keeping the UI responsive:
         return $output;
     });
 
-Check whether the future is complete in your tick callback:
-
-.. code-block:: php
+Check whether the future is complete in your tick callback::
 
     use Symfony\Component\Tui\Event\TickEvent;
 
@@ -86,7 +76,7 @@ Check whether the future is complete in your tick callback:
 
 The tick callback returns ``true`` while work is in progress (the
 Tui ticks at high frequency) and ``false`` when idle. See
-:doc:`/topics/tick_loop` for the full tick loop API.
+:doc:`/tui/topics/tick_loop` for the full tick loop API.
 
 Common Pitfalls
 ---------------

--- a/tui/integrations/revolt.rst
+++ b/tui/integrations/revolt.rst
@@ -23,8 +23,8 @@ The Amp ecosystem provides non-blocking replacements for common
 blocking operations. Since Amp is built on Revolt (the same event
 loop Tui uses), they integrate without any glue code.
 
-**Processes**: use ``amphp/process`` instead of ``proc_open()`` or
-Symfony Process::
+**Processes**: use ``amphp/process`` instead of ``proc_open()`` and
+instead of Symfony Process::
 
     use Amp\Process\Process;
 

--- a/tui/integrations/symfony_console.rst
+++ b/tui/integrations/symfony_console.rst
@@ -15,6 +15,8 @@ Basic Command
     use Symfony\Component\Console\Command\Command;
     use Symfony\Component\Console\Input\InputInterface;
     use Symfony\Component\Console\Output\OutputInterface;
+    use Symfony\Component\Tui\Event\InputEvent;
+    use Symfony\Component\Tui\Input\Keybindings;
     use Symfony\Component\Tui\Tui;
     use Symfony\Component\Tui\Widget\EditorWidget;
     use Symfony\Component\Tui\Widget\TextWidget;
@@ -27,7 +29,13 @@ Basic Command
             OutputInterface $output,
         ): int {
             $tui = new Tui();
-            $tui->quitOn('ctrl+c');
+
+            $keys = new Keybindings(['quit' => ['ctrl+c']]);
+            $tui->on(InputEvent::class, static function (InputEvent $event) use ($tui, $keys): void {
+                if ($keys->matches($event->getData(), 'quit')) {
+                    $tui->stop();
+                }
+            });
 
             $editor = new EditorWidget();
             $editor->onSubmit(fn () => $tui->stop());
@@ -79,7 +87,13 @@ configure widgets::
         $name = $input->getArgument('name');
 
         $tui = new Tui();
-        $tui->quitOn('ctrl+c');
+
+        $keys = new Keybindings(['quit' => ['ctrl+c']]);
+        $tui->on(InputEvent::class, static function (InputEvent $event) use ($tui, $keys): void {
+            if ($keys->matches($event->getData(), 'quit')) {
+                $tui->stop();
+            }
+        });
 
         $editor = new EditorWidget();
         $editor->setText($name);
@@ -112,5 +126,6 @@ Handling Signals
 
 Symfony Console registers signal handlers for ``SIGINT`` and
 ``SIGTERM``. The Tui uses its own terminal handling, so signal
-delivery works as expected. ``quitOn('ctrl+c')`` intercepts the
-Ctrl+C key press at the input level, before it becomes a signal.
+delivery works as expected. Intercepting Ctrl+C via an ``InputEvent``
+listener catches the key press at the input level, before it becomes
+a signal.

--- a/tui/integrations/symfony_console.rst
+++ b/tui/integrations/symfony_console.rst
@@ -55,9 +55,7 @@ Output After the Tui Stops
 --------------------------
 
 Query widget state after ``run()`` returns to produce Console
-output:
-
-.. code-block:: php
+output::
 
     $tui->run();
 
@@ -72,9 +70,7 @@ Using Console Input
 -------------------
 
 Read Console arguments and options before starting the Tui to
-configure widgets:
-
-.. code-block:: php
+configure widgets::
 
     protected function execute(
         InputInterface $input,
@@ -94,9 +90,7 @@ configure widgets:
 Stylesheets
 -----------
 
-Pass a stylesheet to the Tui constructor to theme your command:
-
-.. code-block:: php
+Pass a stylesheet to the Tui constructor to theme your command::
 
     use Symfony\Component\Tui\Style\Style;
     use Symfony\Component\Tui\Style\StyleSheet;
@@ -111,7 +105,7 @@ Pass a stylesheet to the Tui constructor to theme your command:
 
     $tui = new Tui($stylesheet);
 
-See :doc:`/style/index` for the full styling documentation.
+See :doc:`/tui/style/index` for the full styling documentation.
 
 Handling Signals
 ----------------

--- a/tui/integrations/symfony_console.rst
+++ b/tui/integrations/symfony_console.rst
@@ -1,0 +1,122 @@
+Symfony Console
+===============
+
+Tui integrates naturally with Symfony Console. Create a Tui inside
+a command's ``execute()`` method, run it and return the exit code.
+
+Basic Command
+-------------
+
+.. code-block:: php
+
+    namespace App\Command;
+
+    use Symfony\Component\Console\Attribute\AsCommand;
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Input\InputInterface;
+    use Symfony\Component\Console\Output\OutputInterface;
+    use Symfony\Component\Tui\Tui;
+    use Symfony\Component\Tui\Widget\EditorWidget;
+    use Symfony\Component\Tui\Widget\TextWidget;
+
+    #[AsCommand(name: 'app:editor')]
+    final class EditorCommand extends Command
+    {
+        protected function execute(
+            InputInterface $input,
+            OutputInterface $output,
+        ): int {
+            $tui = new Tui();
+            $tui->quitOn('ctrl+c');
+
+            $editor = new EditorWidget();
+            $editor->onSubmit(fn () => $tui->stop());
+
+            $tui->add(new TextWidget('Type your message:'));
+            $tui->add($editor);
+            $tui->setFocus($editor);
+
+            $tui->run();
+
+            if ($editor->wasSubmitted()) {
+                $output->writeln('You wrote:');
+                $output->writeln($editor->getText());
+            }
+
+            return Command::SUCCESS;
+        }
+    }
+
+The Tui takes full control of the terminal while it runs. When
+``run()`` returns, the terminal is restored and you can use the
+Console ``$output`` object normally.
+
+Output After the Tui Stops
+--------------------------
+
+Query widget state after ``run()`` returns to produce Console
+output:
+
+.. code-block:: php
+
+    $tui->run();
+
+    $selected = $list->getSelectedItem();
+    if (null !== $selected) {
+        $output->writeln('Selected: '.$selected['label']);
+    }
+
+    return Command::SUCCESS;
+
+Using Console Input
+-------------------
+
+Read Console arguments and options before starting the Tui to
+configure widgets:
+
+.. code-block:: php
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $name = $input->getArgument('name');
+
+        $tui = new Tui();
+        $tui->quitOn('ctrl+c');
+
+        $editor = new EditorWidget();
+        $editor->setText($name);
+
+        // ...
+    }
+
+Stylesheets
+-----------
+
+Pass a stylesheet to the Tui constructor to theme your command:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Style\Style;
+    use Symfony\Component\Tui\Style\StyleSheet;
+    use Symfony\Component\Tui\Style\VerticalAlign;
+
+    $stylesheet = new StyleSheet([
+        '.root' => new Style(
+            gap: 1,
+            verticalAlign: VerticalAlign::Bottom,
+        ),
+    ]);
+
+    $tui = new Tui($stylesheet);
+
+See :doc:`/style/index` for the full styling documentation.
+
+Handling Signals
+----------------
+
+Symfony Console registers signal handlers for ``SIGINT`` and
+``SIGTERM``. The Tui uses its own terminal handling, so signal
+delivery works as expected. ``quitOn('ctrl+c')`` intercepts the
+Ctrl+C key press at the input level, before it becomes a signal.

--- a/tui/integrations/symfony_console.rst
+++ b/tui/integrations/symfony_console.rst
@@ -31,11 +31,13 @@ Basic Command
             $tui = new Tui();
 
             $keys = new Keybindings(['quit' => ['ctrl+c']]);
-            $tui->on(InputEvent::class, static function (InputEvent $event) use ($tui, $keys): void {
-                if ($keys->matches($event->getData(), 'quit')) {
-                    $tui->stop();
+            $tui->addListener(
+                static function (InputEvent $event) use ($tui, $keys): void {
+                    if ($keys->matches($event->getData(), 'quit')) {
+                        $tui->stop();
+                    }
                 }
-            });
+            );
 
             $editor = new EditorWidget();
             $editor->onSubmit(fn () => $tui->stop());
@@ -89,11 +91,13 @@ configure widgets::
         $tui = new Tui();
 
         $keys = new Keybindings(['quit' => ['ctrl+c']]);
-        $tui->on(InputEvent::class, static function (InputEvent $event) use ($tui, $keys): void {
-            if ($keys->matches($event->getData(), 'quit')) {
-                $tui->stop();
+        $tui->addListener(
+            static function (InputEvent $event) use ($tui, $keys): void {
+                if ($keys->matches($event->getData(), 'quit')) {
+                    $tui->stop();
+                }
             }
-        });
+        );
 
         $editor = new EditorWidget();
         $editor->setText($name);

--- a/tui/integrations/symfony_console.rst
+++ b/tui/integrations/symfony_console.rst
@@ -103,7 +103,7 @@ Pass a stylesheet to the Tui constructor to theme your command:
     use Symfony\Component\Tui\Style\VerticalAlign;
 
     $stylesheet = new StyleSheet([
-        '.root' => new Style(
+        ':root' => new Style(
             gap: 1,
             verticalAlign: VerticalAlign::Bottom,
         ),

--- a/tui/style/index.rst
+++ b/tui/style/index.rst
@@ -10,13 +10,13 @@ There are three ways to style a widget:
 
 1. **Inline style**: call ``setStyle()`` on a widget instance. This
    has the highest priority and overrides everything else
-   (see :doc:`style`).
+   (see :doc:`/tui/style/style`).
 2. **Stylesheet rules**: add CSS-like rules that match widgets by
    class name, FQCN, state or sub-element
-   (see :doc:`stylesheets`).
+   (see :doc:`/tui/style/stylesheets`).
 3. **Utility classes**: add Tailwind-like class names to widgets
    for quick, composable styling without writing stylesheet rules
-   (see :doc:`tailwind`).
+   (see :doc:`/tui/style/tailwind`).
 
 .. toctree::
     :maxdepth: 1

--- a/tui/style/index.rst
+++ b/tui/style/index.rst
@@ -1,0 +1,26 @@
+Styling
+=======
+
+The Tui styling system controls how widgets look and how they are laid
+out. It draws heavily from CSS concepts: styles are immutable value
+objects, stylesheets map selectors to styles and a cascade determines
+which rules win when multiple selectors match.
+
+There are three ways to style a widget:
+
+1. **Inline style**: call ``setStyle()`` on a widget instance. This
+   has the highest priority and overrides everything else
+   (see :doc:`style`).
+2. **Stylesheet rules**: add CSS-like rules that match widgets by
+   class name, FQCN, state or sub-element
+   (see :doc:`stylesheets`).
+3. **Utility classes**: add Tailwind-like class names to widgets
+   for quick, composable styling without writing stylesheet rules
+   (see :doc:`tailwind`).
+
+.. toctree::
+    :maxdepth: 1
+
+    style
+    stylesheets
+    tailwind

--- a/tui/style/style.rst
+++ b/tui/style/style.rst
@@ -261,7 +261,7 @@ Layout Properties
 -----------------
 
 These properties control how containers arrange their children. See
-:doc:`/widgets/container` for usage examples.
+:doc:`/tui/widgets/container` for usage examples.
 
 =====================  ===================================================
 Property               Description

--- a/tui/style/style.rst
+++ b/tui/style/style.rst
@@ -143,7 +143,7 @@ Three shortcuts simplify common operations:
 * ``scale($percentage)``: Positive values darken, negative values
   lighten.
 
-.. code-block:: php
+::
 
     $lighter = Color::named('blue')->tint(40);
     $darker = Color::named('blue')->shade(40);
@@ -263,23 +263,19 @@ Layout Properties
 These properties control how containers arrange their children. See
 :doc:`/widgets/container` for usage examples.
 
-=====================  ==========================================
+=====================  ===================================================
 Property               Description
-=====================  ==========================================
+=====================  ===================================================
 ``direction``          ``Vertical`` or ``Horizontal`` layout
 ``gap``                Spacing between children (rows or columns)
 ``hidden``             Hide the widget (like CSS ``display: none``)
 ``maxColumns``         Cap the widget's available width
-``align``              Horizontal alignment (``Left``, ``Center``,
-                       ``Right``)
-``verticalAlign``      Vertical alignment (``Top``, ``Center``,
-                       ``Bottom``)
-``flex``               Flex grow weight for horizontal layouts
-                       (``0`` = intrinsic width, ``1+`` =
-                       proportional)
-=====================  ==========================================
+``align``              Horizontal: ``Left``, ``Center``, ``Right``
+``verticalAlign``      Vertical: ``Top``, ``Center``, ``Bottom``
+``flex``               Flex grow (``0`` = intrinsic, ``1+`` = proportional)
+=====================  ===================================================
 
-.. code-block:: php
+::
 
     use Symfony\Component\Tui\Style\Direction;
 
@@ -292,15 +288,13 @@ Property               Description
 Content Properties
 ------------------
 
-=====================  ==========================================
+=====================  ===================================================
 Property               Description
-=====================  ==========================================
-``font``               FIGlet font name (``big``, ``small``,
-                       ``slant``, ``standard``, ``mini``)
-``textAlign``          Text alignment within the content area
-                       (``Left``, ``Center``, ``Right``)
+=====================  ===================================================
+``font``               FIGlet font name (e.g. ``big``, ``slant``)
+``textAlign``          Text alignment (``Left``, ``Center``, ``Right``)
 ``cursorShape``        Cursor shape for input widgets
-=====================  ==========================================
+=====================  ===================================================
 
 Merging Styles
 --------------

--- a/tui/style/style.rst
+++ b/tui/style/style.rst
@@ -1,0 +1,315 @@
+Style
+=====
+
+``Style`` is an immutable value object that holds all visual and layout
+properties for a widget. Every ``with*()`` method returns a new
+instance, so styles can be safely shared and reused.
+
+When to Use
+-----------
+
+Use ``Style`` when you need to configure the appearance of a widget:
+colors, text decoration, padding, borders, layout direction, alignment
+and more. You can pass it to a widget directly, to a stylesheet rule
+or combine several styles through the cascade.
+
+Creating a Style
+----------------
+
+Pass properties to the constructor::
+
+    use Symfony\Component\Tui\Style\Padding;
+    use Symfony\Component\Tui\Style\Style;
+
+    $style = new Style(
+        bold: true,
+        color: 'cyan',
+        padding: new Padding(1, 2, 1, 2),
+    );
+
+Or build one incrementally with the fluent ``with*()`` API::
+
+    $style = (new Style())
+        ->withColor('cyan')
+        ->withBold()
+        ->withPadding([1, 2]);
+
+Both approaches produce the same result. The constructor form is more
+compact; the fluent form is easier to read when you start from an
+existing style.
+
+Applying a Style to a Widget
+----------------------------
+
+Set an inline style directly on a widget::
+
+    $widget->setStyle(new Style(bold: true, color: 'red'));
+
+This inline style has the highest priority in the cascade and
+overrides all stylesheet rules.
+
+Nullable Properties and Inheritance
+-----------------------------------
+
+Every property on ``Style`` is nullable. A ``null`` value means
+"not set"; the property will be inherited from lower-priority rules
+during the cascade. An explicit value (even ``false`` or ``0``)
+means "set" and overrides inheritance.
+
+This distinction matters when composing styles::
+
+    // Only sets color; bold, padding, etc. will inherit
+    $style = new Style(color: 'red');
+
+    // Explicitly disables bold, overriding a parent rule
+    $style = new Style(bold: false);
+
+    // Explicit zero padding, overriding inherited padding
+    $style = Style::padding([0]);
+
+Text Formatting Properties
+--------------------------
+
+==================  ====================================
+Property            Description
+==================  ====================================
+``color``           Foreground color
+``background``      Background color
+``bold``            Bold text
+``dim``             Dim/faint text
+``italic``          Italic text
+``underline``       Underlined text
+``strikethrough``   Strikethrough text
+``reverse``         Reverse video (swap fg/bg)
+==================  ====================================
+
+.. code-block:: php
+
+    $style = (new Style())
+        ->withColor('#ff5500')
+        ->withBackground('blue')
+        ->withBold()
+        ->withItalic();
+
+Colors
+------
+
+The ``Color`` class represents a terminal color. It supports three
+formats:
+
+**Named ANSI colors**, the 16 standard terminal colors::
+
+    use Symfony\Component\Tui\Style\Color;
+
+    $red = Color::named('red');
+    $gray = Color::named('gray');
+
+Available names: ``black``, ``red``, ``green``, ``yellow``, ``blue``,
+``magenta``, ``cyan``, ``white``, ``default``, ``bright_black``,
+``bright_red``, ``bright_green``, ``bright_yellow``, ``bright_blue``,
+``bright_magenta``, ``bright_cyan``, ``bright_white``, ``gray``
+(alias for ``bright_black``).
+
+**256-color palette**, integers from 0 to 255::
+
+    $color = Color::palette(202); // orange
+
+**True color RGB**, hex strings or explicit RGB values::
+
+    $color = Color::hex('#ff5500');
+    $color = Color::hex('#f50');   // short form
+    $color = Color::rgb(255, 85, 0);
+
+All ``Style`` methods that accept a color (``withColor()``,
+``withBackground()``, ``withBorderColor()``) use ``Color::from()``
+internally, so you can pass strings and integers directly::
+
+    $style = (new Style())
+        ->withColor('cyan')
+        ->withBackground('#1e1e2e');
+
+Mixing Colors
+~~~~~~~~~~~~~
+
+``mix()`` blends two colors by a percentage. At 0% the result is the
+original color; at 100% it is the other color::
+
+    $blended = Color::hex('#ff0000')->mix('#0000ff', 50);
+
+Three shortcuts simplify common operations:
+
+* ``tint($percentage)``: Lighten toward white.
+* ``shade($percentage)``: Darken toward black.
+* ``scale($percentage)``: Positive values darken, negative values
+  lighten.
+
+.. code-block:: php
+
+    $lighter = Color::named('blue')->tint(40);
+    $darker = Color::named('blue')->shade(40);
+
+These methods are used internally by the Tailwind shade system
+(e.g. ``text-blue-300`` tints the base blue by 40%).
+
+Padding
+-------
+
+``Padding`` adds empty space between a widget's border (or edge) and
+its content. Shorthand arrays work like CSS: 1, 2, 3 or 4 values::
+
+    use Symfony\Component\Tui\Style\Padding;
+
+    Padding::from([1]);           // all sides = 1
+    Padding::from([1, 2]);        // top/bottom = 1, left/right = 2
+    Padding::from([1, 2, 3]);     // top = 1, left/right = 2, bottom = 3
+    Padding::from([1, 2, 3, 4]); // top, right, bottom, left
+
+Named constructors for common patterns::
+
+    Padding::all(2);     // all sides = 2
+    Padding::xy(3, 1);   // left/right = 3, top/bottom = 1
+
+Apply padding through a style::
+
+    $widget->setStyle(new Style(padding: Padding::xy(2, 1)));
+
+    // Or with the shorthand static constructor
+    $widget->setStyle(Style::padding([1, 2]));
+
+Borders
+-------
+
+``Border`` draws a visual frame around the widget. Like padding, it
+accepts 1–4 values for per-side widths::
+
+    use Symfony\Component\Tui\Style\Border;
+
+    Border::from([1]);             // all sides = 1
+    Border::all(1);                // all sides = 1
+    Border::xy(1, 0);             // left/right = 1, top/bottom = 0
+    Border::from([1, 0, 1, 0]);   // top and bottom only
+
+Apply a border through a style::
+
+    $widget->setStyle(Style::border([1]));
+
+    // With pattern and color
+    $widget->setStyle(Style::border([1], 'rounded', 'cyan'));
+
+Border Patterns
+~~~~~~~~~~~~~~~
+
+The border pattern controls the characters used to draw the frame.
+Ten built-in patterns are available:
+
+==================  =======================================
+Pattern             Description
+==================  =======================================
+``normal``          Standard box-drawing (``┌─┐│└─┘``)
+``rounded``         Rounded corners (``╭─╮│╰─╯``)
+``double``          Double-line box (``╔═╗║╚═╝``)
+``tall``            Block-style vertical emphasis
+``wide``            Block-style horizontal emphasis
+``tall-medium``     ~4px balanced border (tall corners)
+``wide-medium``     ~4px balanced border (wide corners)
+``tall-large``      ~8px balanced border (tall corners)
+``wide-large``      ~8px balanced border (wide corners)
+==================  =======================================
+
+Set a pattern when creating the border::
+
+    $border = Border::all(1, 'rounded');
+    $border = Border::all(1, BorderPattern::rounded());
+
+Or change the pattern on an existing border::
+
+    $border = $border->withPattern('double');
+
+Border Color
+~~~~~~~~~~~~
+
+Set a color for the border characters::
+
+    $border = Border::all(1, 'rounded', 'cyan');
+
+    // Or change the color on an existing border
+    $border = $border->withColor('#505050');
+
+The border color can also be set through the ``Style`` fluent API::
+
+    $style = (new Style())
+        ->withBorder(Border::all(1, 'rounded'))
+        ->withBorderColor('cyan');
+
+Combining Padding and Borders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Padding and borders compose naturally. The border wraps the padded
+content area::
+
+    $style = new Style(
+        padding: Padding::xy(2, 1),
+        border: Border::all(1, 'rounded', 'gray'),
+        background: '#1e1e2e',
+    );
+    $widget->setStyle($style);
+
+The rendering order from outside to inside is: border → padding →
+content.
+
+Layout Properties
+-----------------
+
+These properties control how containers arrange their children. See
+:doc:`/widgets/container` for usage examples.
+
+=====================  ==========================================
+Property               Description
+=====================  ==========================================
+``direction``          ``Vertical`` or ``Horizontal`` layout
+``gap``                Spacing between children (rows or columns)
+``hidden``             Hide the widget (like CSS ``display: none``)
+``maxColumns``         Cap the widget's available width
+``align``              Horizontal alignment (``Left``, ``Center``,
+                       ``Right``)
+``verticalAlign``      Vertical alignment (``Top``, ``Center``,
+                       ``Bottom``)
+``flex``               Flex grow weight for horizontal layouts
+                       (``0`` = intrinsic width, ``1+`` =
+                       proportional)
+=====================  ==========================================
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Style\Direction;
+
+    $style = new Style(
+        direction: Direction::Horizontal,
+        gap: 2,
+        padding: Padding::xy(2, 1),
+    );
+
+Content Properties
+------------------
+
+=====================  ==========================================
+Property               Description
+=====================  ==========================================
+``font``               FIGlet font name (``big``, ``small``,
+                       ``slant``, ``standard``, ``mini``)
+``textAlign``          Text alignment within the content area
+                       (``Left``, ``Center``, ``Right``)
+``cursorShape``        Cursor shape for input widgets
+=====================  ==========================================
+
+Merging Styles
+--------------
+
+When you need to combine multiple styles programmatically (outside
+the stylesheet cascade), use ``Style::mergeAll()``::
+
+    $merged = Style::mergeAll([$base, $theme, $override]);
+
+Later styles override earlier ones for non-null properties. This
+allocates a single ``Style`` object regardless of how many inputs
+you pass.

--- a/tui/style/style.rst
+++ b/tui/style/style.rst
@@ -143,7 +143,7 @@ Three shortcuts simplify common operations:
 * ``scale($percentage)``: Positive values darken, negative values
   lighten.
 
-::
+These methods return a new color::
 
     $lighter = Color::named('blue')->tint(40);
     $darker = Color::named('blue')->shade(40);
@@ -275,7 +275,7 @@ Property               Description
 ``flex``               Flex grow (``0`` = intrinsic, ``1+`` = proportional)
 =====================  ===================================================
 
-::
+Set them through the ``Style`` constructor::
 
     use Symfony\Component\Tui\Style\Direction;
 

--- a/tui/style/stylesheets.rst
+++ b/tui/style/stylesheets.rst
@@ -1,0 +1,176 @@
+Stylesheets
+===========
+
+``StyleSheet`` is a collection of style rules with CSS-like selectors.
+It decouples visual appearance from widget code, the same way CSS
+decouples presentation from HTML.
+
+When to Use
+-----------
+
+Use a stylesheet when you want to style widgets by type, class name
+or state without setting inline styles on every instance. Stylesheets
+are the recommended way to theme an entire application.
+
+Basic Usage
+-----------
+
+Create a stylesheet, add rules and attach it to the Tui::
+
+    use Symfony\Component\Tui\Style\Border;
+    use Symfony\Component\Tui\Style\Padding;
+    use Symfony\Component\Tui\Style\Style;
+    use Symfony\Component\Tui\Style\StyleSheet;
+
+    $stylesheet = new StyleSheet();
+    $stylesheet->addRule('.sidebar', new Style(
+        padding: Padding::all(1),
+        border: Border::all(1, 'rounded'),
+    ));
+
+    $tui->addStyleSheet($stylesheet);
+
+Assign the CSS class to a widget::
+
+    $sidebar->addStyleClass('sidebar');
+
+Selectors
+---------
+
+Stylesheets support several selector types, listed here from lowest
+to highest priority:
+
+**Universal selector**, matches every widget::
+
+    $stylesheet->addRule('*', new Style(color: 'white'));
+
+**FQCN selector**, matches widgets by their PHP class (including
+parent classes)::
+
+    use Symfony\Component\Tui\Widget\TextWidget;
+
+    $stylesheet->addRule(TextWidget::class, new Style(
+        color: 'gray',
+    ));
+
+**CSS class selector**, matches widgets that have the given style
+class::
+
+    $stylesheet->addRule('.title', new Style(
+        bold: true,
+        color: 'cyan',
+    ));
+
+**State selector**, matches when a widget is in a specific state
+(e.g. ``:focused``). Combine with FQCN or CSS class selectors::
+
+    use Symfony\Component\Tui\Style\Border;
+    use Symfony\Component\Tui\Style\Style;
+    use Symfony\Component\Tui\Widget\InputWidget;
+
+    $stylesheet->addRule(
+        InputWidget::class.':focused',
+        new Style(bold: true),
+    );
+    $stylesheet->addRule(
+        '.sidebar:focused',
+        new Style(border: Border::all(1, 'rounded', 'cyan')),
+    );
+
+Cascade Order
+-------------
+
+When multiple rules match a widget, they are merged in this order
+(later rules override earlier ones):
+
+1. Universal selector (``*``)
+2. FQCN selector (parent classes first, concrete class last)
+3. CSS class selectors
+4. State selectors (FQCN + state, then CSS class + state)
+5. Responsive breakpoint rules (see below)
+6. Utility class styles (see :doc:`tailwind`)
+7. Instance style (``widget->setStyle()``)
+
+Within each level, ``null`` properties are skipped so that
+lower-priority values show through.
+
+Sub-elements
+------------
+
+Widgets can expose internal parts as sub-elements using CSS
+pseudo-element syntax (``::``). This allows styling individual pieces
+of a widget without subclassing.
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Widget\SelectListWidget;
+
+    // Style the selected item
+    $stylesheet->addRule(
+        SelectListWidget::class.'::selected',
+        new Style(bold: true),
+    );
+
+    // Different style when the widget is focused
+    $stylesheet->addRule(
+        SelectListWidget::class.'::selected:focused',
+        new Style(bold: true, color: 'cyan'),
+    );
+
+    // Target by CSS class
+    $stylesheet->addRule(
+        '.my-list::selected',
+        new Style(color: 'green'),
+    );
+
+Responsive Breakpoints
+----------------------
+
+Rules can be scoped to a minimum terminal width, similar to CSS
+``@media (min-width: ...)``. Breakpoint rules apply when the terminal
+has at least the specified number of columns::
+
+    use Symfony\Component\Tui\Style\Direction;
+
+    $stylesheet->addBreakpoint(
+        120,
+        '.panes',
+        new Style(direction: Direction::Horizontal),
+    );
+
+Below 120 columns, ``.panes`` uses the default vertical layout.
+At 120 columns or wider, it switches to horizontal.
+
+Multiple breakpoints can be defined. They are evaluated in ascending
+order, so wider breakpoints override narrower ones when both match.
+
+Merging Stylesheets
+-------------------
+
+Combine multiple stylesheets like CSS cascading; later rules win::
+
+    $defaults = new StyleSheet([
+        '.panel' => new Style(background: '#1e1e2e'),
+    ]);
+
+    $theme = new StyleSheet([
+        '.panel' => new Style(
+            border: Border::all(1, 'rounded'),
+        ),
+    ]);
+
+    // Theme rules override defaults for the same selector
+    $defaults->merge($theme);
+
+To add rules only for selectors that don't already exist (lower
+priority), use ``mergeDefaults()``::
+
+    $appStylesheet->mergeDefaults($libraryDefaults);
+
+Default Stylesheet
+------------------
+
+Tui ships with a ``DefaultStyleSheet`` that provides sensible base
+styles for all built-in widgets (overlay borders, loader colors,
+markdown heading styles, etc.). It is applied automatically and can
+be overridden by any application stylesheet.

--- a/tui/style/stylesheets.rst
+++ b/tui/style/stylesheets.rst
@@ -88,7 +88,7 @@ When multiple rules match a widget, they are merged in this order
 3. CSS class selectors
 4. State selectors (FQCN + state, then CSS class + state)
 5. Responsive breakpoint rules (see below)
-6. Utility class styles (see :doc:`tailwind`)
+6. Utility class styles (see :doc:`/tui/style/tailwind`)
 7. Instance style (``widget->setStyle()``)
 
 Within each level, ``null`` properties are skipped so that
@@ -99,9 +99,7 @@ Sub-elements
 
 Widgets can expose internal parts as sub-elements using CSS
 pseudo-element syntax (``::``). This allows styling individual pieces
-of a widget without subclassing.
-
-.. code-block:: php
+of a widget without subclassing::
 
     use Symfony\Component\Tui\Widget\SelectListWidget;
 

--- a/tui/style/stylesheets.rst
+++ b/tui/style/stylesheets.rst
@@ -61,21 +61,33 @@ class::
         color: 'cyan',
     ));
 
-**State selector**, matches when a widget is in a specific state
-(e.g. ``:focused``). Combine with FQCN or CSS class selectors::
+**Pseudo-class selector**, matches when a widget is in a specific
+state (e.g. ``:root``, ``:focused``). Use it standalone or combined
+with FQCN or CSS class selectors::
 
     use Symfony\Component\Tui\Style\Border;
     use Symfony\Component\Tui\Style\Style;
     use Symfony\Component\Tui\Widget\InputWidget;
 
+    // Bare pseudo-class: matches any widget in that state
+    $stylesheet->addRule(':root', new Style(gap: 1));
+    $stylesheet->addRule(':focused', new Style(bold: true));
+
+    // Combined with FQCN
     $stylesheet->addRule(
         InputWidget::class.':focused',
         new Style(bold: true),
     );
+
+    // Combined with CSS class
     $stylesheet->addRule(
         '.sidebar:focused',
         new Style(border: Border::all(1, 'rounded', 'cyan')),
     );
+
+The ``:root`` pseudo-class matches the root widget of the tree
+(the widget with no parent). This is the recommended way to style
+the root container created by the Tui.
 
 Cascade Order
 -------------
@@ -86,7 +98,7 @@ When multiple rules match a widget, they are merged in this order
 1. Universal selector (``*``)
 2. FQCN selector (parent classes first, concrete class last)
 3. CSS class selectors
-4. State selectors (FQCN + state, then CSS class + state)
+4. Pseudo-class selectors (bare, then FQCN + state, then CSS class + state)
 5. Responsive breakpoint rules (see below)
 6. Utility class styles (see :doc:`/tui/style/tailwind`)
 7. Instance style (``widget->setStyle()``)

--- a/tui/style/stylesheets.rst
+++ b/tui/style/stylesheets.rst
@@ -62,7 +62,7 @@ class::
     ));
 
 **Pseudo-class selector**, matches when a widget is in a specific
-state (e.g. ``:root``, ``:focused``). Use it standalone or combined
+state (e.g. ``:root``, ``:focus``). Use it standalone or combined
 with FQCN or CSS class selectors::
 
     use Symfony\Component\Tui\Style\Border;
@@ -71,17 +71,17 @@ with FQCN or CSS class selectors::
 
     // Bare pseudo-class: matches any widget in that state
     $stylesheet->addRule(':root', new Style(gap: 1));
-    $stylesheet->addRule(':focused', new Style(bold: true));
+    $stylesheet->addRule(':focus', new Style(bold: true));
 
     // Combined with FQCN
     $stylesheet->addRule(
-        InputWidget::class.':focused',
+        InputWidget::class.':focus',
         new Style(bold: true),
     );
 
     // Combined with CSS class
     $stylesheet->addRule(
-        '.sidebar:focused',
+        '.sidebar:focus',
         new Style(border: Border::all(1, 'rounded', 'cyan')),
     );
 
@@ -123,7 +123,7 @@ of a widget without subclassing::
 
     // Different style when the widget is focused
     $stylesheet->addRule(
-        SelectListWidget::class.'::selected:focused',
+        SelectListWidget::class.'::selected:focus',
         new Style(bold: true, color: 'cyan'),
     );
 

--- a/tui/style/tailwind.rst
+++ b/tui/style/tailwind.rst
@@ -11,7 +11,7 @@ When to Use
 
 Use utility classes for rapid prototyping, one-off styling or when a
 full stylesheet rule feels like overkill. For consistent theming
-across many widgets, prefer :doc:`stylesheets`.
+across many widgets, prefer :doc:`/tui/style/stylesheets`.
 
 Setup
 -----
@@ -102,9 +102,7 @@ Class                       Pattern
 ==========================  ==========================================
 
 Border color classes use the same color syntax as text and background
-(see below).
-
-.. code-block:: php
+(see below)::
 
     $widget->addStyleClass('border');
     $widget->addStyleClass('border-rounded');
@@ -181,17 +179,16 @@ Available bundled fonts: ``big``, ``small``, ``slant``, ``standard``,
 Layout
 ------
 
-========================  ==========================================
+========================  ====================================================
 Class                     Effect
-========================  ==========================================
+========================  ====================================================
 ``flex-row``              Horizontal layout direction
 ``flex-col``              Vertical layout direction
-``flex-{n}``              Flex grow weight (``0`` = intrinsic width,
-                          ``1+`` = proportional)
+``flex-{n}``              Flex grow (``0`` = intrinsic, ``1+`` = proportional)
 ``gap-{n}``               Gap between children
 ``hidden``                Hide the widget
 ``visible``               Show the widget
-========================  ==========================================
+========================  ====================================================
 
 Alignment
 ---------

--- a/tui/style/tailwind.rst
+++ b/tui/style/tailwind.rst
@@ -54,13 +54,13 @@ Padding
 ======================  ==========================================
 Class                   Effect
 ======================  ==========================================
-``p-{n}``              All sides
-``px-{n}``             Left and right
-``py-{n}``             Top and bottom
-``pt-{n}``             Top only
-``pr-{n}``             Right only
-``pb-{n}``             Bottom only
-``pl-{n}``             Left only
+``p-{n}``               All sides
+``px-{n}``              Left and right
+``py-{n}``              Top and bottom
+``pt-{n}``              Top only
+``pr-{n}``              Right only
+``pb-{n}``              Bottom only
+``pl-{n}``              Left only
 ======================  ==========================================
 
 .. code-block:: php

--- a/tui/style/tailwind.rst
+++ b/tui/style/tailwind.rst
@@ -1,0 +1,224 @@
+Tailwind Utility Classes
+========================
+
+``TailwindStylesheet`` extends the standard stylesheet with support
+for Tailwind-like utility classes. Instead of writing explicit rules,
+you add short class names directly to widgets for quick, composable
+styling.
+
+When to Use
+-----------
+
+Use utility classes for rapid prototyping, one-off styling or when a
+full stylesheet rule feels like overkill. For consistent theming
+across many widgets, prefer :doc:`stylesheets`.
+
+Setup
+-----
+
+``TailwindStylesheet`` is a drop-in replacement for ``StyleSheet``.
+Pass it to the Tui the same way::
+
+    use Symfony\Component\Tui\Style\TailwindStylesheet;
+
+    $stylesheet = new TailwindStylesheet();
+    $tui->addStyleSheet($stylesheet);
+
+Adding utility classes to widgets::
+
+    $widget->addStyleClass('p-2');
+    $widget->addStyleClass('bg-red-500');
+    $widget->addStyleClass('bold');
+    $widget->addStyleClass('border');
+    $widget->addStyleClass('border-rounded');
+
+Utility classes compose naturally; each one sets a specific property
+and they are merged together.
+
+Cascade Position
+----------------
+
+Utility classes sit above regular stylesheet rules and below inline
+styles in the cascade:
+
+1. Stylesheet rules (universal, FQCN, CSS class, state, breakpoints)
+2. **Utility class styles**
+3. Instance style (``widget->setStyle()``)
+
+This means utility classes always override stylesheet rules but can
+still be overridden by an inline style.
+
+Padding
+-------
+
+======================  ==========================================
+Class                   Effect
+======================  ==========================================
+``p-{n}``              All sides
+``px-{n}``             Left and right
+``py-{n}``             Top and bottom
+``pt-{n}``             Top only
+``pr-{n}``             Right only
+``pb-{n}``             Bottom only
+``pl-{n}``             Left only
+======================  ==========================================
+
+.. code-block:: php
+
+    $widget->addStyleClass('p-2');
+    $widget->addStyleClass('px-4');
+
+Border
+------
+
+Width classes:
+
+=========================================  ========================
+Class                                      Effect
+=========================================  ========================
+``border``                                 All sides, width 1
+``border-{n}``                             All sides, width n
+``border-t``, ``border-r``, ``border-b``,
+``border-l``                               Individual side, width 1
+``border-t-{n}``, ``border-r-{n}``,
+``border-b-{n}``, ``border-l-{n}``         Individual side, width n
+``border-none``                            Remove border
+=========================================  ========================
+
+Pattern classes:
+
+==========================  ==========================================
+Class                       Pattern
+==========================  ==========================================
+``border-normal``           Standard box-drawing
+``border-rounded``          Rounded corners
+``border-double``           Double-line box
+``border-tall``             Block-style vertical
+``border-wide``             Block-style horizontal
+``border-tall-medium``      ~4px balanced (tall)
+``border-wide-medium``      ~4px balanced (wide)
+``border-tall-large``       ~8px balanced (tall)
+``border-wide-large``       ~8px balanced (wide)
+==========================  ==========================================
+
+Border color classes use the same color syntax as text and background
+(see below).
+
+.. code-block:: php
+
+    $widget->addStyleClass('border');
+    $widget->addStyleClass('border-rounded');
+    $widget->addStyleClass('border-cyan-400');
+
+Colors
+------
+
+Both text and background colors support three formats:
+
+**Tailwind shades**, ``{family}-{shade}`` where family is one of
+``slate``, ``gray``, ``zinc``, ``neutral``, ``stone``, ``red``,
+``orange``, ``amber``, ``yellow``, ``lime``, ``green``, ``emerald``,
+``teal``, ``cyan``, ``sky``, ``blue``, ``indigo``, ``violet``,
+``purple``, ``fuchsia``, ``pink``, ``rose`` and shade is ``50``,
+``100``, ``200``, ``300``, ``400``, ``500``, ``600``, ``700``,
+``800``, ``900`` or ``950``::
+
+    $widget->addStyleClass('text-blue-700');
+    $widget->addStyleClass('bg-emerald-100');
+
+**Hex colors**, wrap in brackets::
+
+    $widget->addStyleClass('text-[#ff5500]');
+    $widget->addStyleClass('bg-[#1e1e2e]');
+
+**256-palette index**::
+
+    $widget->addStyleClass('text-202');
+    $widget->addStyleClass('bg-236');
+
+Text Decoration
+---------------
+
+========================  ==========================================
+Class                     Effect
+========================  ==========================================
+``bold``                  Enable bold
+``not-bold``              Disable bold
+``dim``                   Enable dim/faint
+``not-dim``               Disable dim
+``italic``                Enable italic
+``not-italic``            Disable italic
+``underline``             Enable underline
+``no-underline``          Disable underline
+``line-through``          Enable strikethrough
+``no-line-through``       Disable strikethrough
+``reverse``               Enable reverse video
+``no-reverse``            Disable reverse video
+========================  ==========================================
+
+Text Alignment
+--------------
+
+========================  ==========================================
+Class                     Effect
+========================  ==========================================
+``text-left``             Left-align text (default)
+``text-center``           Center-align text
+``text-right``            Right-align text
+========================  ==========================================
+
+Font
+----
+
+Set a FIGlet font for text rendering::
+
+    $widget->addStyleClass('font-big');
+    $widget->addStyleClass('font-slant');
+
+Available bundled fonts: ``big``, ``small``, ``slant``, ``standard``,
+``mini``.
+
+Layout
+------
+
+========================  ==========================================
+Class                     Effect
+========================  ==========================================
+``flex-row``              Horizontal layout direction
+``flex-col``              Vertical layout direction
+``flex-{n}``              Flex grow weight (``0`` = intrinsic width,
+                          ``1+`` = proportional)
+``gap-{n}``               Gap between children
+``hidden``                Hide the widget
+``visible``               Show the widget
+========================  ==========================================
+
+Alignment
+---------
+
+========================  ==========================================
+Class                     Effect
+========================  ==========================================
+``align-left``            Left-align child widgets
+``align-center``          Center child widgets horizontally
+``align-right``           Right-align child widgets
+``valign-top``            Top-align child widgets
+``valign-center``         Center child widgets vertically
+``valign-bottom``         Bottom-align child widgets
+========================  ==========================================
+
+Combining with Stylesheet Rules
+-------------------------------
+
+Utility classes and regular CSS-class rules coexist. A class name
+that isn't recognized as a utility is treated as a CSS class for
+stylesheet matching::
+
+    $stylesheet = new TailwindStylesheet();
+    $stylesheet->addRule('.panel', new Style(
+        background: '#1e1e2e',
+    ));
+
+    $widget->addStyleClass('panel');  // matched by the rule
+    $widget->addStyleClass('p-2');    // parsed as utility
+    $widget->addStyleClass('bold');   // parsed as utility

--- a/tui/topics/compositing.rst
+++ b/tui/topics/compositing.rst
@@ -1,0 +1,111 @@
+Compositing
+===========
+
+Compositing lets you merge multiple layers of content into a
+single output. Each layer is a set of ANSI-formatted lines at a
+position, and layers can be transparent so the content below shows
+through.
+
+This is useful for rendering effects like animated backgrounds with
+text on top, watermarks, or any scenario where a widget needs to
+combine independently rendered content.
+
+The Compositor
+--------------
+
+The ``Compositor`` class merges layers in order. Layer 0 is the
+base (typically opaque, filling the entire screen); subsequent
+layers are painted on top:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Render\Compositor;
+    use Symfony\Component\Tui\Render\Layer;
+
+    $lines = Compositor::composite(
+        new Layer($backgroundLines),                     // opaque base
+        new Layer($foregroundLines, transparent: true),   // transparent overlay
+    );
+
+``composite()`` returns ``string[]``, one ANSI-formatted string per
+terminal row, ready to be returned from a widget's ``render()``
+method.
+
+The canvas dimensions are derived from the first (base) layer:
+height is the number of lines, width is the visible width of the
+first line.
+
+The Layer Value Object
+----------------------
+
+A ``Layer`` describes content to composite:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Render\Layer;
+
+    $layer = new Layer(
+        lines: $lines,           // string[] of ANSI-formatted content
+        row: 0,                  // vertical offset (default: 0)
+        col: 0,                  // horizontal offset (default: 0)
+        transparent: false,      // transparency flag (default: false)
+        width: null,             // explicit canvas width (base layer only)
+        height: null,            // explicit canvas height (base layer only)
+    );
+
+All parameters except ``lines`` are optional.
+
+The ``width`` and ``height`` parameters are only meaningful on the
+base layer (the first one passed to ``composite()``). When set,
+they define the canvas dimensions explicitly. When ``null``, the
+canvas dimensions are derived from the base layer's content.
+
+How Transparency Works
+----------------------
+
+When a layer is transparent (``transparent: true``):
+
+* **Cells with content but no explicit background** inherit the
+  background from the layer below. The foreground character and
+  color are painted on top of whatever background was already
+  there.
+
+* **Plain spaces with no styling** are fully transparent: the
+  entire cell from the layer below is preserved (character,
+  foreground, background, and attributes).
+
+* **Cells with an explicit background** are opaque and overwrite
+  the layer below completely.
+
+When a layer is opaque (the default), every cell overwrites the
+layer below regardless of styling.
+
+Positioned Layers
+-----------------
+
+Layers can be offset from the top-left corner. This is useful for
+compositing smaller content at a specific position:
+
+.. code-block:: php
+
+    $lines = Compositor::composite(
+        new Layer($fullScreenBackground),
+        new Layer($smallWidget, row: 5, col: 10, transparent: true),
+    );
+
+The offset applies to the entire content of the layer. Cells
+outside the layer's content area are unaffected.
+
+Multiple Layers
+---------------
+
+Any number of layers can be composited. They are applied in order,
+so layer N can see the merged result of layers 0 through N-1:
+
+.. code-block:: php
+
+    $lines = Compositor::composite(
+        new Layer($background),
+        new Layer($midground, transparent: true),
+        new Layer($foreground, transparent: true),
+    );

--- a/tui/topics/compositing.rst
+++ b/tui/topics/compositing.rst
@@ -15,9 +15,7 @@ The Compositor
 
 The ``Compositor`` class merges layers in order. Layer 0 is the
 base (typically opaque, filling the entire screen); subsequent
-layers are painted on top:
-
-.. code-block:: php
+layers are painted on top::
 
     use Symfony\Component\Tui\Render\Compositor;
     use Symfony\Component\Tui\Render\Layer;
@@ -38,9 +36,7 @@ first line.
 The Layer Value Object
 ----------------------
 
-A ``Layer`` describes content to composite:
-
-.. code-block:: php
+A ``Layer`` describes content to composite::
 
     use Symfony\Component\Tui\Render\Layer;
 
@@ -84,9 +80,7 @@ Positioned Layers
 -----------------
 
 Layers can be offset from the top-left corner. This is useful for
-compositing smaller content at a specific position:
-
-.. code-block:: php
+compositing smaller content at a specific position::
 
     $lines = Compositor::composite(
         new Layer($fullScreenBackground),
@@ -100,9 +94,7 @@ Multiple Layers
 ---------------
 
 Any number of layers can be composited. They are applied in order,
-so layer N can see the merged result of layers 0 through N-1:
-
-.. code-block:: php
+so layer N can see the merged result of layers 0 through N-1::
 
     $lines = Compositor::composite(
         new Layer($background),

--- a/tui/topics/events.rst
+++ b/tui/topics/events.rst
@@ -1,0 +1,109 @@
+Events
+======
+
+Widgets communicate with your application through events. Tui uses
+the Symfony EventDispatcher, so all events flow through a single
+dispatcher shared by the entire widget tree.
+
+Per-Widget Listeners
+--------------------
+
+The most common way to handle events is to register a callback on
+the widget that emits them:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Event\SubmitEvent;
+
+    $input->onSubmit(function (SubmitEvent $event) {
+        $value = $event->getValue();
+    });
+
+    $input->onCancel(function () use ($tui) {
+        $tui->stop();
+    });
+
+Per-widget listeners are automatically scoped to the target widget.
+They are also cleaned up when the widget is detached from the tree.
+
+Global Listeners
+----------------
+
+Register a listener on the Tui to catch events from any widget:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Event\CancelEvent;
+
+    $tui->on(CancelEvent::class, function (CancelEvent $event) {
+        // Fires when ANY widget dispatches CancelEvent
+        $tui->stop();
+    });
+
+This is useful when multiple widgets should trigger the same
+behavior (e.g. stopping the Tui on cancel).
+
+When you need to distinguish which widget fired the event, use
+``getTarget()``:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Event\SubmitEvent;
+
+    $tui->on(SubmitEvent::class, function (SubmitEvent $event) use ($editor) {
+        if ($event->getTarget() === $editor) {
+            // handle editor submit
+        }
+    });
+
+Quitting the Application
+------------------------
+
+``Tui::quitOn()`` registers key patterns that stop the Tui
+automatically:
+
+.. code-block:: php
+
+    $tui->quitOn('ctrl+c');
+    $tui->quitOn('ctrl+c', 'ctrl+q'); // multiple keys
+
+Quit keys are checked first, before any other input handling.
+
+Global Input Interceptor
+------------------------
+
+``Tui::onInput()`` registers a callback that runs before any widget
+receives keyboard input. Return ``true`` to consume the input and
+prevent further processing:
+
+.. code-block:: php
+
+    $tui->onInput(function (string $data) use ($tui): bool {
+        if ('?' === $data) {
+            // show a help overlay
+            return true;
+        }
+
+        return false;
+    });
+
+The input flow is: quit keys, then global interceptor, then focus
+manager (F6 cycling), then the focused widget.
+
+Event Types
+-----------
+
+* ``SubmitEvent``: the user confirmed input (Enter). Carries
+  a text value.
+* ``CancelEvent``: the user cancelled (Escape, Ctrl+C).
+* ``ChangeEvent``: the text content changed. Carries a text value.
+* ``SelectEvent``: the user picked an item from a list. Carries
+  the value, label and full item array.
+* ``SelectionChangeEvent``: the highlighted item changed (arrow
+  keys, scroll).
+* ``SettingChangeEvent``: a setting value changed. Carries the
+  setting id and new value.
+* ``TabChangeEvent``: the active tab changed. Carries previous
+  and new indices/ids.
+* ``FocusEvent``: focus moved between widgets. Carries the new
+  and previous widget.

--- a/tui/topics/events.rst
+++ b/tui/topics/events.rst
@@ -9,9 +9,7 @@ Per-Widget Listeners
 --------------------
 
 The most common way to handle events is to register a callback on
-the widget that emits them:
-
-.. code-block:: php
+the widget that emits them::
 
     use Symfony\Component\Tui\Event\SubmitEvent;
 
@@ -29,9 +27,7 @@ They are also cleaned up when the widget is detached from the tree.
 Global Listeners
 ----------------
 
-Register a listener on the Tui to catch events from any widget:
-
-.. code-block:: php
+Register a listener on the Tui to catch events from any widget::
 
     use Symfony\Component\Tui\Event\CancelEvent;
 
@@ -44,9 +40,7 @@ This is useful when multiple widgets should trigger the same
 behavior (e.g. stopping the Tui on cancel).
 
 When you need to distinguish which widget fired the event, use
-``getTarget()``:
-
-.. code-block:: php
+``getTarget()``::
 
     use Symfony\Component\Tui\Event\SubmitEvent;
 
@@ -60,9 +54,7 @@ Quitting the Application
 ------------------------
 
 ``Tui::quitOn()`` registers key patterns that stop the Tui
-automatically:
-
-.. code-block:: php
+automatically::
 
     $tui->quitOn('ctrl+c');
     $tui->quitOn('ctrl+c', 'ctrl+q'); // multiple keys
@@ -74,9 +66,7 @@ Global Input Interceptor
 
 ``Tui::onInput()`` registers a callback that runs before any widget
 receives keyboard input. Return ``true`` to consume the input and
-prevent further processing:
-
-.. code-block:: php
+prevent further processing::
 
     $tui->onInput(function (string $data) use ($tui): bool {
         if ('?' === $data) {

--- a/tui/topics/events.rst
+++ b/tui/topics/events.rst
@@ -96,7 +96,5 @@ Event Types
   keys, scroll).
 * ``SettingChangeEvent``: a setting value changed. Carries the
   setting id and new value.
-* ``TabChangeEvent``: the active tab changed. Carries previous
-  and new indices/ids.
 * ``FocusEvent``: focus moved between widgets. Carries the new
   and previous widget.

--- a/tui/topics/events.rst
+++ b/tui/topics/events.rst
@@ -27,11 +27,12 @@ They are also cleaned up when the widget is detached from the tree.
 Global Listeners
 ----------------
 
-Register a listener on the Tui to catch events from any widget::
+Register a listener on the Tui to catch events from any widget.
+The event class is inferred from the listener's type hint::
 
     use Symfony\Component\Tui\Event\CancelEvent;
 
-    $tui->on(CancelEvent::class, function (CancelEvent $event) {
+    $tui->addListener(function (CancelEvent $event) {
         // Fires when ANY widget dispatches CancelEvent
         $tui->stop();
     });
@@ -44,7 +45,7 @@ When you need to distinguish which widget fired the event, use
 
     use Symfony\Component\Tui\Event\SubmitEvent;
 
-    $tui->on(SubmitEvent::class, function (SubmitEvent $event) use ($editor) {
+    $tui->addListener(function (SubmitEvent $event) use ($editor) {
         if ($event->getTarget() === $editor) {
             // handle editor submit
         }
@@ -55,20 +56,21 @@ Global Input Interceptor
 
 ``InputEvent`` is dispatched before focus navigation and before the
 focused widget receives input. Register a listener with
-``Tui::on()`` to intercept raw input. Call ``stopPropagation()`` to
-consume the input and prevent further processing::
+``Tui::addListener()`` to intercept raw input. Call
+``stopPropagation()`` to consume the input and prevent further
+processing::
 
     use Symfony\Component\Tui\Event\InputEvent;
     use Symfony\Component\Tui\Input\Keybindings;
 
     $keys = new Keybindings(['quit' => ['ctrl+c', 'ctrl+q']]);
-    $tui->on(InputEvent::class, function (InputEvent $event) use ($tui, $keys): void {
+    $tui->addListener(function (InputEvent $event) use ($tui, $keys): void {
         if ($keys->matches($event->getData(), 'quit')) {
             $tui->stop();
         }
     });
 
-    $tui->on(InputEvent::class, function (InputEvent $event): void {
+    $tui->addListener(function (InputEvent $event): void {
         if ('?' === $event->getData()) {
             // show a help overlay
             $event->stopPropagation();

--- a/tui/topics/events.rst
+++ b/tui/topics/events.rst
@@ -50,39 +50,40 @@ When you need to distinguish which widget fired the event, use
         }
     });
 
-Quitting the Application
-------------------------
-
-``Tui::quitOn()`` registers key patterns that stop the Tui
-automatically::
-
-    $tui->quitOn('ctrl+c');
-    $tui->quitOn('ctrl+c', 'ctrl+q'); // multiple keys
-
-Quit keys are checked first, before any other input handling.
-
 Global Input Interceptor
 ------------------------
 
-``Tui::onInput()`` registers a callback that runs before any widget
-receives keyboard input. Return ``true`` to consume the input and
-prevent further processing::
+``InputEvent`` is dispatched before focus navigation and before the
+focused widget receives input. Register a listener with
+``Tui::on()`` to intercept raw input. Call ``stopPropagation()`` to
+consume the input and prevent further processing::
 
-    $tui->onInput(function (string $data) use ($tui): bool {
-        if ('?' === $data) {
-            // show a help overlay
-            return true;
+    use Symfony\Component\Tui\Event\InputEvent;
+    use Symfony\Component\Tui\Input\Keybindings;
+
+    $keys = new Keybindings(['quit' => ['ctrl+c', 'ctrl+q']]);
+    $tui->on(InputEvent::class, function (InputEvent $event) use ($tui, $keys): void {
+        if ($keys->matches($event->getData(), 'quit')) {
+            $tui->stop();
         }
-
-        return false;
     });
 
-The input flow is: quit keys, then global interceptor, then focus
-manager (F6 cycling), then the focused widget.
+    $tui->on(InputEvent::class, function (InputEvent $event): void {
+        if ('?' === $event->getData()) {
+            // show a help overlay
+            $event->stopPropagation();
+        }
+    });
+
+Multiple listeners can be registered; they run in priority order.
+The input flow is: ``InputEvent`` listeners, then focus manager
+(F6 cycling), then the focused widget.
 
 Event Types
 -----------
 
+* ``InputEvent``: raw terminal input received. Dispatched before
+  focus handling; call ``stopPropagation()`` to consume the input.
 * ``SubmitEvent``: the user confirmed input (Enter). Carries
   a text value.
 * ``CancelEvent``: the user cancelled (Escape, Ctrl+C).

--- a/tui/topics/focus.rst
+++ b/tui/topics/focus.rst
@@ -1,0 +1,115 @@
+Focus Management
+================
+
+When your application has multiple focusable widgets, you need to
+manage which one receives keyboard input. The ``FocusManager``
+handles this.
+
+Focus Cycling
+-------------
+
+By default, **F6** moves focus to the next focusable widget and
+**Shift+F6** moves it to the previous one. This works automatically
+when you register widgets with the focus manager.
+
+Registering Focusable Widgets
+-----------------------------
+
+Add widgets to the focus manager so they participate in the focus
+cycle:
+
+.. code-block:: php
+
+    $focus = $tui->getFocusManager();
+    $focus->add($editor1);
+    $focus->add($editor2);
+    $focus->add($editor3);
+
+    $tui->setFocus($editor1);
+
+The order you add widgets determines the cycling order. Pressing
+**F6** moves focus through the list, wrapping from the last widget
+back to the first.
+
+Remove a widget from the cycle with ``remove()``:
+
+.. code-block:: php
+
+    $focus->remove($editor2);
+
+Setting Focus Programmatically
+------------------------------
+
+Move focus to any widget at any time:
+
+.. code-block:: php
+
+    $tui->setFocus($editor3);
+
+Query the currently focused widget:
+
+.. code-block:: php
+
+    $focused = $tui->getFocus();
+
+Reacting to Focus Changes
+-------------------------
+
+Register a callback that fires whenever focus changes:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Event\FocusEvent;
+
+    $focus = $tui->getFocusManager();
+    $focus->onFocusChanged(function (FocusEvent $event) {
+        $now = $event->getTarget();
+        $previous = $event->getPrevious();
+    });
+
+Focus and Styling
+-----------------
+
+Focusable widgets automatically report a ``:focused`` state flag
+when they have focus. Use this in stylesheet rules to change
+appearance based on focus.
+
+**Highlight the focused widget** with a colored border:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Style\Border;
+    use Symfony\Component\Tui\Style\Style;
+
+    $stylesheet->addRule('.editor', new Style(
+        border: Border::all(1, 'rounded', 'gray'),
+    ));
+    $stylesheet->addRule('.editor:focused', new Style(
+        border: Border::all(1, 'rounded', 'cyan'),
+    ));
+
+**Style a sub-element differently when focused**, for example
+changing the cursor shape:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Style\Style;
+    use Symfony\Component\Tui\Style\CursorShape;
+
+    $stylesheet->addRule(
+        '.editor::cursor',
+        new Style(cursorShape: CursorShape::Bar),
+    );
+
+**Combine FQCN and state selectors** when you want to target all
+instances of a widget type:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Style\Style;
+    use Symfony\Component\Tui\Widget\InputWidget;
+
+    $stylesheet->addRule(
+        InputWidget::class.':focused',
+        new Style(bold: true),
+    );

--- a/tui/topics/focus.rst
+++ b/tui/topics/focus.rst
@@ -60,7 +60,7 @@ Register a callback that fires whenever focus changes::
 Focus and Styling
 -----------------
 
-Focusable widgets automatically report a ``:focused`` state flag
+Focusable widgets automatically report a ``:focus`` state flag
 when they have focus. Use this in stylesheet rules to change
 appearance based on focus.
 
@@ -72,7 +72,7 @@ appearance based on focus.
     $stylesheet->addRule('.editor', new Style(
         border: Border::all(1, 'rounded', 'gray'),
     ));
-    $stylesheet->addRule('.editor:focused', new Style(
+    $stylesheet->addRule('.editor:focus', new Style(
         border: Border::all(1, 'rounded', 'cyan'),
     ));
 
@@ -94,6 +94,6 @@ instances of a widget type::
     use Symfony\Component\Tui\Widget\InputWidget;
 
     $stylesheet->addRule(
-        InputWidget::class.':focused',
+        InputWidget::class.':focus',
         new Style(bold: true),
     );

--- a/tui/topics/focus.rst
+++ b/tui/topics/focus.rst
@@ -16,9 +16,7 @@ Registering Focusable Widgets
 -----------------------------
 
 Add widgets to the focus manager so they participate in the focus
-cycle:
-
-.. code-block:: php
+cycle::
 
     $focus = $tui->getFocusManager();
     $focus->add($editor1);
@@ -31,33 +29,25 @@ The order you add widgets determines the cycling order. Pressing
 **F6** moves focus through the list, wrapping from the last widget
 back to the first.
 
-Remove a widget from the cycle with ``remove()``:
-
-.. code-block:: php
+Remove a widget from the cycle with ``remove()``::
 
     $focus->remove($editor2);
 
 Setting Focus Programmatically
 ------------------------------
 
-Move focus to any widget at any time:
-
-.. code-block:: php
+Move focus to any widget at any time::
 
     $tui->setFocus($editor3);
 
-Query the currently focused widget:
-
-.. code-block:: php
+Query the currently focused widget::
 
     $focused = $tui->getFocus();
 
 Reacting to Focus Changes
 -------------------------
 
-Register a callback that fires whenever focus changes:
-
-.. code-block:: php
+Register a callback that fires whenever focus changes::
 
     use Symfony\Component\Tui\Event\FocusEvent;
 
@@ -74,9 +64,7 @@ Focusable widgets automatically report a ``:focused`` state flag
 when they have focus. Use this in stylesheet rules to change
 appearance based on focus.
 
-**Highlight the focused widget** with a colored border:
-
-.. code-block:: php
+**Highlight the focused widget** with a colored border::
 
     use Symfony\Component\Tui\Style\Border;
     use Symfony\Component\Tui\Style\Style;
@@ -89,12 +77,10 @@ appearance based on focus.
     ));
 
 **Style a sub-element differently when focused**, for example
-changing the cursor shape:
+changing the cursor shape::
 
-.. code-block:: php
-
-    use Symfony\Component\Tui\Style\Style;
     use Symfony\Component\Tui\Style\CursorShape;
+    use Symfony\Component\Tui\Style\Style;
 
     $stylesheet->addRule(
         '.editor::cursor',
@@ -102,9 +88,7 @@ changing the cursor shape:
     );
 
 **Combine FQCN and state selectors** when you want to target all
-instances of a widget type:
-
-.. code-block:: php
+instances of a widget type::
 
     use Symfony\Component\Tui\Style\Style;
     use Symfony\Component\Tui\Widget\InputWidget;

--- a/tui/topics/index.rst
+++ b/tui/topics/index.rst
@@ -1,0 +1,15 @@
+Topics
+======
+
+In-depth guides for features that you may not need in every
+application.
+
+.. toctree::
+    :maxdepth: 1
+
+    templates
+    focus
+    events
+    keybindings
+    compositing
+    tick_loop

--- a/tui/topics/index.rst
+++ b/tui/topics/index.rst
@@ -7,7 +7,6 @@ application.
 .. toctree::
     :maxdepth: 1
 
-    templates
     focus
     events
     keybindings

--- a/tui/topics/keybindings.rst
+++ b/tui/topics/keybindings.rst
@@ -25,6 +25,11 @@ Key identifiers can be:
   ``Key::UP``, ``Key::DOWN``, ``Key::TAB``, ``Key::F6``, etc.
 * Modifier combinations: ``'ctrl+c'``, ``'alt+d'``,
   ``'shift+enter'``, ``'ctrl+shift+k'``.
+* Helpers that build those combinations: ``Key::ctrl('c')``,
+  ``Key::shift('tab')``, ``Key::alt(Key::BACKSPACE)``, plus
+  ``Key::ctrlShift()``, ``Key::ctrlAlt()``, ``Key::shiftAlt()`` and
+  ``Key::ctrlShiftAlt()``. They return the same strings as the
+  literal forms above, so both styles are interchangeable.
 * Single characters: ``'+'``, ``'-'``, ``'q'``, ``'r'``.
 
 Always use these key identifiers instead of raw escape sequences

--- a/tui/topics/keybindings.rst
+++ b/tui/topics/keybindings.rst
@@ -30,8 +30,8 @@ Key identifiers can be:
 Always use these key identifiers instead of raw escape sequences
 (``"\x03"``, ``"\x1b[A"``, etc.). The key abstraction handles
 differences between terminal encodings (legacy and Kitty protocol)
-transparently. The same identifiers work everywhere: keybindings,
-``quitOn()`` and ``onInput()`` matching.
+transparently. The same identifiers work everywhere: keybindings
+and ``InputEvent`` listeners.
 
 Widget Default Keybindings
 --------------------------

--- a/tui/topics/keybindings.rst
+++ b/tui/topics/keybindings.rst
@@ -8,9 +8,7 @@ How It Works
 ------------
 
 A ``Keybindings`` instance is a map from action names (strings) to
-lists of key identifiers:
-
-.. code-block:: php
+lists of key identifiers::
 
     use Symfony\Component\Tui\Input\Key;
     use Symfony\Component\Tui\Input\Keybindings;
@@ -50,9 +48,7 @@ Overriding Widget Keybindings
 -----------------------------
 
 Pass a ``Keybindings`` instance to the widget constructor to
-override specific actions:
-
-.. code-block:: php
+override specific actions::
 
     use Symfony\Component\Tui\Input\Key;
     use Symfony\Component\Tui\Input\Keybindings;
@@ -80,9 +76,7 @@ When a widget checks its keybindings, three layers are merged
    instance via ``setKeybindings()`` or the constructor.
 
 This lets you set application-wide overrides at the Tui level while
-still allowing per-widget customization:
-
-.. code-block:: php
+still allowing per-widget customization::
 
     use Symfony\Component\Tui\Input\Keybindings;
     use Symfony\Component\Tui\Tui;
@@ -122,7 +116,7 @@ Action                      Meaning
 ==========================  ==========================================
 
 macOS: Option Key as Alt/Meta
-------------------------------
+-----------------------------
 
 On macOS, the Option key acts as a compose key by default (for typing
 accented characters like e, n). Terminal applications that rely on Alt

--- a/tui/topics/keybindings.rst
+++ b/tui/topics/keybindings.rst
@@ -1,0 +1,144 @@
+Keybindings
+===========
+
+The keybindings system maps action names to key patterns, allowing
+keyboard shortcuts to be customized without changing widget code.
+
+How It Works
+------------
+
+A ``Keybindings`` instance is a map from action names (strings) to
+lists of key identifiers:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Input\Key;
+    use Symfony\Component\Tui\Input\Keybindings;
+
+    $kb = new Keybindings([
+        'submit' => [Key::ENTER],
+        'cancel' => [Key::ESCAPE, 'ctrl+c'],
+        'delete_word' => ['ctrl+w', 'alt+backspace'],
+    ]);
+
+Key identifiers can be:
+
+* Constants from the ``Key`` class: ``Key::ENTER``, ``Key::ESCAPE``,
+  ``Key::UP``, ``Key::DOWN``, ``Key::TAB``, ``Key::F6``, etc.
+* Modifier combinations: ``'ctrl+c'``, ``'alt+d'``,
+  ``'shift+enter'``, ``'ctrl+shift+k'``.
+* Single characters: ``'+'``, ``'-'``, ``'q'``, ``'r'``.
+
+Always use these key identifiers instead of raw escape sequences
+(``"\x03"``, ``"\x1b[A"``, etc.). The key abstraction handles
+differences between terminal encodings (legacy and Kitty protocol)
+transparently. The same identifiers work everywhere: keybindings,
+``quitOn()`` and ``onInput()`` matching.
+
+Widget Default Keybindings
+--------------------------
+
+Every focusable widget defines its own default keybindings via
+``getDefaultKeybindings()``. For example, ``InputWidget`` maps
+``submit`` to Enter, ``select_cancel`` to Escape, ``cursor_left``
+to Left arrow, etc.
+
+You can see a widget's defaults in its documentation page under
+"Default Keybindings."
+
+Overriding Widget Keybindings
+-----------------------------
+
+Pass a ``Keybindings`` instance to the widget constructor to
+override specific actions:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Input\Key;
+    use Symfony\Component\Tui\Input\Keybindings;
+    use Symfony\Component\Tui\Widget\EditorWidget;
+
+    $editor = new EditorWidget(keybindings: new Keybindings([
+        'submit' => ['ctrl+s'],
+        'new_line' => [Key::ENTER],
+    ]));
+
+Only the actions you specify are overridden; the remaining actions
+keep their defaults.
+
+The Three-Layer Merge
+---------------------
+
+When a widget checks its keybindings, three layers are merged
+(later layers override earlier ones):
+
+1. **Widget defaults**: the built-in bindings defined by the widget
+   class.
+2. **Tui-level keybindings**: bindings passed to the ``Tui``
+   constructor, shared across all widgets.
+3. **Widget-level keybindings**: bindings set on the widget
+   instance via ``setKeybindings()`` or the constructor.
+
+This lets you set application-wide overrides at the Tui level while
+still allowing per-widget customization:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Input\Keybindings;
+    use Symfony\Component\Tui\Tui;
+
+    // Application-wide: remap submit to Ctrl+S for all widgets
+    $tui = new Tui(keybindings: new Keybindings([
+        'submit' => ['ctrl+s'],
+    ]));
+
+Action Names
+------------
+
+Action names use **snake_case** by convention. Common action names
+shared across widgets:
+
+==========================  ==========================================
+Action                      Meaning
+==========================  ==========================================
+``submit``                  Confirm / send
+``select_cancel``           Cancel / dismiss
+``cursor_up``               Move cursor up
+``cursor_down``             Move cursor down
+``cursor_left``             Move cursor left
+``cursor_right``            Move cursor right
+``cursor_word_left``        Move cursor one word left
+``cursor_word_right``       Move cursor one word right
+``cursor_line_start``       Move cursor to line start
+``cursor_line_end``         Move cursor to line end
+``delete_char_backward``    Delete character before cursor
+``delete_char_forward``     Delete character after cursor
+``delete_word_backward``    Delete word before cursor
+``select_up``               Move selection up
+``select_down``             Move selection down
+``select_confirm``          Confirm selection
+``select_page_up``          Page up in a list
+``select_page_down``        Page down in a list
+==========================  ==========================================
+
+macOS: Option Key as Alt/Meta
+------------------------------
+
+On macOS, the Option key acts as a compose key by default (for typing
+accented characters like e, n). Terminal applications that rely on Alt
+key combinations, such as ``alt+backspace`` (delete word),
+``alt+d`` (delete word forward), ``alt+b``/``alt+f`` (word
+navigation), require the Option key to be configured as Meta/Alt in
+your terminal emulator:
+
+====================  =====================================================================
+Terminal              Setting
+====================  =====================================================================
+**Ghostty**           ``macos-option-as-alt = true`` in ``~/.config/ghostty/config``
+**iTerm2**            Preferences > Profiles > Keys > Left Option Key > **Esc+**
+**Terminal.app**      Preferences > Profiles > Keyboard > **Use Option as Meta key**
+**Kitty**             ``macos_option_as_alt yes`` in ``kitty.conf``
+====================  =====================================================================
+
+Without this setting, pressing ``Option+Backspace`` is handled by macOS
+itself and never reaches the application.

--- a/tui/topics/tick_loop.rst
+++ b/tui/topics/tick_loop.rst
@@ -100,7 +100,7 @@ callback, then stop when done::
         return true;
     });
 
-See :doc:`/integrations/revolt` for more on non-blocking I/O.
+See :doc:`/tui/integrations/revolt` for more on non-blocking I/O.
 
 Game Loops
 ----------

--- a/tui/topics/tick_loop.rst
+++ b/tui/topics/tick_loop.rst
@@ -1,0 +1,161 @@
+Tick Loop
+=========
+
+The tick loop is the heartbeat of a Tui application. It runs
+repeatedly while the Tui is active, giving your code a chance to
+check async results, update widgets and control the rendering pace.
+
+Registering a Tick Callback
+---------------------------
+
+Use ``Tui::onTick()`` to register a callback that runs on every
+tick:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Event\TickEvent;
+
+    $tui->onTick(function (TickEvent $event) {
+        // check async work, update widgets, etc.
+    });
+
+Pass ``null`` to remove the callback.
+
+The TickEvent
+-------------
+
+The ``TickEvent`` provides:
+
+* ``getDeltaTime()``: seconds elapsed since the previous tick. Use
+  this for time-based updates (animations, elapsed timers, etc.).
+
+Busy and Idle Hints
+-------------------
+
+The Tui adapts its tick frequency based on whether work is in
+progress:
+
+* **Busy** (10 ms interval): the Tui ticks at high frequency for
+  responsive updates while async work is running.
+* **Idle** (no ticking): the Tui stops ticking entirely when there
+  is nothing to poll, saving CPU.
+* **Fallback** (250 ms interval): when the Tui can't determine
+  busy/idle, it uses a slow poll.
+
+You control this by signaling whether you are busy. There are two
+equivalent ways:
+
+**Return a boolean** from the callback:
+
+.. code-block:: php
+
+    $tui->onTick(function (TickEvent $event) use ($future) {
+        if ($future->isComplete()) {
+            $result = $future->await();
+            // update widgets with the result
+
+            return false; // idle, stop ticking
+        }
+
+        return true; // busy, keep ticking fast
+    });
+
+**Call** ``setBusy()`` **on the event**:
+
+.. code-block:: php
+
+    $tui->onTick(function (TickEvent $event) use ($runner) {
+        $runner->tick();
+
+        $event->setBusy($runner->isStreaming());
+    });
+
+If you neither return a boolean nor call ``setBusy()``, the Tui
+falls back to slow polling (250 ms).
+
+Typical Pattern
+---------------
+
+A common pattern is to start async work, poll it in the tick
+callback, then stop when done:
+
+.. code-block:: php
+
+    use Amp\Process\Process;
+    use Symfony\Component\Tui\Event\TickEvent;
+    use function Amp\async;
+
+    $loader = new LoaderWidget('Installing...');
+    $tui->add($loader);
+
+    $future = async(function () {
+        $process = Process::start('composer install');
+
+        return $process->join();
+    });
+
+    $tui->onTick(function (TickEvent $event) use (
+        $future, $tui, $loader,
+    ) {
+        if ($future->isComplete()) {
+            $exitCode = $future->await();
+            $loader->stop();
+            $tui->onTick(null);
+
+            return false;
+        }
+
+        return true;
+    });
+
+See :doc:`/integrations/revolt` for more on non-blocking I/O.
+
+Game Loops
+----------
+
+Games and real-time animations need the tick callback to run
+continuously. Call ``$event->setBusy()`` so the Tui keeps ticking
+at 10 ms intervals instead of going idle:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Event\TickEvent;
+
+    $tui->onTick(function (TickEvent $event) use ($game, $widget) {
+        $game->update($event->getDeltaTime());
+        $widget->invalidate();
+        $event->setBusy();
+    });
+
+The simplest approach is to pass ``getDeltaTime()`` directly to
+your game logic. Movement and timers scale with real elapsed time,
+so the game runs at the same speed regardless of tick rate.
+
+Fixed Timestep
+~~~~~~~~~~~~~~
+
+When game logic must run at a deterministic rate (physics,
+collision detection), use ``PeriodicStepper`` to convert variable
+delta time into a fixed number of steps per tick:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Loop\PeriodicStepper;
+
+    // Run game logic 60 times per second
+    $stepper = PeriodicStepper::everyMs(16);
+
+    $tui->onTick(function (TickEvent $event) use (
+        $stepper, $game, $widget,
+    ) {
+        $steps = $stepper->advance();
+        for ($i = 0; $i < $steps; ++$i) {
+            $game->step(); // always the same time increment
+        }
+        $widget->invalidate();
+        $event->setBusy();
+    });
+
+If a tick takes longer than expected (e.g. a slow render),
+``PeriodicStepper`` catches up by returning multiple steps, capped
+at a maximum to prevent spirals.

--- a/tui/topics/tick_loop.rst
+++ b/tui/topics/tick_loop.rst
@@ -9,9 +9,7 @@ Registering a Tick Callback
 ---------------------------
 
 Use ``Tui::onTick()`` to register a callback that runs on every
-tick:
-
-.. code-block:: php
+tick::
 
     use Symfony\Component\Tui\Event\TickEvent;
 
@@ -45,9 +43,7 @@ progress:
 You control this by signaling whether you are busy. There are two
 equivalent ways:
 
-**Return a boolean** from the callback:
-
-.. code-block:: php
+**Return a boolean** from the callback::
 
     $tui->onTick(function (TickEvent $event) use ($future) {
         if ($future->isComplete()) {
@@ -60,9 +56,7 @@ equivalent ways:
         return true; // busy, keep ticking fast
     });
 
-**Call** ``setBusy()`` **on the event**:
-
-.. code-block:: php
+**Call** ``setBusy()`` **on the event**::
 
     $tui->onTick(function (TickEvent $event) use ($runner) {
         $runner->tick();
@@ -77,9 +71,7 @@ Typical Pattern
 ---------------
 
 A common pattern is to start async work, poll it in the tick
-callback, then stop when done:
-
-.. code-block:: php
+callback, then stop when done::
 
     use Amp\Process\Process;
     use Symfony\Component\Tui\Event\TickEvent;
@@ -115,9 +107,7 @@ Game Loops
 
 Games and real-time animations need the tick callback to run
 continuously. Call ``$event->setBusy()`` so the Tui keeps ticking
-at 10 ms intervals instead of going idle:
-
-.. code-block:: php
+at 10 ms intervals instead of going idle::
 
     use Symfony\Component\Tui\Event\TickEvent;
 
@@ -136,9 +126,7 @@ Fixed Timestep
 
 When game logic must run at a deterministic rate (physics,
 collision detection), use ``PeriodicStepper`` to convert variable
-delta time into a fixed number of steps per tick:
-
-.. code-block:: php
+delta time into a fixed number of steps per tick::
 
     use Symfony\Component\Tui\Loop\PeriodicStepper;
 

--- a/tui/widgets/basics.rst
+++ b/tui/widgets/basics.rst
@@ -9,9 +9,7 @@ Widget ID
 ---------
 
 Assign an id to any widget so you can retrieve it later from
-anywhere in the tree:
-
-.. code-block:: php
+anywhere in the tree::
 
     $input->setId('search');
     $tui->add($input);
@@ -19,9 +17,7 @@ anywhere in the tree:
     // Later, from anywhere
     $widget = $tui->getById('search');
 
-IDs can also be used to find widgets within a subtree:
-
-.. code-block:: php
+IDs can also be used to find widgets within a subtree::
 
     $found = $container->findById('search');
 
@@ -29,9 +25,7 @@ Style Classes
 -------------
 
 Style classes connect widgets to stylesheet rules. Add and remove
-them at any time:
-
-.. code-block:: php
+them at any time::
 
     $widget->addStyleClass('sidebar');
     $widget->addStyleClass('highlighted');
@@ -40,9 +34,7 @@ them at any time:
 A widget can have multiple style classes. The stylesheet resolves
 all matching rules and merges them (see :doc:`/tui/style/stylesheets`).
 
-Tailwind-style utility classes work the same way:
-
-.. code-block:: php
+Tailwind-style utility classes work the same way::
 
     $widget->addStyleClass('p-2');
     $widget->addStyleClass('bold');
@@ -54,18 +46,14 @@ Inline Styles
 -------------
 
 Set a style directly on a widget. This has the highest priority in
-the cascade and overrides all stylesheet rules:
-
-.. code-block:: php
+the cascade and overrides all stylesheet rules::
 
     use Symfony\Component\Tui\Style\Style;
 
     $widget->setStyle(new Style(bold: true, color: 'cyan'));
 
 Pass ``null`` to remove the inline style and fall back to the
-stylesheet:
-
-.. code-block:: php
+stylesheet::
 
     $widget->setStyle(null);
 
@@ -76,9 +64,7 @@ Per-Widget Event Listeners
 
 Register event listeners on a specific widget using the typed
 shortcut methods (``onSubmit()``, ``onCancel()``, etc.) or the
-generic ``on()`` method:
-
-.. code-block:: php
+generic ``on()`` method::
 
     use Symfony\Component\Tui\Event\SubmitEvent;
 
@@ -102,9 +88,7 @@ Vertical Expansion
 
 By default, widgets only occupy the rows they need. Some widgets
 can fill all remaining vertical space by enabling vertical
-expansion:
-
-.. code-block:: php
+expansion::
 
     $container->expandVertically(true);
     $editor->expandVertically(true);
@@ -125,9 +109,7 @@ Labels
 ------
 
 Widgets have an optional label, used by container widgets like
-``TabsWidget`` to display a title:
-
-.. code-block:: php
+``TabsWidget`` to display a title::
 
     $widget->setLabel('Overview');
 
@@ -136,8 +118,6 @@ Widget Tree
 
 Widgets form a tree. Container widgets (``ContainerWidget``,
 ``TabsWidget``, etc.) hold child widgets. You can walk up the tree
-with ``getParent()``:
-
-.. code-block:: php
+with ``getParent()``::
 
     $parent = $widget->getParent();

--- a/tui/widgets/basics.rst
+++ b/tui/widgets/basics.rst
@@ -1,0 +1,143 @@
+Widget Basics
+=============
+
+All widgets extend ``AbstractWidget``, which provides a set of
+common APIs. This page documents the features shared by every
+widget.
+
+Widget ID
+---------
+
+Assign an id to any widget so you can retrieve it later from
+anywhere in the tree:
+
+.. code-block:: php
+
+    $input->setId('search');
+    $tui->add($input);
+
+    // Later, from anywhere
+    $widget = $tui->getById('search');
+
+IDs can also be used to find widgets within a subtree:
+
+.. code-block:: php
+
+    $found = $container->findById('search');
+
+Style Classes
+-------------
+
+Style classes connect widgets to stylesheet rules. Add and remove
+them at any time:
+
+.. code-block:: php
+
+    $widget->addStyleClass('sidebar');
+    $widget->addStyleClass('highlighted');
+    $widget->removeStyleClass('highlighted');
+
+A widget can have multiple style classes. The stylesheet resolves
+all matching rules and merges them (see :doc:`/style/stylesheets`).
+
+Tailwind-style utility classes work the same way:
+
+.. code-block:: php
+
+    $widget->addStyleClass('p-2');
+    $widget->addStyleClass('bold');
+    $widget->addStyleClass('bg-red-500');
+
+See :doc:`/style/tailwind` for the full list of utility classes.
+
+Inline Styles
+-------------
+
+Set a style directly on a widget. This has the highest priority in
+the cascade and overrides all stylesheet rules:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Style\Style;
+
+    $widget->setStyle(new Style(bold: true, color: 'cyan'));
+
+Pass ``null`` to remove the inline style and fall back to the
+stylesheet:
+
+.. code-block:: php
+
+    $widget->setStyle(null);
+
+See :doc:`/style/style` for all available style properties.
+
+Per-Widget Event Listeners
+--------------------------
+
+Register event listeners on a specific widget using the typed
+shortcut methods (``onSubmit()``, ``onCancel()``, etc.) or the
+generic ``on()`` method:
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Event\SubmitEvent;
+
+    // Typed shortcut
+    $input->onSubmit(function (SubmitEvent $event) {
+        // ...
+    });
+
+    // Generic form (works for any event type)
+    $input->on(SubmitEvent::class, function (SubmitEvent $event) {
+        // ...
+    });
+
+Per-widget listeners are automatically scoped to the target widget
+and cleaned up when the widget is detached from the tree. See
+:doc:`/topics/events` for global listeners and the full event
+system.
+
+Vertical Expansion
+------------------
+
+By default, widgets only occupy the rows they need. Some widgets
+can fill all remaining vertical space by enabling vertical
+expansion:
+
+.. code-block:: php
+
+    $container->expandVertically(true);
+    $editor->expandVertically(true);
+
+The following widgets support vertical expansion:
+
+* ``ContainerWidget``: fills remaining height. Expansion propagates
+  automatically; if any child is vertically expanded, the container
+  reports itself as expanded too.
+* ``EditorWidget``: grows the editing area to fill available space.
+* ``AnimatedImageWidget``: grows the animation area to fill
+  available space (except in ``ImageScaling::None`` mode).
+
+This is useful for layouts where one section should grow to fill
+the terminal height while others stay at their natural size.
+
+Labels
+------
+
+Widgets have an optional label, used by container widgets like
+``TabsWidget`` to display a title:
+
+.. code-block:: php
+
+    $widget->setLabel('Overview');
+
+Widget Tree
+-----------
+
+Widgets form a tree. Container widgets (``ContainerWidget``,
+``TabsWidget``, etc.) hold child widgets. You can walk up the tree
+with ``getParent()``:
+
+.. code-block:: php
+
+    $parent = $widget->getParent();

--- a/tui/widgets/basics.rst
+++ b/tui/widgets/basics.rst
@@ -38,7 +38,7 @@ them at any time:
     $widget->removeStyleClass('highlighted');
 
 A widget can have multiple style classes. The stylesheet resolves
-all matching rules and merges them (see :doc:`/style/stylesheets`).
+all matching rules and merges them (see :doc:`/tui/style/stylesheets`).
 
 Tailwind-style utility classes work the same way:
 
@@ -48,7 +48,7 @@ Tailwind-style utility classes work the same way:
     $widget->addStyleClass('bold');
     $widget->addStyleClass('bg-red-500');
 
-See :doc:`/style/tailwind` for the full list of utility classes.
+See :doc:`/tui/style/tailwind` for the full list of utility classes.
 
 Inline Styles
 -------------
@@ -69,7 +69,7 @@ stylesheet:
 
     $widget->setStyle(null);
 
-See :doc:`/style/style` for all available style properties.
+See :doc:`/tui/style/style` for all available style properties.
 
 Per-Widget Event Listeners
 --------------------------
@@ -94,7 +94,7 @@ generic ``on()`` method:
 
 Per-widget listeners are automatically scoped to the target widget
 and cleaned up when the widget is detached from the tree. See
-:doc:`/topics/events` for global listeners and the full event
+:doc:`/tui/topics/events` for global listeners and the full event
 system.
 
 Vertical Expansion

--- a/tui/widgets/basics.rst
+++ b/tui/widgets/basics.rst
@@ -99,8 +99,6 @@ The following widgets support vertical expansion:
   automatically; if any child is vertically expanded, the container
   reports itself as expanded too.
 * ``EditorWidget``: grows the editing area to fill available space.
-* ``AnimatedImageWidget``: grows the animation area to fill
-  available space (except in ``ImageScaling::None`` mode).
 
 This is useful for layouts where one section should grow to fill
 the terminal height while others stay at their natural size.
@@ -108,16 +106,15 @@ the terminal height while others stay at their natural size.
 Labels
 ------
 
-Widgets have an optional label, used by container widgets like
-``TabsWidget`` to display a title::
+Widgets have an optional label, used by container widgets to display
+a title::
 
     $widget->setLabel('Overview');
 
 Widget Tree
 -----------
 
-Widgets form a tree. Container widgets (``ContainerWidget``,
-``TabsWidget``, etc.) hold child widgets. You can walk up the tree
-with ``getParent()``::
+Widgets form a tree. Container widgets such as ``ContainerWidget``
+hold child widgets. You can walk up the tree with ``getParent()``::
 
     $parent = $widget->getParent();

--- a/tui/widgets/cancellable_loader.rst
+++ b/tui/widgets/cancellable_loader.rst
@@ -1,7 +1,7 @@
 CancellableLoaderWidget
 =======================
 
-``CancellableLoaderWidget`` extends :doc:`loader` with focus and
+``CancellableLoaderWidget`` extends :doc:`/tui/widgets/loader` with focus and
 keyboard support so the user can cancel the operation by pressing
 **Escape** or **Ctrl+C**.
 
@@ -11,7 +11,7 @@ When to Use
 Use ``CancellableLoaderWidget`` for long-running operations that the
 user should be able to abort: network requests, file indexing, AI
 inference, etc. If the operation cannot be cancelled, use
-:doc:`loader` instead.
+:doc:`/tui/widgets/loader` instead.
 
 Basic Usage
 -----------
@@ -55,7 +55,7 @@ Inherited Features
 ------------------
 
 ``CancellableLoaderWidget`` inherits all features from
-:doc:`loader`: spinner styles, animation speed, message updates and
+:doc:`/tui/widgets/loader`: spinner styles, animation speed, message updates and
 the finished indicator.
 
 Default Keybindings

--- a/tui/widgets/cancellable_loader.rst
+++ b/tui/widgets/cancellable_loader.rst
@@ -34,7 +34,7 @@ Listen for the ``CancelEvent`` to react when the user cancels::
 
     use Symfony\Component\Tui\Event\CancelEvent;
 
-    $loader->onCancel(function (CancelEvent $event) {
+    $loader->onCancel(function (CancelEvent $event) use ($loader) {
         // abort the background operation
         $loader->stop();
     });

--- a/tui/widgets/cancellable_loader.rst
+++ b/tui/widgets/cancellable_loader.rst
@@ -1,0 +1,68 @@
+CancellableLoaderWidget
+=======================
+
+``CancellableLoaderWidget`` extends :doc:`loader` with focus and
+keyboard support so the user can cancel the operation by pressing
+**Escape** or **Ctrl+C**.
+
+When to Use
+-----------
+
+Use ``CancellableLoaderWidget`` for long-running operations that the
+user should be able to abort: network requests, file indexing, AI
+inference, etc. If the operation cannot be cancelled, use
+:doc:`loader` instead.
+
+Basic Usage
+-----------
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Widget\CancellableLoaderWidget;
+
+    $loader = new CancellableLoaderWidget('Generating response...');
+    $tui->add($loader);
+    $tui->setFocus($loader);
+
+Because ``CancellableLoaderWidget`` implements ``FocusableInterface``,
+it must receive focus to capture keyboard input.
+
+Handling Cancellation
+---------------------
+
+Listen for the ``CancelEvent`` to react when the user cancels::
+
+    use Symfony\Component\Tui\Event\CancelEvent;
+
+    $loader->onCancel(function (CancelEvent $event) {
+        // abort the background operation
+        $loader->stop();
+    });
+
+You can also check the cancellation state at any time::
+
+    if ($loader->isCancelled()) {
+        // handle cancellation
+    }
+
+Call ``reset()`` to clear the cancelled flag before reusing the
+widget::
+
+    $loader->reset();
+    $loader->start();
+
+Inherited Features
+------------------
+
+``CancellableLoaderWidget`` inherits all features from
+:doc:`loader`: spinner styles, animation speed, message updates and
+the finished indicator.
+
+Default Keybindings
+-------------------
+
+====================  ====================
+Key                   Action
+====================  ====================
+Escape, Ctrl+C        Cancel
+====================  ====================

--- a/tui/widgets/container.rst
+++ b/tui/widgets/container.rst
@@ -1,0 +1,124 @@
+ContainerWidget
+===============
+
+``ContainerWidget`` groups child widgets and arranges them using
+vertical or horizontal layout. It is the primary tool for composing
+complex terminal interfaces from smaller widgets.
+
+When to Use
+-----------
+
+Use ``ContainerWidget`` whenever you need to combine several widgets
+into a single visual region: a sidebar next to a main content area,
+a stack of form fields, a toolbar of buttons, etc.
+
+Basic Usage
+-----------
+
+Create a container, add children and attach it to the Tui::
+
+    use Symfony\Component\Tui\Widget\ContainerWidget;
+    use Symfony\Component\Tui\Widget\TextWidget;
+
+    $container = new ContainerWidget();
+    $container->add(new TextWidget('First'));
+    $container->add(new TextWidget('Second'));
+    $tui->add($container);
+
+By default, children are stacked vertically (top to bottom).
+
+Layout Direction
+----------------
+
+Set the layout direction to arrange children horizontally::
+
+    use Symfony\Component\Tui\Style\Direction;
+    use Symfony\Component\Tui\Style\Style;
+
+    $container->setStyle(new Style(direction: Direction::Horizontal));
+
+Or use a stylesheet rule::
+
+    $stylesheet->addRule('.toolbar', new Style(
+        direction: Direction::Horizontal,
+        gap: 2,
+    ));
+    $container->addStyleClass('toolbar');
+
+Gap
+---
+
+The ``gap`` style property adds spacing (in terminal rows for vertical
+layout, columns for horizontal layout) between children::
+
+    $container->setStyle(new Style(gap: 1));
+
+Flex Column Widths
+------------------
+
+In horizontal layouts, children share space equally by default. The
+``flex`` style property gives you control over how space is distributed:
+
+- ``flex: 0``: the child gets its intrinsic (content) width
+- ``flex: 1+``: the child gets a proportional share of the remaining space
+
+A fixed sidebar next to a flexible main area::
+
+    $sidebar->setStyle(new Style(flex: 0));
+    $main->setStyle(new Style(flex: 1));
+
+Three columns with a 1:2:1 ratio::
+
+    $left->setStyle(new Style(flex: 1));
+    $center->setStyle(new Style(flex: 2));
+    $right->setStyle(new Style(flex: 1));
+
+Combine ``flex: 0`` with ``maxColumns`` to cap the intrinsic width::
+
+    $sidebar->setStyle(new Style(flex: 0, maxColumns: 30));
+
+When no child has ``flex`` set, horizontal layout falls back to equal
+distribution (backward compatible).
+
+Vertical Expansion
+------------------
+
+A container can fill all available vertical space by calling
+``expandVertically(true)``. This is useful for layouts where one
+section should grow to fill the remaining terminal height::
+
+    $container->expandVertically(true);
+
+Vertical expansion also propagates automatically: if any child is
+vertically expanded, the container reports itself as expanded too.
+
+Managing Children
+-----------------
+
+Add, remove or clear children at any time::
+
+    $container->add($widget);
+    $container->remove($widget);
+    $container->clear();
+
+Call ``all()`` to retrieve the current list of children::
+
+    $children = $container->all();
+
+Styling
+-------
+
+Like all widgets, ``ContainerWidget`` supports padding, borders and
+background colors through the Style system::
+
+    $container->setStyle(new Style(
+        padding: 1,
+        border: Border::Rounded,
+        bg: Color::Gray,
+    ));
+
+Events
+------
+
+``ContainerWidget`` does not emit any events. It is a layout-only
+widget and does not handle input directly.

--- a/tui/widgets/container.rst
+++ b/tui/widgets/container.rst
@@ -114,6 +114,7 @@ background colors through the Style system::
     use Symfony\Component\Tui\Style\Border;
     use Symfony\Component\Tui\Style\Color;
     use Symfony\Component\Tui\Style\Padding;
+    use Symfony\Component\Tui\Style\Style;
 
     $container->setStyle(new Style(
         padding: Padding::all(1),

--- a/tui/widgets/container.rst
+++ b/tui/widgets/container.rst
@@ -111,10 +111,14 @@ Styling
 Like all widgets, ``ContainerWidget`` supports padding, borders and
 background colors through the Style system::
 
+    use Symfony\Component\Tui\Style\Border;
+    use Symfony\Component\Tui\Style\Color;
+    use Symfony\Component\Tui\Style\Padding;
+
     $container->setStyle(new Style(
-        padding: 1,
-        border: Border::Rounded,
-        bg: Color::Gray,
+        padding: Padding::all(1),
+        border: Border::all(1, 'rounded'),
+        background: Color::named('gray'),
     ));
 
 Events

--- a/tui/widgets/editor.rst
+++ b/tui/widgets/editor.rst
@@ -78,16 +78,17 @@ Key                           Action
 Enter                         Submit
 Shift+Enter                   Insert newline
 Escape                        Cancel
+Shift+Space                   Insert a space
 Up / Down                     Move cursor
 Left, Ctrl+B                  Move cursor left
 Right, Ctrl+F                 Move cursor right
-Alt+Left, Ctrl+Left           Move word left
-Alt+Right, Ctrl+Right         Move word right
+Alt+Left, Ctrl+Left, Alt+B    Move word left
+Alt+Right, Ctrl+Right, Alt+F  Move word right
 Home, Ctrl+A                  Move to line start
 End, Ctrl+E                   Move to line end
 Page Up / Page Down           Scroll by page
-Backspace                     Delete character backward
-Delete, Ctrl+D                Delete character forward
+Backspace, Shift+Backspace    Delete character backward
+Delete, Ctrl+D, Shift+Delete  Delete character forward
 Ctrl+W, Alt+Backspace         Delete word backward
 Alt+D, Alt+Delete             Delete word forward
 Ctrl+Shift+K                  Delete entire line
@@ -99,4 +100,11 @@ Ctrl+Y                        Yank (paste from kill ring)
 Alt+Y                         Yank pop (cycle kill ring)
 Ctrl+]                        Jump forward to character
 Ctrl+Alt+]                    Jump backward to character
+Ctrl+C                        Copy (not handled, see below)
 ============================  ==============================
+
+``Ctrl+C`` is bound to the ``copy`` action, but the editor has no
+selection model and does not implement it: the key event is ignored
+by the widget and left for the parent application to handle (the
+conventional copy or abort signal). Rebind ``copy`` if that key is
+needed for something else.

--- a/tui/widgets/editor.rst
+++ b/tui/widgets/editor.rst
@@ -2,7 +2,7 @@ EditorWidget
 ============
 
 ``EditorWidget`` is a full-featured multi-line text editor with word
-wrapping, scrolling, undo/redo, a kill ring and autocomplete support.
+wrapping, scrolling, undo/redo and a kill ring.
 
 When to Use
 -----------
@@ -40,20 +40,6 @@ To make the editor fill all remaining vertical space, call::
 
     $editor->expandVertically(true);
 
-Autocomplete
-------------
-
-Attach an autocomplete provider to get context-aware suggestions when
-the user presses **Tab**::
-
-    use Symfony\Component\Tui\Autocomplete\FilePathProvider;
-
-    $editor->setAutocompleteProvider(new FilePathProvider());
-
-The autocomplete dropdown appears inline and can be navigated with
-**Up**/**Down** and confirmed with **Enter**. Press **Escape** to
-dismiss it.
-
 Events
 ------
 
@@ -69,8 +55,7 @@ Events
           $text = $event->getValue();
       });
 
-* ``CancelEvent``: Fired when the user presses **Escape** or
-  **Ctrl+C** (if no autocomplete dropdown is open)::
+* ``CancelEvent``: Fired when the user presses **Escape**::
 
       $editor->onCancel(function () {
           // discard changes or close the editor
@@ -92,9 +77,8 @@ Key                           Action
 ============================  ==============================
 Enter                         Submit
 Shift+Enter                   Insert newline
-Escape, Ctrl+C                Cancel / close autocomplete
-Tab                           Trigger autocomplete
-Up / Down                     Move cursor or navigate autocomplete
+Escape                        Cancel
+Up / Down                     Move cursor
 Left, Ctrl+B                  Move cursor left
 Right, Ctrl+F                 Move cursor right
 Alt+Left, Ctrl+Left           Move word left

--- a/tui/widgets/editor.rst
+++ b/tui/widgets/editor.rst
@@ -9,7 +9,7 @@ When to Use
 
 Use ``EditorWidget`` when you need multi-line text editing: a message
 composer, a code snippet editor, a configuration file viewer, etc.
-For single-line input, use :doc:`input` instead.
+For single-line input, use :doc:`/tui/widgets/input` instead.
 
 Basic Usage
 -----------

--- a/tui/widgets/editor.rst
+++ b/tui/widgets/editor.rst
@@ -1,0 +1,118 @@
+EditorWidget
+============
+
+``EditorWidget`` is a full-featured multi-line text editor with word
+wrapping, scrolling, undo/redo, a kill ring and autocomplete support.
+
+When to Use
+-----------
+
+Use ``EditorWidget`` when you need multi-line text editing: a message
+composer, a code snippet editor, a configuration file viewer, etc.
+For single-line input, use :doc:`input` instead.
+
+Basic Usage
+-----------
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Widget\EditorWidget;
+
+    $editor = new EditorWidget();
+    $tui->add($editor);
+    $tui->setFocus($editor);
+
+Set or read the editor content::
+
+    $editor->setText("Line one\nLine two");
+    $content = $editor->getText();
+
+Sizing
+------
+
+Control the visible height of the editor with minimum and maximum line
+counts::
+
+    $editor->setMinVisibleLines(5);
+    $editor->setMaxVisibleLines(20);
+
+To make the editor fill all remaining vertical space, call::
+
+    $editor->expandVertically(true);
+
+Autocomplete
+------------
+
+Attach an autocomplete provider to get context-aware suggestions when
+the user presses **Tab**::
+
+    use Symfony\Component\Tui\Autocomplete\FilePathProvider;
+
+    $editor->setAutocompleteProvider(new FilePathProvider());
+
+The autocomplete dropdown appears inline and can be navigated with
+**Up**/**Down** and confirmed with **Enter**. Press **Escape** to
+dismiss it.
+
+Events
+------
+
+``EditorWidget`` dispatches three events:
+
+* ``SubmitEvent``: Fired when the user presses **Enter** (the
+  default submit binding). Use ``Shift+Enter`` to insert a newline
+  instead::
+
+      use Symfony\Component\Tui\Event\SubmitEvent;
+
+      $editor->onSubmit(function (SubmitEvent $event) {
+          $text = $event->getValue();
+      });
+
+* ``CancelEvent``: Fired when the user presses **Escape** or
+  **Ctrl+C** (if no autocomplete dropdown is open)::
+
+      $editor->onCancel(function () {
+          // discard changes or close the editor
+      });
+
+* ``ChangeEvent``: Fired on every text modification::
+
+      use Symfony\Component\Tui\Event\ChangeEvent;
+
+      $editor->onChange(function (ChangeEvent $event) {
+          $currentText = $event->getValue();
+      });
+
+Default Keybindings
+-------------------
+
+============================  ==============================
+Key                           Action
+============================  ==============================
+Enter                         Submit
+Shift+Enter                   Insert newline
+Escape, Ctrl+C                Cancel / close autocomplete
+Tab                           Trigger autocomplete
+Up / Down                     Move cursor or navigate autocomplete
+Left, Ctrl+B                  Move cursor left
+Right, Ctrl+F                 Move cursor right
+Alt+Left, Ctrl+Left           Move word left
+Alt+Right, Ctrl+Right         Move word right
+Home, Ctrl+A                  Move to line start
+End, Ctrl+E                   Move to line end
+Page Up / Page Down           Scroll by page
+Backspace                     Delete character backward
+Delete, Ctrl+D                Delete character forward
+Ctrl+W, Alt+Backspace         Delete word backward
+Alt+D, Alt+Delete             Delete word forward
+Ctrl+Shift+K                  Delete entire line
+Ctrl+U                        Delete to line start
+Ctrl+K                        Delete to line end
+Ctrl+- (minus)                Undo
+Ctrl+Shift+Z                  Redo
+Ctrl+Y                        Yank (paste from kill ring)
+Alt+Y                         Yank pop (cycle kill ring)
+Ctrl+]                        Jump forward to character
+Ctrl+Alt+]                    Jump backward to character
+============================  ==============================

--- a/tui/widgets/index.rst
+++ b/tui/widgets/index.rst
@@ -19,7 +19,6 @@ the focus manager can route key events to them.
     input
     editor
     select_list
-    tabs
     settings_list
     loader
     cancellable_loader

--- a/tui/widgets/index.rst
+++ b/tui/widgets/index.rst
@@ -1,0 +1,27 @@
+Widgets
+=======
+
+Widgets are the building blocks of a Tui application. Each widget is
+responsible for rendering a piece of the terminal UI and, optionally,
+handling user input.
+
+All widgets extend ``AbstractWidget``, which provides common features
+such as style classes, state flags, event listeners and invalidation.
+Widgets that accept keyboard input implement ``FocusableInterface`` so
+the focus manager can route key events to them.
+
+.. toctree::
+    :maxdepth: 1
+
+    basics
+    text
+    container
+    input
+    editor
+    select_list
+    tabs
+    settings_list
+    loader
+    cancellable_loader
+    progress_bar
+    markdown

--- a/tui/widgets/input.rst
+++ b/tui/widgets/input.rst
@@ -9,7 +9,7 @@ When to Use
 
 Use ``InputWidget`` when you need a short, single-line text field:
 a search box, a filename prompt, a command palette filter, etc.
-For multi-line editing, use :doc:`editor` instead.
+For multi-line editing, use :doc:`/tui/widgets/editor` instead.
 
 Basic Usage
 -----------

--- a/tui/widgets/input.rst
+++ b/tui/widgets/input.rst
@@ -1,0 +1,105 @@
+InputWidget
+===========
+
+``InputWidget`` is a single-line text input with cursor,
+horizontal scrolling and configurable keybindings.
+
+When to Use
+-----------
+
+Use ``InputWidget`` when you need a short, single-line text field:
+a search box, a filename prompt, a command palette filter, etc.
+For multi-line editing, use :doc:`editor` instead.
+
+Basic Usage
+-----------
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Widget\InputWidget;
+
+    $input = new InputWidget();
+    $tui->add($input);
+    $tui->setFocus($input);
+
+Set an initial value or read the current value::
+
+    $input->setValue('initial text');
+    $value = $input->getValue();
+
+Prompt
+------
+
+The prompt string is displayed before the cursor. Change it with
+``setPrompt()``::
+
+    $input->setPrompt('Search: ');
+
+The default prompt is ``> ``.
+
+Events
+------
+
+``InputWidget`` dispatches three events:
+
+* ``SubmitEvent``: Fired when the user presses **Enter**. The event
+  carries the current text value::
+
+      use Symfony\Component\Tui\Event\SubmitEvent;
+
+      $input->onSubmit(function (SubmitEvent $event) {
+          $value = $event->getValue();
+          // process the submitted text
+      });
+
+* ``CancelEvent``: Fired when the user presses **Escape** or
+  **Ctrl+C**::
+
+      $input->onCancel(function () {
+          // close the input or revert changes
+      });
+
+* ``ChangeEvent``: Fired on every text modification (typing,
+  deleting, pasting)::
+
+      use Symfony\Component\Tui\Event\ChangeEvent;
+
+      $input->onChange(function (ChangeEvent $event) {
+          $currentText = $event->getValue();
+      });
+
+You can check after the fact whether the input was submitted or
+cancelled with ``wasSubmitted()``.
+
+Default Keybindings
+-------------------
+
+========================  ==================================
+Key                       Action
+========================  ==================================
+Enter                     Submit
+Escape, Ctrl+C            Cancel
+Left, Ctrl+B              Move cursor left
+Right, Ctrl+F             Move cursor right
+Alt+Left, Ctrl+Left       Move word left
+Alt+Right, Ctrl+Right     Move word right
+Home, Ctrl+A              Move to line start
+End, Ctrl+E               Move to line end
+Backspace                 Delete character backward
+Delete, Ctrl+D            Delete character forward
+Ctrl+W, Alt+Backspace     Delete word backward
+Ctrl+U                    Delete to line start
+Ctrl+K                    Delete to line end
+========================  ==================================
+
+Custom Keybindings
+------------------
+
+Pass a ``Keybindings`` instance to the constructor to override any
+of the default bindings::
+
+    use Symfony\Component\Tui\Input\Keybindings;
+
+    $input = new InputWidget(keybindings: new Keybindings([
+        'submit' => ['ctrl+s'],
+    ]));

--- a/tui/widgets/input.rst
+++ b/tui/widgets/input.rst
@@ -74,23 +74,23 @@ cancelled with ``wasSubmitted()``.
 Default Keybindings
 -------------------
 
-========================  ==================================
-Key                       Action
-========================  ==================================
-Enter                     Submit
-Escape, Ctrl+C            Cancel
-Left, Ctrl+B              Move cursor left
-Right, Ctrl+F             Move cursor right
-Alt+Left, Ctrl+Left       Move word left
-Alt+Right, Ctrl+Right     Move word right
-Home, Ctrl+A              Move to line start
-End, Ctrl+E               Move to line end
-Backspace                 Delete character backward
-Delete, Ctrl+D            Delete character forward
-Ctrl+W, Alt+Backspace     Delete word backward
-Ctrl+U                    Delete to line start
-Ctrl+K                    Delete to line end
-========================  ==================================
+============================  ==================================
+Key                           Action
+============================  ==================================
+Enter                         Submit
+Escape, Ctrl+C                Cancel
+Left, Ctrl+B                  Move cursor left
+Right, Ctrl+F                 Move cursor right
+Alt+Left, Ctrl+Left, Alt+B    Move word left
+Alt+Right, Ctrl+Right, Alt+F  Move word right
+Home, Ctrl+A                  Move to line start
+End, Ctrl+E                   Move to line end
+Backspace, Shift+Backspace    Delete character backward
+Delete, Ctrl+D, Shift+Delete  Delete character forward
+Ctrl+W, Alt+Backspace         Delete word backward
+Ctrl+U                        Delete to line start
+Ctrl+K                        Delete to line end
+============================  ==================================
 
 Custom Keybindings
 ------------------

--- a/tui/widgets/loader.rst
+++ b/tui/widgets/loader.rst
@@ -10,8 +10,8 @@ When to Use
 Use ``LoaderWidget`` to indicate that a background operation is in
 progress: loading data, waiting for a network response, processing
 files, etc. For operations that can be cancelled, use
-:doc:`cancellable_loader`. For operations with measurable progress,
-use :doc:`progress_bar`.
+:doc:`/tui/widgets/cancellable_loader`. For operations with measurable progress,
+use :doc:`/tui/widgets/progress_bar`.
 
 Basic Usage
 -----------

--- a/tui/widgets/loader.rst
+++ b/tui/widgets/loader.rst
@@ -1,0 +1,86 @@
+LoaderWidget
+============
+
+``LoaderWidget`` displays an animated spinner with a text message.
+The animation advances automatically via the event loop.
+
+When to Use
+-----------
+
+Use ``LoaderWidget`` to indicate that a background operation is in
+progress: loading data, waiting for a network response, processing
+files, etc. For operations that can be cancelled, use
+:doc:`cancellable_loader`. For operations with measurable progress,
+use :doc:`progress_bar`.
+
+Basic Usage
+-----------
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Widget\LoaderWidget;
+
+    $loader = new LoaderWidget('Fetching data...');
+    $tui->add($loader);
+
+The loader starts automatically on construction. Stop it when the
+operation completes::
+
+    $loader->stop();
+
+Call ``start()`` to restart the animation after stopping it.
+
+Message
+-------
+
+Update the message while the loader is running::
+
+    $loader->setMessage('Processing items...');
+
+Spinner Styles
+--------------
+
+Eight built-in spinner styles are available: ``dots`` (default),
+``line``, ``bounce``, ``pulse``, ``bar``, ``shade``, ``arc`` and
+``circle``.
+
+Switch the style with ``setSpinner()``::
+
+    $loader->setSpinner('pulse');
+
+Register a custom spinner with ``addSpinner()``::
+
+    LoaderWidget::addSpinner('arrows', ['←', '↑', '→', '↓']);
+    $loader->setSpinner('arrows');
+
+Animation Speed
+---------------
+
+Control the frame rate with ``setIntervalMs()``::
+
+    $loader->setIntervalMs(120); // slower animation
+
+The default interval is 80 ms.
+
+Finished Indicator
+------------------
+
+Show a static character when the loader stops instead of hiding it
+entirely::
+
+    $loader->setFinishedIndicator('✓');
+    $loader->stop(); // displays "✓ Fetching data..."
+
+Styleable Elements
+------------------
+
+``LoaderWidget`` exposes two styleable elements:
+
+* ``spinner``: the animated character.
+* ``message``: the text next to the spinner.
+
+Events
+------
+
+``LoaderWidget`` does not emit any events. Check its state with
+``isRunning()``.

--- a/tui/widgets/markdown.rst
+++ b/tui/widgets/markdown.rst
@@ -1,0 +1,93 @@
+MarkdownWidget
+==============
+
+``MarkdownWidget`` renders Markdown text with terminal styling. It
+uses ``league/commonmark`` for parsing and ``tempest/highlight`` for
+syntax highlighting of fenced code blocks.
+
+When to Use
+-----------
+
+Use ``MarkdownWidget`` when you need to display rich formatted text:
+AI assistant responses, documentation previews, changelogs, README
+files, etc. For plain unformatted text, use :doc:`text` instead.
+
+Basic Usage
+-----------
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Widget\MarkdownWidget;
+
+    $md = new MarkdownWidget('# Hello
+
+    This is **bold** and *italic* text.');
+    $tui->add($md);
+
+Update the content at any time::
+
+    $md->setText($newMarkdown);
+
+Supported Markdown Features
+---------------------------
+
+``MarkdownWidget`` supports the full CommonMark specification plus
+GitHub Flavored Markdown extensions:
+
+* **Headings** (``# H1`` through ``###### H6``), rendered with a
+  ``#`` prefix and heading styling.
+* **Bold** (``**text**``) and **italic** (``*text*``).
+* **Strikethrough** (``~~text~~``).
+* **Inline code** (````code````), highlighted with code styling.
+* **Fenced code blocks** with syntax highlighting for most languages.
+* **Indented code blocks**.
+* **Block quotes** (``> text``), rendered with a vertical border.
+* **Ordered and unordered lists**.
+* **Links** (``[text](url)``), the URL is displayed in parentheses.
+* **Tables**, rendered with Unicode box-drawing characters.
+* **Horizontal rules** (``---``).
+
+Syntax Highlighting
+-------------------
+
+Fenced code blocks with a language identifier are syntax-highlighted
+automatically::
+
+    $md = new MarkdownWidget('
+    ```php
+    $greeting = "Hello, world!";
+    echo $greeting;
+    ```
+    ');
+
+The default highlighter uses a dark terminal theme. Pass a custom
+``Highlighter`` instance to the constructor for a different theme::
+
+    use Tempest\Highlight\Highlighter;
+
+    $md = new MarkdownWidget($text, highlighter: new Highlighter($myTheme));
+
+Styleable Elements
+------------------
+
+``MarkdownWidget`` exposes several styleable elements for fine-grained
+control over the appearance:
+
+* ``heading``: heading text.
+* ``bold``: bold inline text.
+* ``italic``: italic inline text.
+* ``strikethrough``: strikethrough text.
+* ``code``: inline code.
+* ``code-block-border``: top/bottom border of code blocks.
+* ``quote``: block quote text.
+* ``quote-border``: block quote vertical border.
+* ``list-bullet``: list bullet or number.
+* ``link``: link text.
+* ``link-url``: link URL.
+* ``hr``: horizontal rule.
+
+Events
+------
+
+``MarkdownWidget`` does not emit any events. It is a pure display
+widget.

--- a/tui/widgets/markdown.rst
+++ b/tui/widgets/markdown.rst
@@ -10,7 +10,7 @@ When to Use
 
 Use ``MarkdownWidget`` when you need to display rich formatted text:
 AI assistant responses, documentation previews, changelogs, README
-files, etc. For plain unformatted text, use :doc:`text` instead.
+files, etc. For plain unformatted text, use :doc:`/tui/widgets/text` instead.
 
 Basic Usage
 -----------
@@ -38,7 +38,7 @@ GitHub Flavored Markdown extensions:
   ``#`` prefix and heading styling.
 * **Bold** (``**text**``) and **italic** (``*text*``).
 * **Strikethrough** (``~~text~~``).
-* **Inline code** (````code````), highlighted with code styling.
+* **Inline code** (``code``), highlighted with code styling.
 * **Fenced code blocks** with syntax highlighting for most languages.
 * **Indented code blocks**.
 * **Block quotes** (``> text``), rendered with a vertical border.

--- a/tui/widgets/progress_bar.rst
+++ b/tui/widgets/progress_bar.rst
@@ -1,0 +1,133 @@
+ProgressBarWidget
+=================
+
+``ProgressBarWidget`` renders an animated progress bar with
+configurable format, characters and placeholders. It supports both
+determinate (known total) and indeterminate (unknown total) modes.
+
+When to Use
+-----------
+
+Use ``ProgressBarWidget`` when you can measure or estimate the
+progress of an operation: file downloads, batch processing, indexing,
+etc. For operations without measurable progress, use :doc:`loader`
+instead.
+
+Basic Usage
+-----------
+
+Determinate mode (known total)::
+
+    use Symfony\Component\Tui\Widget\ProgressBarWidget;
+
+    $progress = new ProgressBarWidget(max: 100);
+    $tui->add($progress);
+    $progress->start();
+
+    // In your processing loop:
+    $progress->advance();     // +1 step
+    $progress->advance(10);   // +10 steps
+    $progress->setProgress(50); // jump to step 50
+
+    $progress->finish();      // complete the bar
+
+Indeterminate mode (unknown total)::
+
+    $progress = new ProgressBarWidget(); // max: 0
+    $progress->start();
+    $progress->advance(); // increments the counter without a percentage
+
+Format Strings
+--------------
+
+The format string controls what is displayed. Several built-in formats
+are available as class constants:
+
+``FORMAT_NORMAL``
+    ``3/10 [━━━━━━━━━━━━━━━━]  30%``
+
+``FORMAT_VERBOSE``
+    ``3/10 [━━━━━━━━━━━━━━━━]  30% 0:05``
+
+``FORMAT_VERY_VERBOSE``
+    ``3/10 [━━━━━━━━━━━━━━━━]  30% 0:05/0:15``
+
+``FORMAT_DEBUG``
+    ``3/10 [━━━━━━━━━━━━━━━━]  30% 0:05/0:15 12.0 MiB``
+
+``FORMAT_INDETERMINATE``
+    ``42 [━━━━━━━━━━━━━━━━]``
+
+Set a custom format at any time::
+
+    $progress->setFormat(' %current%/%max% [%bar%] %percent%% %message%');
+
+Built-in Placeholders
+---------------------
+
+==================  ==========================================
+Placeholder         Description
+==================  ==========================================
+``%current%``       Current step
+``%max%``           Maximum steps
+``%bar%``           The visual bar
+``%percent%``       Percentage (0–100)
+``%elapsed%``       Elapsed time (``m:ss``)
+``%remaining%``     Estimated remaining time
+``%estimated%``     Estimated total time
+``%memory%``        Current memory usage
+``%message%``       Custom message (see below)
+==================  ==========================================
+
+Custom Placeholders
+-------------------
+
+Register a custom placeholder formatter::
+
+    $progress->setPlaceholderFormatter(
+        'rate',
+        function (ProgressBarWidget $bar) {
+            $elapsed = time() - $bar->getStartTime();
+
+            return $elapsed > 0
+                ? sprintf('%.1f items/s', $bar->getProgress() / $elapsed)
+                : '0 items/s';
+        },
+    );
+    $progress->setFormat(' %current%/%max% [%bar%] %rate%');
+
+Messages
+--------
+
+Attach named messages for use in the format string::
+
+    $progress->setMessage('Downloading archive...');
+    $progress->setMessage('archive.tar.gz', 'filename');
+
+Retrieve them with ``getMessage('filename')``.
+
+Bar Characters
+--------------
+
+Customize the bar appearance::
+
+    $progress->setBarCharacter('█');       // filled portion
+    $progress->setEmptyBarCharacter('░');  // empty portion
+    $progress->setProgressCharacter('▸');  // cursor at progress position
+    $progress->setBarWidth(40);           // bar width in characters
+
+Styleable Elements
+------------------
+
+``ProgressBarWidget`` exposes four styleable elements:
+
+* ``text``: the full rendered line.
+* ``bar-fill``: the filled portion of the bar.
+* ``bar-empty``: the empty portion of the bar.
+* ``bar-progress``: the progress character.
+
+Events
+------
+
+``ProgressBarWidget`` does not emit events. Query its state with
+``isRunning()``, ``getProgress()`` and ``getProgressPercent()``.

--- a/tui/widgets/progress_bar.rst
+++ b/tui/widgets/progress_bar.rst
@@ -10,7 +10,7 @@ When to Use
 
 Use ``ProgressBarWidget`` when you can measure or estimate the
 progress of an operation: file downloads, batch processing, indexing,
-etc. For operations without measurable progress, use :doc:`loader`
+etc. For operations without measurable progress, use :doc:`/tui/widgets/loader`
 instead.
 
 Basic Usage

--- a/tui/widgets/select_list.rst
+++ b/tui/widgets/select_list.rst
@@ -1,0 +1,105 @@
+SelectListWidget
+================
+
+``SelectListWidget`` displays a scrollable list of items with keyboard
+navigation. The user can move through the list and confirm a selection.
+
+When to Use
+-----------
+
+Use ``SelectListWidget`` when the user must pick one item from a list:
+a file picker, a command palette result list, a model selector, etc.
+For settings that cycle through predefined values, consider
+:doc:`settings_list` instead.
+
+Basic Usage
+-----------
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Widget\SelectListWidget;
+
+    $items = [
+        ['value' => 'apple', 'label' => 'Apple'],
+        ['value' => 'banana', 'label' => 'Banana'],
+        ['value' => 'cherry', 'label' => 'Cherry'],
+    ];
+
+    $list = new SelectListWidget($items);
+    $tui->add($list);
+    $tui->setFocus($list);
+
+Each item is an associative array with at least ``value`` and ``label``
+keys. An optional ``description`` key adds secondary text next to the
+selected item.
+
+Visible Count
+-------------
+
+Control how many items are visible at once with the ``maxVisible``
+parameter (default ``5``)::
+
+    $list = new SelectListWidget($items, maxVisible: 10);
+
+A scroll indicator (e.g. ``(3/12)``) appears when the list is longer
+than the visible window.
+
+Filtering
+---------
+
+Call ``setFilter()`` to narrow the list to items whose value starts
+with the given string. This is useful when combining a
+``SelectListWidget`` with an :doc:`input` for fuzzy search::
+
+    $list->setFilter('ban'); // shows only "Banana"
+
+Updating Items
+--------------
+
+Replace the full item list at runtime with ``setItems()``::
+
+    $list->setItems($newItems);
+
+This resets the selection index and any active filter.
+
+Events
+------
+
+* ``SelectEvent``: Fired when the user confirms a selection with
+  **Enter**::
+
+      use Symfony\Component\Tui\Event\SelectEvent;
+
+      $list->onSelect(function (SelectEvent $event) {
+          $value = $event->getValue();
+      });
+
+* ``CancelEvent``: Fired when the user presses **Escape** or
+  **Ctrl+C**::
+
+      $list->onCancel(function () {
+          // close the list
+      });
+
+* ``SelectionChangeEvent``: Fired whenever the highlighted item
+  changes (arrow keys, scroll, click)::
+
+      use Symfony\Component\Tui\Event\SelectionChangeEvent;
+
+      $list->onSelectionChange(function (SelectionChangeEvent $event) {
+          $highlighted = $event->getValue();
+      });
+
+Default Keybindings
+-------------------
+
+==========================  ==================================
+Key                         Action
+==========================  ==================================
+Up                          Move selection up (wraps)
+Down                        Move selection down (wraps)
+Page Up, Left               Page up
+Page Down, Right             Page down
+Enter                       Confirm selection
+Escape, Ctrl+C              Cancel
+==========================  ==================================

--- a/tui/widgets/select_list.rst
+++ b/tui/widgets/select_list.rst
@@ -10,7 +10,7 @@ When to Use
 Use ``SelectListWidget`` when the user must pick one item from a list:
 a file picker, a command palette result list, a model selector, etc.
 For settings that cycle through predefined values, consider
-:doc:`settings_list` instead.
+:doc:`/tui/widgets/settings_list` instead.
 
 Basic Usage
 -----------
@@ -49,7 +49,7 @@ Filtering
 
 Call ``setFilter()`` to narrow the list to items whose value starts
 with the given string. This is useful when combining a
-``SelectListWidget`` with an :doc:`input` for fuzzy search::
+``SelectListWidget`` with an :doc:`/tui/widgets/input` for fuzzy search::
 
     $list->setFilter('ban'); // shows only "Banana"
 

--- a/tui/widgets/select_list.rst
+++ b/tui/widgets/select_list.rst
@@ -47,9 +47,11 @@ than the visible window.
 Filtering
 ---------
 
-Call ``setFilter()`` to narrow the list to items whose value starts
-with the given string. This is useful when combining a
-``SelectListWidget`` with an :doc:`/tui/widgets/input` for fuzzy search::
+Call ``setFilter()`` to narrow the list to the items whose ``value``
+starts with the given string. The comparison is case-insensitive and
+applies to the ``value`` key only, not to ``label`` or ``description``.
+This is useful when combining a ``SelectListWidget`` with an
+:doc:`/tui/widgets/input` used as a search box::
 
     $list->setFilter('ban'); // shows only "Banana"
 

--- a/tui/widgets/settings_list.rst
+++ b/tui/widgets/settings_list.rst
@@ -10,8 +10,8 @@ When to Use
 
 Use ``SettingsListWidget`` for preference panels, configuration screens
 or any UI where the user picks values for a set of named options. For
-free-form text input, use :doc:`input` or :doc:`editor`. For picking a
-single item from a plain list, use :doc:`select_list`.
+free-form text input, use :doc:`/tui/widgets/input` or :doc:`/tui/widgets/editor`. For picking a
+single item from a plain list, use :doc:`/tui/widgets/select_list`.
 
 Basic Usage
 -----------

--- a/tui/widgets/settings_list.rst
+++ b/tui/widgets/settings_list.rst
@@ -10,8 +10,9 @@ When to Use
 
 Use ``SettingsListWidget`` for preference panels, configuration screens
 or any UI where the user picks values for a set of named options. For
-free-form text input, use :doc:`/tui/widgets/input` or :doc:`/tui/widgets/editor`. For picking a
-single item from a plain list, use :doc:`/tui/widgets/select_list`.
+free-form text input, use :doc:`/tui/widgets/input` or
+:doc:`/tui/widgets/editor`. For picking a single item from a plain list,
+use :doc:`/tui/widgets/select_list`.
 
 Basic Usage
 -----------

--- a/tui/widgets/settings_list.rst
+++ b/tui/widgets/settings_list.rst
@@ -1,0 +1,139 @@
+SettingsListWidget
+==================
+
+``SettingsListWidget`` displays a navigable list of settings where
+each item has a label and a current value. Values can be cycled through
+predefined options or chosen via a submenu.
+
+When to Use
+-----------
+
+Use ``SettingsListWidget`` for preference panels, configuration screens
+or any UI where the user picks values for a set of named options. For
+free-form text input, use :doc:`input` or :doc:`editor`. For picking a
+single item from a plain list, use :doc:`select_list`.
+
+Basic Usage
+-----------
+
+.. code-block:: php
+
+    use Symfony\Component\Tui\Widget\SettingItem;
+    use Symfony\Component\Tui\Widget\SettingsListWidget;
+
+    $items = [
+        new SettingItem(
+            id: 'theme',
+            label: 'Theme',
+            currentValue: 'dark',
+            description: 'Choose the color theme',
+            values: ['dark', 'light', 'auto'],
+        ),
+        new SettingItem(
+            id: 'font_size',
+            label: 'Font Size',
+            currentValue: '14',
+            values: ['12', '14', '16', '18'],
+        ),
+    ];
+
+    $settings = new SettingsListWidget($items);
+    $tui->add($settings);
+    $tui->setFocus($settings);
+
+Setting Items
+-------------
+
+Each ``SettingItem`` is defined with:
+
+* ``id``: a unique identifier for the setting.
+* ``label``: the display name shown in the list.
+* ``currentValue``: the initial value.
+* ``description``: optional help text shown when the item is selected.
+* ``values``: a list of allowed values for cycling. When empty, the
+  item must use a submenu instead.
+* ``submenu``: a callable that creates a focusable widget for picking
+  a value (see below).
+
+Cycling Values
+--------------
+
+When an item has predefined ``values``, the user cycles through them
+with **Enter**, **Space**, **Left** or **Right**::
+
+    new SettingItem(
+        id: 'difficulty',
+        label: 'Difficulty',
+        currentValue: 'normal',
+        values: ['easy', 'normal', 'hard'],
+    );
+
+Submenus
+--------
+
+For settings that require a richer picker (e.g. a search-and-select
+list), provide a ``submenu`` callable. The callable receives the
+current value and a done callback::
+
+    new SettingItem(
+        id: 'language',
+        label: 'Language',
+        currentValue: 'en',
+        submenu: function (string $current, callable $done) {
+            $list = new SelectListWidget([
+                ['value' => 'en', 'label' => 'English'],
+                ['value' => 'fr', 'label' => 'French'],
+                ['value' => 'de', 'label' => 'German'],
+            ]);
+
+            return $list;
+        },
+    );
+
+The submenu widget must implement ``FocusableInterface``. When it
+dispatches a ``SelectEvent``, the selected value is applied. When it
+dispatches a ``CancelEvent``, the change is discarded.
+
+Reading and Updating Values
+---------------------------
+
+Read or update values programmatically::
+
+    $settings->getValue('theme');        // 'dark'
+    $settings->updateValue('theme', 'light');
+
+Events
+------
+
+* ``SettingChangeEvent``: Fired whenever a setting value changes
+  (cycling or submenu selection)::
+
+      use Symfony\Component\Tui\Event\SettingChangeEvent;
+
+      $settings->onChange(function (SettingChangeEvent $event) {
+          $id = $event->getId();
+          $newValue = $event->getValue();
+      });
+
+* ``CancelEvent``: Fired when the user presses **Escape** or
+  **Ctrl+C**::
+
+      $settings->onCancel(function () {
+          // close the settings panel
+      });
+
+Default Keybindings
+-------------------
+
+========================  ==================================
+Key                       Action
+========================  ==================================
+Up                        Move selection up
+Down                      Move selection down
+Page Up                   Page up
+Page Down                 Page down
+Enter, Space              Activate (cycle or open submenu)
+Right                     Cycle value forward
+Left                      Cycle value backward
+Escape, Ctrl+C            Cancel
+========================  ==================================

--- a/tui/widgets/text.rst
+++ b/tui/widgets/text.rst
@@ -1,0 +1,73 @@
+TextWidget
+==========
+
+``TextWidget`` displays static text in the terminal. It is the most
+basic widget and the one you will use most often for labels, paragraphs
+and decorative headings.
+
+When to Use
+-----------
+
+Use ``TextWidget`` whenever you need to display a read-only piece of
+text: a title, a status message, a paragraph of instructions, etc.
+For user-editable text, use :doc:`input` or :doc:`editor` instead.
+
+Basic Usage
+-----------
+
+Create a ``TextWidget`` with a string and add it to the Tui::
+
+    use Symfony\Component\Tui\Widget\TextWidget;
+
+    $text = new TextWidget('Hello, terminal!');
+    $tui->add($text);
+
+Update the text at any time with ``setText()``::
+
+    $text->setText('New content');
+
+Word Wrapping and Truncation
+----------------------------
+
+By default, text wraps to multiple lines when it exceeds the available
+width. If you prefer to truncate long lines with an ellipsis instead,
+pass ``truncate: true`` to the constructor::
+
+    $text = new TextWidget('A very long line...', truncate: true);
+
+FIGlet Fonts
+------------
+
+When a FIGlet font is set via the Style system, the text is rendered as
+large ASCII art. Five fonts are bundled: ``big``, ``small``, ``slant``,
+``standard`` and ``mini``.
+
+Apply a font with a Tailwind utility class::
+
+    $title = new TextWidget('Welcome');
+    $title->addStyleClass('font-big');
+
+Or through a stylesheet rule::
+
+    use Symfony\Component\Tui\Style\Style;
+
+    $stylesheet->addRule('.title', new Style(font: 'big'));
+    $title->addStyleClass('title');
+
+Custom FIGlet fonts can be registered via the ``FontRegistry``
+passed to the ``Renderer``::
+
+    use Symfony\Component\Tui\Render\Renderer;
+    use Symfony\Component\Tui\Widget\Figlet\FontRegistry;
+
+    $fontRegistry = new FontRegistry();
+    $fontRegistry->register('brand', '/path/to/font.flf');
+
+    $renderer = new Renderer(fontRegistry: $fontRegistry);
+    $tui = new Tui(renderer: $renderer);
+
+Events
+------
+
+``TextWidget`` does not emit any events. It is a pure display widget
+with no focus or input handling.

--- a/tui/widgets/text.rst
+++ b/tui/widgets/text.rst
@@ -10,7 +10,8 @@ When to Use
 
 Use ``TextWidget`` whenever you need to display a read-only piece of
 text: a title, a status message, a paragraph of instructions, etc.
-For user-editable text, use :doc:`/tui/widgets/input` or :doc:`/tui/widgets/editor` instead.
+For user-editable text, use :doc:`/tui/widgets/input` or
+:doc:`/tui/widgets/editor` instead.
 
 Basic Usage
 -----------

--- a/tui/widgets/text.rst
+++ b/tui/widgets/text.rst
@@ -10,7 +10,7 @@ When to Use
 
 Use ``TextWidget`` whenever you need to display a read-only piece of
 text: a title, a status message, a paragraph of instructions, etc.
-For user-editable text, use :doc:`input` or :doc:`editor` instead.
+For user-editable text, use :doc:`/tui/widgets/input` or :doc:`/tui/widgets/editor` instead.
 
 Basic Usage
 -----------


### PR DESCRIPTION
Fixes #22281

Takes over #22201, rebased on 8.2 (it was 10 commits behind and 1008 commits stale), with the review feedback applied and the examples checked against the component as merged.

Symbols that do not exist in the component, now removed: `TabsWidget`, `AnimatedImageWidget`, `TabChangeEvent`, and the entire autocomplete feature (`Tui\Autocomplete\FilePathProvider`, `EditorWidget::setAutocompleteProvider()`, and the related keybinding tables). The editor's `CancelEvent` fires on Escape only; `ctrl+c` is bound to `copy` and left to the parent.

The `ContainerWidget` styling example failed on all four of its arguments (`padding: 1` needs a `Padding`, `Border::Rounded` and `Color::Gray` are not constants, and the parameter is `background`, not `bg`). It now matches the API used elsewhere in the same page set.

Also documents the `Key::ctrl()` / `Key::alt()` modifier helpers, which were used in review suggestions but never described.