### PR TITLE
[FrameworkBundle][HttpKernel] Document the hinclude deprecation

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1324,6 +1324,12 @@ hinclude_default_template
 
 **type**: ``string`` **default**: ``null``
 
+.. deprecated:: 8.2
+
+    The ``hinclude_default_template`` option is deprecated since Symfony 8.2.
+    Use the ``esi`` or ``inline`` fragment renderers, or `Symfony UX Turbo`_,
+    instead.
+
 Sets the content shown during the loading of the fragment or when JavaScript
 is disabled. This can be either a template name or the content itself.
 
@@ -5217,6 +5223,7 @@ to know their differences.
 .. _`utf-8 modifier`: https://www.php.net/reference.pcre.pattern.modifiers
 .. _`Link HTTP header`: https://tools.ietf.org/html/rfc5988
 .. _`SMTP session`: https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol#SMTP_transport_example
+.. _`Symfony UX Turbo`: https://ux.symfony.com/turbo
 .. _`OpenSSL cipher`: https://www.php.net/manual/en/openssl.ciphers.php
 .. _`PHP attributes`: https://www.php.net/manual/en/language.attributes.overview.php
 .. _`shared cache`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#shared_cache

--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -751,8 +751,8 @@ falls back to the behavior of `render`_ otherwise.
 
     The ``render_esi()`` function is an example of the shortcut functions
     of ``render``. It automatically sets the strategy based on what's given
-    in the function name, e.g. ``render_hinclude()`` will use the hinclude.js
-    strategy. This works for all ``render_*()`` functions.
+    in the function name, e.g. ``render_ssi()`` will use the SSI strategy.
+    This works for all ``render_*()`` functions.
 
 .. _reference-twig-function-render-ssi:
 

--- a/templates.rst
+++ b/templates.rst
@@ -790,6 +790,14 @@ template fragments. Configure that special URL in the ``fragments`` option:
 How to Embed Asynchronous Content with hinclude.js
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. deprecated:: 8.2
+
+    The hinclude.js integration (the ``render_hinclude()`` Twig function, the
+    ``HIncludeFragmentRenderer`` class and the
+    ``framework.fragments.hinclude_default_template`` option) is deprecated
+    since Symfony 8.2. Use the ``render_esi()`` or ``render()`` functions, or
+    `Symfony UX Turbo`_, instead.
+
 .. note::
 
     ``hinclude.js`` is a legacy technique. For asynchronous, self-updating
@@ -1579,6 +1587,7 @@ for this class and :doc:`tag your service </service_container/tags>` with ``twig
 .. _`Turbo Streams`: https://symfony.com/bundles/ux-turbo/current/index.html
 .. _`official Twig extensions`: https://github.com/twigphp?q=extra
 .. _`snake case`: https://en.wikipedia.org/wiki/Snake_case
+.. _`Symfony UX Turbo`: https://ux.symfony.com/turbo
 .. _`tags`: https://twig.symfony.com/doc/3.x/tags/index.html
 .. _`Twig block tag`: https://twig.symfony.com/doc/3.x/tags/block.html
 .. _`Twig Environment`: https://github.com/twigphp/Twig/blob/3.x/src/Environment.php


### PR DESCRIPTION
Fix #22687

Documents the hinclude deprecation (symfony/symfony#64071):

- deprecation banner on the hinclude section of `templates.rst`, covering the `render_hinclude()` Twig function, the `HIncludeFragmentRenderer` class and the `framework.fragments.hinclude_default_template` option, pointing to `render_esi()`/`render()` and Symfony UX Turbo;
- same banner on the `hinclude_default_template` option in the framework configuration reference;
- the shortcut-functions note in the Twig reference now uses `render_ssi()` as its example instead of the deprecated `render_hinclude()`.