### PR TITLE
[ObjectMapper] Clarify which direction a `transform` applies to

### DIFF
--- a/object_mapper.rst
+++ b/object_mapper.rst
@@ -390,6 +390,13 @@ You can use that method to format a property when mapping it::
         public string $stockLevel = '100';
     }
 
+.. note::
+
+    A ``#[Map]`` attribute that omits ``source`` describes the mapping to apply
+    when its own class is used as the source. To transform a value while mapping
+    *into* a class, declare the mapping on the target property and name the source
+    property explicitly, as shown in `Transforming Values on the Target Class`_.
+
 Using Transformer Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -577,8 +584,9 @@ its values from a source, especially when working with external data formats.
 This is done using the ``source`` parameter in the ``#[Map]`` attribute on the
 target class's properties.
 
-Note that if both the ``source`` and the ``target`` classes define the ``#[Map]``
-attribute, the ``source`` takes precedence.
+Note that when both the ``source`` and the ``target`` classes define a ``#[Map]``
+attribute for the same property, the one declared on the ``source`` takes
+precedence.
 
 Consider the following class that stores the data obtained from an external API
 that uses snake_case property names::
@@ -628,8 +636,8 @@ Using it in practice::
     // $product->price = 123.45
 
 When using source-based mapping, the ``ObjectMapper`` will automatically use the
-target's ``#[Map(source: ...)]`` attributes if no mapping is defined on the
-source class.
+target's ``#[Map(source: ...)]`` attributes for the properties that the source
+class does not map itself.
 
 Transforming Values on the Target Class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Documents a rule the ObjectMapper already follows but never states: whether a `#[Map(transform: ...)]` applies on the way *out* of a class or on the way *in* depends on whether the mapping names its `source`.

Companion to symfony/symfony#65366, which restores that rule in the code. The docs are not wrong today — both existing examples already use the right shape — but the rule is only implied by where the examples put the attribute, which is what allowed the runtime to drift away from it unnoticed.

## What changed

**1. A note after "Using Callables"**, stating the rule next to the example that demonstrates it. That example declares a bare `#[Map(transform: 'intval')]` on `ProductInput`, which is the *source*, while the inbound counterpart in "Transforming Values on the Target Class" uses an explicit `#[Map(source: 'price', transform: ...)]`. The difference between the two is load-bearing and was never spelled out.

**2. Two sentences in "Mapping Based on Target Properties" made per-property.** Both described precedence at class granularity, while the mapper resolves it per property:

> if both the `source` and the `target` classes define the `#[Map]` attribute, the `source` takes precedence

> the `ObjectMapper` will automatically use the target's `#[Map(source: ...)]` attributes if no mapping is defined **on the source class**

A source class routinely carries `#[Map]` for *some* properties while leaving others to the same-name copy, and the target's `#[Map(source: ...)]` still applies to those others. Read literally at class level, the current wording says it would not.

No examples were changed — they were already correct.
