### PR TITLE
[Messenger] Document the logging middleware

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -4002,6 +4002,75 @@ to configure the validation groups.
             ],
         ]);
 
+Logging Middleware
+~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``logging`` middleware was introduced in Symfony 8.2.
+
+Add the ``logging`` middleware to log how long each message took to process and
+how much memory it used. It's not part of the default middleware, so only the
+buses that list it explicitly are affected:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/messenger.yaml
+        framework:
+            messenger:
+                buses:
+                    messenger.bus.default:
+                        middleware:
+                            - logging
+
+    .. code-block:: php
+
+        // config/packages/messenger.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'messenger' => [
+                    'buses' => [
+                        'messenger.bus.default' => [
+                            'middleware' => [
+                                'logging',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+Its position in the stack defines what is measured: everything below it. It logs
+the following messages on the ``messenger`` channel:
+
+=========  ===========================================  ========================================
+Level      Message                                      Logged when
+=========  ===========================================  ========================================
+``info``   ``"{class}" message successfully handled.``  The message was handled
+``info``   ``"{class}" message sent to transport.``     The message was only sent to a transport
+``error``  ``Unable to handle "{class}" message.``      The middleware stack threw an exception
+=========  ===========================================  ========================================
+
+All of them include the ``class``, ``duration_ms`` and ``memory_usage`` context
+keys, plus an ``exception`` key for the failing case.
+
+Messages handled asynchronously are logged twice in their life: once when they
+are dispatched, where the duration is the time needed to hand them to the
+transport, and once in the worker, where the duration is the time needed to
+handle them. Keep this distinction in mind when building dashboards from these
+logs, otherwise every message is counted twice and the time to send a message
+is read as the time to handle it.
+
+.. note::
+
+    ``memory_usage`` is a delta of :phpfunction:`memory_get_usage` expressed in
+    bytes, so it can be negative when a handler frees more memory than it
+    allocates.
+
 Messenger Events
 ~~~~~~~~~~~~~~~~
 

--- a/messenger.rst
+++ b/messenger.rst
@@ -4058,18 +4058,20 @@ Level      Message                                      Logged when
 All of them include the ``class``, ``duration_ms`` and ``memory_usage`` context
 keys, plus an ``exception`` key for the failing case.
 
-Messages handled asynchronously are logged twice in their life: once when they
-are dispatched, where the duration is the time needed to hand them to the
-transport, and once in the worker, where the duration is the time needed to
-handle them. Keep this distinction in mind when building dashboards from these
-logs, otherwise every message is counted twice and the time to send a message
-is read as the time to handle it.
+Messages handled asynchronously are logged at least twice in their life: once
+when they are dispatched, where the duration is the time needed to hand them to
+the transport, and once in the worker, where the duration is the time needed to
+handle them (each :ref:`retry <messenger-retries-failures>` adds another entry).
+Keep this distinction in mind when building dashboards from these logs,
+otherwise every message is counted twice and the time to send a message is read
+as the time to handle it.
 
 .. note::
 
-    ``memory_usage`` is a delta of :phpfunction:`memory_get_usage` expressed in
-    bytes, so it can be negative when a handler frees more memory than it
-    allocates.
+    ``duration_ms`` is rounded to whole milliseconds, so fast handlers report
+    ``0``. ``memory_usage`` is a delta of :phpfunction:`memory_get_usage`
+    expressed in bytes, so it can be negative when a handler frees more memory
+    than it allocates.
 
 Messenger Events
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Documents the optional `LoggingMiddleware` added in symfony/symfony#64621.

Covers how to enable it per bus (it is in no default stack) and that its position decides what is measured, the three log messages with their levels and context keys on the `messenger` channel, the sent-vs-handled distinction when building dashboards, and the fact that `memory_usage` is a `memory_get_usage()` delta that can be negative.

Fixes #22725