### PR TITLE
[Messenger] Document the DBAL ping and transaction middlewares

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -3978,8 +3978,9 @@ wouldn't be one.
 Unlike ``doctrine_transaction``, ``DoctrineDbalTransactionMiddleware`` doesn't
 flush any entity manager before committing: the handlers do it.
 
-They have no configuration shortcut yet, so register them as services and add
-their class name to the middleware list of the bus:
+They have no configuration shortcut yet, so register them as services first,
+then add their class name to the ``middleware`` list of the bus shown above,
+where the ``doctrine_*`` shortcuts are:
 
 .. code-block:: yaml
 
@@ -3995,17 +3996,6 @@ their class name to the middleware list of the bus:
         Symfony\Bridge\Doctrine\Messenger\DoctrineDbalTransactionMiddleware:
             arguments:
                 - '@doctrine'
-
-.. code-block:: yaml
-
-    # config/packages/messenger.yaml
-    framework:
-        messenger:
-            buses:
-                command_bus:
-                    middleware:
-                        - 'Symfony\Bridge\Doctrine\Messenger\DoctrineDbalPingConnectionMiddleware'
-                        - 'Symfony\Bridge\Doctrine\Messenger\DoctrineDbalTransactionMiddleware'
 
 .. versionadded:: 8.2
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -3960,25 +3960,20 @@ may want to use:
 Middleware for DBAL Connections
 ...............................
 
-The middlewares above are built on the entity managers of the ORM. Their DBAL
-counterparts work on connections instead, so they also run in applications that
-don't use the ORM:
+The middlewares above are built on the entity managers of the ORM. These two
+work on DBAL connections instead, so they also run in applications that don't
+use the ORM:
 
 * :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalPingConnectionMiddleware`
   pings the connections and reconnects the closed ones;
-* :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalCloseConnectionMiddleware`
-  closes the connections after handling;
-* :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalOpenTransactionLoggerMiddleware`
-  logs an error when a handler leaves a transaction open;
 * :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalTransactionMiddleware`
   wraps all handlers in a single DBAL transaction.
 
-They all take the connection registry as their first argument. The ping, close
-and logger middlewares then take connection names, either a single name or a
-list of them; passing none targets every DBAL connection. The logger middleware
-takes its logger second and its connection names third. The transaction
-middleware takes a single optional connection name, as a transaction spanning
-several connections wouldn't be one.
+Both take the connection registry as their first argument. The ping middleware
+then takes connection names, either a single name or a list of them; passing
+none pings every DBAL connection. The transaction middleware takes a single
+optional connection name, as a transaction spanning several connections
+wouldn't be one.
 
 Unlike ``doctrine_transaction``, ``DoctrineDbalTransactionMiddleware`` doesn't
 flush any entity manager before committing: the handlers do it.
@@ -3999,15 +3994,14 @@ their class name to the middleware list of the bus:
 
 .. versionadded:: 8.2
 
-    The DBAL middlewares were introduced in Symfony 8.2.
+    ``DoctrineDbalPingConnectionMiddleware`` and
+    ``DoctrineDbalTransactionMiddleware`` were introduced in Symfony 8.2.
 
 .. deprecated:: 8.2
 
-    ``DoctrinePingConnectionMiddleware``, ``DoctrineCloseConnectionMiddleware``
-    and ``DoctrineOpenTransactionLoggerMiddleware`` are deprecated since Symfony
-    8.2 in favor of their DBAL counterparts. Beware that the DBAL ping
-    middleware doesn't reset closed entity managers, as workers already reset
-    them between messages.
+    ``DoctrinePingConnectionMiddleware`` is deprecated since Symfony 8.2 in
+    favor of ``DoctrineDbalPingConnectionMiddleware``, which doesn't reset
+    closed entity managers, as workers already reset them between messages.
 
 Other Middlewares
 ~~~~~~~~~~~~~~~~~

--- a/messenger.rst
+++ b/messenger.rst
@@ -3955,6 +3955,60 @@ may want to use:
             ],
         ]);
 
+.. _messenger-doctrine-dbal-middleware:
+
+Middleware for DBAL Connections
+...............................
+
+The middlewares above are built on the entity managers of the ORM. Their DBAL
+counterparts work on connections instead, so they also run in applications that
+don't use the ORM:
+
+* :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalPingConnectionMiddleware`
+  pings the connections and reconnects the closed ones;
+* :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalCloseConnectionMiddleware`
+  closes the connections after handling;
+* :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalOpenTransactionLoggerMiddleware`
+  logs an error when a handler leaves a transaction open;
+* :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalTransactionMiddleware`
+  wraps all handlers in a single DBAL transaction.
+
+They all take the connection registry as their first argument. The ping, close
+and logger middlewares then take connection names, either a single name or a
+list of them; passing none targets every DBAL connection. The logger middleware
+takes its logger second and its connection names third. The transaction
+middleware takes a single optional connection name, as a transaction spanning
+several connections wouldn't be one.
+
+Unlike ``doctrine_transaction``, ``DoctrineDbalTransactionMiddleware`` doesn't
+flush any entity manager before committing: the handlers do it.
+
+They have no configuration shortcut yet, so register them as services and add
+their class name to the middleware list of the bus:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+    services:
+        Symfony\Bridge\Doctrine\Messenger\DoctrineDbalPingConnectionMiddleware:
+            arguments:
+                - '@doctrine'
+                # ping every DBAL connection; pass a name or a list of names
+                # to restrict it to some of them
+                #- ['default', 'legacy']
+
+.. versionadded:: 8.2
+
+    The DBAL middlewares were introduced in Symfony 8.2.
+
+.. deprecated:: 8.2
+
+    ``DoctrinePingConnectionMiddleware``, ``DoctrineCloseConnectionMiddleware``
+    and ``DoctrineOpenTransactionLoggerMiddleware`` are deprecated since Symfony
+    8.2 in favor of their DBAL counterparts. Beware that the DBAL ping
+    middleware doesn't reset closed entity managers, as workers already reset
+    them between messages.
+
 Other Middlewares
 ~~~~~~~~~~~~~~~~~
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -3965,7 +3965,7 @@ work on DBAL connections instead, so they also run in applications that don't
 use the ORM:
 
 * :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalPingConnectionMiddleware`
-  pings the connections and reconnects the closed ones;
+  pings the open connections and reestablishes the broken ones;
 * :class:`Symfony\\Bridge\\Doctrine\\Messenger\\DoctrineDbalTransactionMiddleware`
   wraps all handlers in a single DBAL transaction.
 
@@ -3991,6 +3991,21 @@ their class name to the middleware list of the bus:
                 # ping every DBAL connection; pass a name or a list of names
                 # to restrict it to some of them
                 #- ['default', 'legacy']
+
+        Symfony\Bridge\Doctrine\Messenger\DoctrineDbalTransactionMiddleware:
+            arguments:
+                - '@doctrine'
+
+.. code-block:: yaml
+
+    # config/packages/messenger.yaml
+    framework:
+        messenger:
+            buses:
+                command_bus:
+                    middleware:
+                        - 'Symfony\Bridge\Doctrine\Messenger\DoctrineDbalPingConnectionMiddleware'
+                        - 'Symfony\Bridge\Doctrine\Messenger\DoctrineDbalTransactionMiddleware'
 
 .. versionadded:: 8.2
 


### PR DESCRIPTION
Closes #22665

Documents `DoctrineDbalPingConnectionMiddleware` and `DoctrineDbalTransactionMiddleware`, added in symfony/symfony#65346.