### PR TITLE
[Form] Document the id rendered on the form element

### DIFF
--- a/form/form_customization.rst
+++ b/form/form_customization.rst
@@ -121,6 +121,9 @@ Variable                Description
 ``errors``              Validation errors for this field. Note: ``form.errors`` only contains
                         global errors, not all field errors. Use ``valid`` to check form validity
 ``form``                The ``FormView`` instance itself
+``form_id``             The ``id`` HTML attribute rendered on the ``<form>`` element when a
+                        field uses the :ref:`form_attr <reference-form-option-form-attr>` option
+                        (``null`` otherwise). Only applies to the root form element
 ``full_name``           The ``name`` HTML attribute value (e.g., ``user[email]``)
 ``help``                Help text displayed with the field
 ``id``                  The ``id`` HTML attribute value (e.g., ``user_email``)
@@ -306,6 +309,34 @@ or remove it like any other attribute:
     Rendering the ``name`` attribute through ``attr`` was introduced in
     Symfony 8.2. Previously, the attribute was always rendered with the form
     name and could not be overridden or removed.
+
+An ``id`` attribute is rendered too, but only when a field uses the
+:ref:`form_attr <reference-form-option-form-attr>` option, so that the
+``form`` attribute of that field points to this ``<form>`` element. Its value
+comes from the ``form_id`` variable, which Symfony computes while building the
+form view. To choose that id, define the ``attr`` option of the root form::
+
+    $form = $this->createForm(RegistrationFormType::class, $registration, [
+        'attr' => ['id' => 'registration-form'],
+    ]);
+
+.. warning::
+
+    Overriding this ``id`` at render time (with
+    ``form_start(form, {attr: {id: 'other-id'}})``) or removing it (with
+    ``attr: {id: false}``) leaves the fields using ``form_attr`` pointing to
+    an element that doesn't exist, so the browser stops submitting them with
+    the form.
+
+.. versionadded:: 8.2
+
+    Rendering the ``id`` attribute on the ``<form>`` element and the
+    ``form_id`` variable were introduced in Symfony 8.2.
+
+.. note::
+
+    Form themes that override the ``form_start`` block without rendering
+    ``form_id`` keep the previous behavior and render no ``id`` attribute.
 
 .. _reference-forms-twig-widget:
 

--- a/reference/forms/types/form.rst
+++ b/reference/forms/types/form.rst
@@ -76,6 +76,8 @@ This callable takes form data and returns whether the value is considered empty.
 
 .. include:: /reference/forms/types/options/extra_fields_message.rst.inc
 
+.. _reference-form-option-form-attr:
+
 .. include:: /reference/forms/types/options/form_attr.rst.inc
 
 ``getter``

--- a/reference/forms/types/options/form_attr.rst.inc
+++ b/reference/forms/types/options/form_attr.rst.inc
@@ -13,6 +13,41 @@ its HTML form id. By doing this, a form element can be rendered outside the HTML
 This can be useful when you need to solve nested form problems.
 You can also set this to ``true`` on a root form to automatically set the "form" attribute on all its children.
 
+As soon as one field uses this option, the form themes render an ``id``
+attribute on the ``<form>`` element, so that the reference of those fields
+points to a valid target. That id is:
+
+* the ``id`` defined in the ``attr`` option of the root form, if there's one;
+* the string given to ``form_attr`` when the option is a string, wherever it
+  is defined in the form tree (a string defined on the root form wins over a
+  string defined on one of its children);
+* ``form_`` followed by the id of the root form otherwise (e.g.
+  ``form_registration`` for a form named ``registration``).
+
+The last case adds the ``form_`` prefix because the id of the root form is
+already rendered on the element wrapping the fields:
+
+.. code-block:: html
+
+    <form name="registration" method="post" id="form_registration">
+        <div id="registration">
+            <!-- ... -->
+        </div>
+    </form>
+
+    <!-- rendered outside the form, but submitted with it -->
+    <textarea name="registration[body]" id="registration_body" form="form_registration"></textarea>
+
+Forms that don't use this option are not affected: no ``id`` attribute is
+rendered on their ``<form>`` element.
+
+.. versionadded:: 8.2
+
+    Rendering an ``id`` attribute on the ``<form>`` element was introduced in
+    Symfony 8.2. In previous versions, the fields referenced the id of the
+    element wrapping them, which is not a valid target for the "form"
+    attribute.
+
 .. note::
 
     When the root form has no ID, ``form_attr`` is required to be a string identifier to be used as the form ID.


### PR DESCRIPTION
Fixes #22656.

Documents symfony/symfony#48013, which makes the `<form>` element render an
`id` so that the `form_attr` option resolves. Until now the root form's id was
only rendered on the element wrapping the fields, so `form="X"` pointed at a
`<div>` and browsers ignored the reference.

* `reference/forms/types/options/form_attr.rst.inc`: explains that the themes
  render an `id` on `<form>` as soon as a field uses the option, where that id
  comes from (`attr.id`, the `form_attr` string wherever it sits in the tree,
  or `form_` + the root id) and why the prefix is needed;
* `form/form_customization.rst`: adds the `form_id` view variable to the list
  of form variables and describes the new attribute in the `form_start()`
  section, including how to choose the id and the note about themes that
  override the `form_start` block;
* `reference/forms/types/form.rst`: adds the anchor both pages link to.
