### PR TITLE
[HttpCache] Fix references to `/expression_language`

### DIFF
--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -117,7 +117,7 @@ Applying Cache Conditionally
 
 Use the ``if`` option to apply the ``#[Cache]`` attribute only when a given
 condition is met. This option accepts a closure or an
-:doc:`ExpressionLanguage </components/expression_language>` expression that
+:doc:`ExpressionLanguage </expression_language>` expression that
 receives the ``Request`` object and the controller arguments and must return
 a boolean value:
 

--- a/http_cache/validation.rst
+++ b/http_cache/validation.rst
@@ -227,7 +227,7 @@ Using Expressions in the Cache Attribute
 
 The ``#[Cache]`` attribute supports using expressions for the ``etag`` and
 ``lastModified`` options. These expressions are evaluated using the
-:doc:`ExpressionLanguage component </components/expression_language>` and
+:doc:`ExpressionLanguage component </expression_language>` and
 have access to the following variables:
 
 ``request``


### PR DESCRIPTION
From #22621, #21725 and #21848
