### PR TITLE
[Testing] Document how to stop the Panther web server

### DIFF
--- a/testing/end_to_end.rst
+++ b/testing/end_to_end.rst
@@ -94,6 +94,17 @@ under test is started on demand and stopped when ``tearDownAfterClass()`` is cal
 On the other hand, when the extension is registered, the web server will be stopped
 only after the very last test.
 
+.. tip::
+
+    If a test must temporarily ensure that the Panther web server is not
+    running (for example, before an operation that needs exclusive access to a
+    shared resource), call ``static::stopWebServer()``. This also closes the
+    current browser clients.
+
+    A later call to ``static::createPantherClient()`` starts a new web server
+    and browser client. Don't reuse a client created before
+    ``stopWebServer()``.
+
 Usage
 -----
 


### PR DESCRIPTION
This documents `stopWebServer()` next to the existing Panther web server
lifecycle explanation.

This method is useful when a test needs to ensure that the Panther web server
is not running before an operation that requires exclusive access to a shared
resource. One practical example is avoiding SQLite "database is locked" errors
when the test process needs to modify the database between browser test phases.

The documentation also clarifies that browser clients created before
`stopWebServer()` must not be reused and that `createPantherClient()` starts a
new server and browser client afterwards.

This documents existing Panther behavior and does not introduce a new feature.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->