### PR TITLE
[ExpressionLanguage] Move docs out of the components

### DIFF
--- a/_build/redirection_map
+++ b/_build/redirection_map
@@ -329,8 +329,8 @@
 /components/dependency_injection/types /service_container/injection_types
 /components/event_dispatcher/index /event_dispatcher
 /components/event_dispatcher/introduction /event_dispatcher
-/components/expression_language/introduction /components/expression_language
-/components/expression_language/index /components/expression_language
+/components/expression_language/introduction /expression_language
+/components/expression_language/index /expression_language
 /components/filesystem/introduction /components/filesystem
 /components/filesystem/index /components/filesystem
 /components/form/form_events /form/events
@@ -578,9 +578,9 @@
 /components/var_dumper/advanced /components/var_dumper#advanced-usage
 /components/yaml/yaml_format /reference/formats/yaml
 /components/expression_language/syntax /reference/formats/expression_language
-/components/expression_language/ast /components/expression_language#expression-language-ast
-/components/expression_language/caching /components/expression_language#expression-language-caching
-/components/expression_language/extending /components/expression_language#expression-language-extending
+/components/expression_language/ast /expression_language#expression-language-ast
+/components/expression_language/caching /expression_language#expression-language-caching
+/components/expression_language/extending /expression_language#expression-language-extending
 /notifier/chatters /notifier#sending-chat-messages
 /notifier/texters /notifier#sending-sms
 /notifier/events /notifier#notifier-events
@@ -639,3 +639,4 @@
 /components/event_dispatcher/traceable_dispatcher /event_dispatcher#event-dispatcher-traceable-dispatcher
 /components/ldap /security/ldap
 /components/mime /mailer
+/components/expression_language /expression_language

--- a/doctrine.rst
+++ b/doctrine.rst
@@ -924,7 +924,7 @@ Fetch via an Expression
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 If automatic fetching doesn't work for your use case, you can write an expression
-using the :doc:`ExpressionLanguage component </components/expression_language>`::
+using the :doc:`ExpressionLanguage component </expression_language>`::
 
     #[Route('/product/{product_id}')]
     public function show(

--- a/expression_language.rst
+++ b/expression_language.rst
@@ -1,32 +1,26 @@
-The ExpressionLanguage Component
-================================
-
-    The ExpressionLanguage component provides an engine that can compile and
-    evaluate expressions. An expression is a one-liner that returns a value
-    (mostly, but not limited to, Booleans).
-
-Installation
-------------
-
-.. code-block:: terminal
-
-    $ composer require symfony/expression-language
-
-.. include:: /components/require_autoload.rst.inc
+Expression Language
+===================
 
 .. _how-can-the-expression-engine-help-me:
 
-How can the Expression Language Help Me?
-----------------------------------------
+Applications often need to define some logic in places where PHP code can't be
+used or is not safe to use: an access rule in the security configuration, the
+condition of a validation constraint, a discount rule stored in the database
+and editable by non-developers. The ExpressionLanguage component was created
+for these use cases. It provides an engine that can compile and evaluate
+**expressions**: one-liners that return a value (mostly, but not limited to,
+Booleans) using a syntax similar to PHP and Twig.
 
-The purpose of the component is to allow users to use expressions inside
-configuration for more complex logic. For example, the Symfony Framework uses
-expressions in security, for validation rules and in route matching.
+Symfony itself uses expressions in many features, such as :doc:`security rules
+</security/expressions>`, :ref:`route matching conditions
+<routing-matching-expressions>`, the :doc:`Expression validation constraint
+</reference/constraints/Expression>` and :doc:`service container configuration
+</service_container/expression_language>`.
 
-Besides using the component in the framework itself, the ExpressionLanguage
-component is a perfect candidate for the foundation of a *business rule engine*.
-The idea is to let the webmaster of a website configure things in a dynamic
-way without using PHP and without introducing security problems:
+In your own applications, the ExpressionLanguage component is a perfect
+candidate for the foundation of a *business rule engine*. The idea is to let
+non-developers of a website configure things in a dynamic way without using
+PHP and without introducing security problems:
 
 .. _component-expression-language-examples:
 
@@ -45,6 +39,15 @@ Expressions can be seen as a very restricted PHP sandbox and are less vulnerable
 to external injections because you must explicitly declare which variables are
 available in an expression (but you should still sanitize any data given by end
 users and passed to expressions).
+
+Installation
+------------
+
+.. code-block:: terminal
+
+    $ composer require symfony/expression-language
+
+.. include:: /components/require_autoload.rst.inc
 
 Usage
 -----
@@ -76,14 +79,6 @@ The main class of the component is
 
     See :doc:`/reference/formats/expression_language` to learn the syntax of
     the ExpressionLanguage component.
-
-Null Coalescing Operator
-........................
-
-.. note::
-
-    This content has been moved to the :ref:`null coalescing operator <component-expression-null-coalescing-operator>`
-    section of ExpressionLanguage syntax reference page.
 
 Parsing and Linting Expressions
 ...............................

--- a/index.rst
+++ b/index.rst
@@ -33,6 +33,7 @@ Topics
     doctrine
     deployment
     event_dispatcher
+    expression_language
     forms
     frontend
     html_sanitizer

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -5638,7 +5638,7 @@ Each marking store can define any of these options:
 
 * ``from`` (**type**: ``string`` or ``array``) value from the ``places``,
   multiple values are allowed for both ``workflow`` and ``state_machine``;
-* ``guard`` (**type**: ``string``) an :doc:`ExpressionLanguage </components/expression_language>`
+* ``guard`` (**type**: ``string``) an :doc:`ExpressionLanguage </expression_language>`
   compatible expression to block the transition;
 * ``name`` (**type**: ``string``) the name of the transition;
 * ``to`` (**type**: ``string`` or ``array``) value from the ``places``,

--- a/reference/formats/expression_language.rst
+++ b/reference/formats/expression_language.rst
@@ -1,7 +1,7 @@
 The Expression Syntax
 =====================
 
-The :doc:`ExpressionLanguage component </components/expression_language>` uses a
+The :doc:`ExpressionLanguage component </expression_language>` uses a
 specific syntax which is based on the expression syntax of Twig. In this document,
 you can find all supported syntaxes.
 

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -233,7 +233,7 @@ expression
 ~~~~~~~~~~
 
 Creates an :class:`Symfony\\Component\\ExpressionLanguage\\Expression` related
-to the :doc:`ExpressionLanguage component </components/expression_language>`.
+to the :doc:`ExpressionLanguage component </expression_language>`.
 
 .. code-block:: twig
 

--- a/workflow.rst
+++ b/workflow.rst
@@ -1394,7 +1394,7 @@ feature is provided by "guards", which can be used in two ways.
 First, you can listen to :ref:`the guard events <workflow-usage-guard-events>`.
 Alternatively, you can define a ``guard`` configuration option for the
 transition. The value of this option is any valid expression created with the
-:doc:`ExpressionLanguage component </components/expression_language>`:
+:doc:`ExpressionLanguage component </expression_language>`:
 
 .. configuration-block::
 


### PR DESCRIPTION
This also adds a better introduction in the main article to explain what's the purpose of the component and the scenarios where it can be used.