### PR TITLE
 Update the code checker used to lint code examples in the docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
             -   name: Set-up PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.4
+                    php-version: 8.5
                     coverage: none
 
             -   name: Fetch branch from where the PR started
@@ -119,7 +119,7 @@ jobs:
 
             -   name: Install dependencies
                 if: ${{ steps.find-files.outputs.files }}
-                run: composer create-project symfony-tools/code-block-checker:@dev _checker
+                run: composer create-project symfony-tools/code-block-checker:^1.0 _checker
 
             -   name: Install test application
                 if: ${{ steps.find-files.outputs.files }}


### PR DESCRIPTION
We just released the 1.0.0 version of the code checker (https://github.com/symfony-tools/code-block-checker/releases/tag/v1.0.0) so let's use it