### PR TITLE
[Mailer] Document the SMTP `timeout` DSN option

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -272,6 +272,7 @@ party provider:
 
     When using SMTP, the default timeout for sending a message before throwing an
     exception is the value defined in the `default_socket_timeout`_ PHP.ini option.
+    Use the ``timeout`` DSN option described below to override it.
 
 .. note::
 
@@ -541,10 +542,11 @@ Other Options
 
 ``timeout``
     The maximum number of seconds to wait when connecting to the SMTP server and
-    when reading from or writing to it. Fractional values are allowed and the
-    value must be a positive number; otherwise an ``InvalidArgumentException``
-    is thrown. When this option is not set, the ``default_socket_timeout`` PHP
-    ini setting is used (60 seconds by default)::
+    when reading from or writing to it. It only applies to the ``smtp://`` and
+    ``smtps://`` transports. Fractional values are allowed and the value must be
+    a positive number; otherwise an ``InvalidArgumentException`` is thrown. When
+    this option is not set, the `default_socket_timeout`_ PHP.ini option is used
+    (60 seconds by default)::
 
         $dsn = 'smtps://smtp.example.com?timeout=10'
 

--- a/mailer.rst
+++ b/mailer.rst
@@ -539,6 +539,19 @@ Other Options
 
         $dsn = 'smtps://smtp.example.com?max_per_second=2'
 
+``timeout``
+    The maximum number of seconds to wait when connecting to the SMTP server and
+    when reading from or writing to it. Fractional values are allowed and the
+    value must be a positive number; otherwise an ``InvalidArgumentException``
+    is thrown. When this option is not set, the ``default_socket_timeout`` PHP
+    ini setting is used (60 seconds by default)::
+
+        $dsn = 'smtps://smtp.example.com?timeout=10'
+
+    .. versionadded:: 8.2
+
+        The ``timeout`` option was introduced in Symfony 8.2.
+
 Custom Transport Factories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Documents the `timeout` DSN option added in symfony/symfony#65420.

It covers the TCP connect as well as the read/write operations on the socket, accepts fractional values, must be a positive number (an `InvalidArgumentException` is thrown otherwise), and falls back to `default_socket_timeout` when not set. Only the native `smtp://` and `smtps://` transports read it, which the entry now states explicitly; the existing note about `default_socket_timeout` points at it.

Fixes #22727