### PR TITLE
[Mailer] Document the Scaleway webhook parser

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -106,7 +106,7 @@ Service               Install with                                        Webhoo
 `Postal`_             ``composer require symfony/postal-mailer``
 `Postmark`_           ``composer require symfony/postmark-mailer``        yes
 `Resend`_             ``composer require symfony/resend-mailer``          yes
-`Scaleway`_           ``composer require symfony/scaleway-mailer``
+`Scaleway`_           ``composer require symfony/scaleway-mailer``        yes
 `SendGrid`_           ``composer require symfony/sendgrid-mailer``        yes
 `Sweego`_             ``composer require symfony/sweego-mailer``          yes
 `TurboSMTP`_          ``composer require symfony/turbo-smtp-mailer``      yes
@@ -115,6 +115,7 @@ Service               Install with                                        Webhoo
 .. versionadded:: 8.2
 
     The ``TurboSMTP`` integration was introduced in Symfony 8.2.
+    Webhook support for ``Scaleway`` was also introduced in Symfony 8.2.
 
 .. note::
 

--- a/webhook.rst
+++ b/webhook.rst
@@ -445,9 +445,14 @@ Mailomat        ``mailer.webhook.request_parser.mailomat``
 Mailtrap        ``mailer.webhook.request_parser.mailtrap``
 Postmark        ``mailer.webhook.request_parser.postmark``
 Resend          ``mailer.webhook.request_parser.resend``
+Scaleway        ``mailer.webhook.request_parser.scaleway``
 Sendgrid        ``mailer.webhook.request_parser.sendgrid``
 Sweego          ``mailer.webhook.request_parser.sweego``
 ==============  ============================================
+
+.. versionadded:: 8.2
+
+    The Scaleway webhook parser was introduced in Symfony 8.2.
 
 .. note::
 
@@ -491,6 +496,20 @@ The routing name becomes part of your webhook URL (e.g.,
 ``https://example.com/webhook/mailer_mailgun``). Configure this URL at your
 mailer provider and store the webhook secret in your environment (via the
 :doc:`secrets management system </configuration/secrets>` or in a ``.env`` file).
+
+.. note::
+
+    Scaleway delivers its email events through `Scaleway Topics and Events`_,
+    which signs each message instead of sharing a secret, so the ``secret``
+    option can be omitted for this provider. Messages are verified with the
+    certificate referenced by their ``SigningCertURL`` field, after checking
+    that this certificate was issued by the Scaleway certificate authority
+    bundled with the bridge. Fetching that certificate requires the
+    :doc:`HttpClient component </http_client>` to be installed. The parser also
+    confirms the subscription automatically the first time Scaleway calls the
+    endpoint; that confirmation message carries no email event, so the endpoint
+    answers it with an HTTP 406 response. This is expected and doesn't mean the
+    subscription failed.
 
 Then create a consumer to handle delivery and engagement events::
 
@@ -684,4 +703,5 @@ For advanced use cases, you can implement custom sending logic using
 :class:`Symfony\\Component\\Webhook\\Server\\TransportInterface` to control
 header generation, signing, and HTTP transport.
 
+.. _`Scaleway Topics and Events`: https://www.scaleway.com/en/docs/topics-and-events/reference-content/verifying-webhooks/
 .. _`Webhook Component for Email Events screencast`: https://symfonycasts.com/screencast/mailtrap/email-event-webhook


### PR DESCRIPTION
Documents the Scaleway webhook `RequestParser` added in symfony/symfony#65355.

Adds `mailer.webhook.request_parser.scaleway` to the mailer parsers table, marks Scaleway as supporting webhooks in the mailer transports table, and describes what is specific to this provider: SNS-style signed messages (so the routing `secret` can be omitted), the signing certificate validated against the Scaleway CA bundled with the bridge (which requires HttpClient), and the automatic subscription confirmation answered with a 406.

Fixes #22683