### PR TITLE
[Security] Document the status-code-specific HttpException thrown by #[IsGranted]

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2494,6 +2494,24 @@ is 403), this can be done by setting with the ``statusCode`` argument::
         // ...
     }
 
+The exception thrown is the
+:class:`Symfony\\Component\\HttpKernel\\Exception\\HttpException` subclass that
+matches the given status code. The example above throws a
+:class:`Symfony\\Component\\HttpKernel\\Exception\\LockedHttpException` and
+``statusCode: 404`` throws a
+:class:`Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException`. Only
+the 400, 403, 404, 406, 409, 410, 411, 412, 415, 422, 423, 428, 429 and 503
+status codes have a matching subclass. Any other status code throws the generic
+``HttpException``.
+
+.. versionadded:: 8.2
+
+    Throwing the ``HttpException`` subclass that matches the status code was
+    introduced in Symfony 8.2. Previously, the generic ``HttpException`` was
+    always thrown. Existing ``catch (HttpException $e)`` blocks and
+    ``instanceof`` checks keep working, because the thrown exception is a
+    subclass of it.
+
 You can also set the internal exception code of the
 :class:`Symfony\\Component\\Security\\Core\\Exception\\AccessDeniedException`
 that is thrown with the ``exceptionCode`` argument::

--- a/security/voters.rst
+++ b/security/voters.rst
@@ -415,9 +415,11 @@ However, you can change this behavior by specifying the message and status code 
 
 .. tip::
 
-    If the status code is different from 403, an
-    :class:`Symfony\\Component\\HttpKernel\\Exception\\HttpException`
-    will be thrown instead.
+    When you set a status code, the
+    :class:`Symfony\\Component\\HttpKernel\\Exception\\HttpException` subclass
+    matching it is thrown instead of ``AccessDeniedException``. The example
+    above throws a
+    :class:`Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException`.
 
 .. _security-voters-change-strategy:
 


### PR DESCRIPTION
Documents what `#[IsGranted]` throws when the `statusCode` option is set, changed in Symfony 8.2 by symfony/symfony#65137.

Two places:

- `security.rst`, right after the `statusCode` example, states that the thrown exception is the `HttpException` subclass matching the status code, with a `versionadded` note for 8.2.
- `security/voters.rst` had a tip saying a plain `HttpException` is thrown when the status code is not 403.

Behavior checked against the 8.2 code rather than restated from the feature PR. `HttpException::fromStatusCode()` has a dedicated class for 400, 403, 404, 406, 409, 410, 411, 412, 415, 422, 423, 428, 429 and 503, and returns a plain `HttpException` for everything else. Two things came out of that and are documented:

- The `statusCode: 423` example already in `security.rst` throws a `LockedHttpException`.
- `UnauthorizedHttpException` (401) and `MethodNotAllowedHttpException` (405) exist but are not in that list, since their constructors need a `$challenge` / `$allow` argument. That's why the list of codes is spelled out rather than described as "codes that have a class".

The voters.rst tip needed a second correction beyond the class name. The listener branches on `if ($statusCode = $attribute->statusCode)`, not on the value, so `statusCode: 403` also goes through `fromStatusCode()` and throws HttpKernel's `AccessDeniedHttpException`. The "different from 403" carve-out in the tip was never accurate.

@chalasr about your note on the issue: the voters.rst tip is the part that reads wrong now. The security.rst addition is the smaller half and can be trimmed if you prefer.

Fixes #22574
