### PR TITLE
[Encore] Add low-maintenance notice recommending Symfony Reprise

### DIFF
--- a/frontend/encore/index.rst
+++ b/frontend/encore/index.rst
@@ -3,6 +3,12 @@
 Webpack Encore Documentation
 ----------------------------
 
+.. warning::
+
+    Webpack Encore is now in low-maintenance mode (bug fixes, security patches,
+    and ``peerDependencies`` updates only). If your project needs a bundler, we
+    recommend migrating to `Symfony Reprise`_.
+
 Getting Started
 ...............
 
@@ -52,3 +58,4 @@ Full API
 * `Full API`_
 
 .. _`Full API`: https://github.com/symfony/webpack-encore/blob/master/index.js
+.. _`Symfony Reprise`: https://github.com/symfony/reprise


### PR DESCRIPTION
I thought it could be interesting to mention it there