### PR TITLE
[RemoteEvent] Document SMS engagement events

### DIFF
--- a/webhook.rst
+++ b/webhook.rst
@@ -568,6 +568,33 @@ Configure similarly to mailers, then consume
         }
     }
 
+The :class:`Symfony\\Component\\RemoteEvent\\Event\\Sms\\SmsEvent` object exposes
+the type of the event through its ``getName()`` method, which returns one of the
+following constants:
+
+* ``SmsEvent::DELIVERED``: the SMS was delivered to the recipient;
+* ``SmsEvent::FAILED``: the SMS could not be delivered;
+* ``SmsEvent::CLICKED``: the recipient clicked a link contained in the SMS;
+* ``SmsEvent::UNSUBSCRIBED``: the recipient opted out of receiving further SMS
+  (e.g. by replying ``STOP``).
+
+.. versionadded:: 8.2
+
+    The ``SmsEvent::CLICKED`` and ``SmsEvent::UNSUBSCRIBED`` events were
+    introduced in Symfony 8.2. They are currently supported by the Sweego
+    bridge (mapped from the ``sms_clicked`` and ``sms_stop`` webhook events).
+
+For example, you can react to these engagement events as follows::
+
+    private function handleSms(SmsEvent $event): void
+    {
+        match ($event->getName()) {
+            SmsEvent::CLICKED => $this->onLinkClicked($event),
+            SmsEvent::UNSUBSCRIBED => $this->onUnsubscribe($event),
+            default => null,
+        };
+    }
+
 Sending Webhooks
 ----------------
 


### PR DESCRIPTION
Documents the feature added in symfony/symfony#65038 (milestone 8.2), which
adds SMS engagement events to the RemoteEvent component.

The `SmsEvent` class gains two new event names:

* `SmsEvent::CLICKED` (recipient clicked a link in the SMS);
* `SmsEvent::UNSUBSCRIBED` (recipient opted out, e.g. by replying `STOP`).

These are supported by the Sweego bridge, mapped from the `sms_clicked` and
`sms_stop` webhook events.

This PR documents the full list of `SmsEvent` event types in the Notifier
webhooks section of `webhook.rst`, with a `.. versionadded:: 8.2` directive and
a handling example.

Closes #22597