### PR TITLE
[HttpKernel] Document staged values in source value resolvers

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -383,7 +383,7 @@ The ``MapQueryParameter`` attribute supports the following argument types:
 Arguments of any other class type are not rejected: their raw value is stored in
 the request attributes under the argument name, so that the value resolver able
 to build that type picks it up from there, exactly as if the value came from the
-route. This is how a date, a UID or a Doctrine entity can be read from the query
+route. This is how a date or a Doctrine entity can be read from the query
 string::
 
     use App\Entity\Post;
@@ -391,16 +391,14 @@ string::
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Attribute\MapDateTime;
     use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
-    use Symfony\Component\Uid\Ulid;
 
     // ...
 
-    // https://example.com/dashboard?from=2026-01-15&to=31/01/2026&traceId=...&post=...
+    // https://example.com/dashboard?from=2026-01-15&to=31/01/2026&post=...
     public function dashboard(
         #[MapQueryParameter] \DateTimeImmutable $from,
         // combine both attributes to restrict the accepted date format
         #[MapQueryParameter] #[MapDateTime(format: 'd/m/Y')] \DateTimeImmutable $to,
-        #[MapQueryParameter] Ulid $traceId,
         #[MapQueryParameter] #[MapEntity] Post $post,
     ): Response
     {
@@ -411,9 +409,10 @@ string::
 
     Only single scalar values are stored this way. Array values (e.g.
     ``?from[]=2026-01-15``) are rejected with the ``validationFailedStatusCode``
-    of the attribute and variadic arguments of a class type are not supported.
-    When no resolver converts the stored value, the argument can't be resolved,
-    unless it's nullable, in which case it resolves to ``null``.
+    of the attribute. Variadic arguments of a class type are not supported at
+    all: they throw a ``LogicException``, whatever that status code is. When no
+    resolver converts the stored value, the argument can't be resolved, unless
+    it's nullable, in which case it resolves to ``null``.
 
 ``#[MapQueryParameter]`` can take an optional argument called ``filter``. You can use the
 `Validate Filters`_ constants defined in PHP::
@@ -915,8 +914,13 @@ The attribute supports the following argument types:
 * :class:`Symfony\\Component\\HttpFoundation\\AcceptHeader`: returns a parsed
   ``AcceptHeader`` object for advanced quality-value handling.
 
+.. versionadded:: 8.2
+
+    The support for any other type built by another value resolver was
+    introduced in Symfony 8.2.
+
 Like ``#[MapQueryParameter]``, any other class type is stored in the request
-attributes so that another value resolver builds it::
+attributes so that another value resolver builds it (e.g. a UID)::
 
     use Symfony\Component\HttpFoundation\Response;
     use Symfony\Component\HttpKernel\Attribute\MapRequestHeader;
@@ -929,11 +933,6 @@ attributes so that another value resolver builds it::
     ): Response {
         // ...
     }
-
-.. versionadded:: 8.2
-
-    The support for any other type built by another value resolver was
-    introduced in Symfony 8.2.
 
 If the header is missing and the argument has no default value and is not
 nullable, a ``400 Bad Request`` response is returned. You can customize this

--- a/controller.rst
+++ b/controller.rst
@@ -375,6 +375,46 @@ The ``MapQueryParameter`` attribute supports the following argument types:
 * ``string``
 * Objects that extend :class:`Symfony\\Component\\Uid\\AbstractUid`
 
+.. versionadded:: 8.2
+
+    The support for any other type built by another value resolver was
+    introduced in Symfony 8.2.
+
+Arguments of any other class type are not rejected: their raw value is stored in
+the request attributes under the argument name, so that the value resolver able
+to build that type picks it up from there, exactly as if the value came from the
+route. This is how a date, a UID or a Doctrine entity can be read from the query
+string::
+
+    use App\Entity\Post;
+    use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpKernel\Attribute\MapDateTime;
+    use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+    use Symfony\Component\Uid\Ulid;
+
+    // ...
+
+    // https://example.com/dashboard?from=2026-01-15&to=31/01/2026&traceId=...&post=...
+    public function dashboard(
+        #[MapQueryParameter] \DateTimeImmutable $from,
+        // combine both attributes to restrict the accepted date format
+        #[MapQueryParameter] #[MapDateTime(format: 'd/m/Y')] \DateTimeImmutable $to,
+        #[MapQueryParameter] Ulid $traceId,
+        #[MapQueryParameter] #[MapEntity] Post $post,
+    ): Response
+    {
+        // ...
+    }
+
+.. note::
+
+    Only single scalar values are stored this way. Array values (e.g.
+    ``?from[]=2026-01-15``) are rejected with the ``validationFailedStatusCode``
+    of the attribute and variadic arguments of a class type are not supported.
+    When no resolver converts the stored value, the argument can't be resolved,
+    unless it's nullable, in which case it resolves to ``null``.
+
 ``#[MapQueryParameter]`` can take an optional argument called ``filter``. You can use the
 `Validate Filters`_ constants defined in PHP::
 
@@ -874,6 +914,26 @@ The attribute supports the following argument types:
   returns ``['en_US', 'en']``);
 * :class:`Symfony\\Component\\HttpFoundation\\AcceptHeader`: returns a parsed
   ``AcceptHeader`` object for advanced quality-value handling.
+
+Like ``#[MapQueryParameter]``, any other class type is stored in the request
+attributes so that another value resolver builds it::
+
+    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpKernel\Attribute\MapRequestHeader;
+    use Symfony\Component\Uid\Ulid;
+
+    // ...
+
+    public function dashboard(
+        #[MapRequestHeader(name: 'x-trace')] Ulid $traceId,
+    ): Response {
+        // ...
+    }
+
+.. versionadded:: 8.2
+
+    The support for any other type built by another value resolver was
+    introduced in Symfony 8.2.
 
 If the header is missing and the argument has no default value and is not
 nullable, a ``400 Bad Request`` response is returned. You can customize this

--- a/controller/value_resolver.rst
+++ b/controller/value_resolver.rst
@@ -253,6 +253,11 @@ been provided; that's why you can assign ``null`` as ``$session``'s default valu
 You can target a resolver by passing its name as ``ValueResolver``'s first argument.
 For convenience, built-in resolvers' names are their FQCN.
 
+.. versionadded:: 8.2
+
+    ``SourceValueResolverInterface`` and the ability to target several resolvers
+    for the same argument were introduced in Symfony 8.2.
+
 Resolvers that only select where a value comes from, such as the ones behind the
 :ref:`MapQueryParameter <controller_map-request>` and
 :ref:`MapRequestHeader <controller_map-request-header>` attributes, implement
@@ -260,7 +265,14 @@ Resolvers that only select where a value comes from, such as the ones behind the
 Targeting one of them keeps the whole chain behind it, so that the resolver able
 to build the argument type still runs. This is also why more than one resolver
 can be targeted for the same argument, provided that exactly one of them is such
-a source resolver::
+a source resolver. In the following example, both attributes target a resolver
+(they extend ``ValueResolver``), and only ``MapQueryParameter`` is a source::
+
+    use Symfony\Component\HttpFoundation\Response;
+    use Symfony\Component\HttpKernel\Attribute\MapDateTime;
+    use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+
+    // ...
 
     public function dashboard(
         #[MapQueryParameter] #[MapDateTime(format: 'd/m/Y')] \DateTimeImmutable $to,
@@ -268,11 +280,6 @@ a source resolver::
     {
         // ...
     }
-
-.. versionadded:: 8.2
-
-    ``SourceValueResolverInterface`` and the ability to target several resolvers
-    for the same argument were introduced in Symfony 8.2.
 
 A targeted resolver can also be disabled by passing ``ValueResolver``'s ``$disabled``
 argument to ``true``; this is how :ref:`MapEntity allows you to disable the

--- a/controller/value_resolver.rst
+++ b/controller/value_resolver.rst
@@ -253,6 +253,27 @@ been provided; that's why you can assign ``null`` as ``$session``'s default valu
 You can target a resolver by passing its name as ``ValueResolver``'s first argument.
 For convenience, built-in resolvers' names are their FQCN.
 
+Resolvers that only select where a value comes from, such as the ones behind the
+:ref:`MapQueryParameter <controller_map-request>` and
+:ref:`MapRequestHeader <controller_map-request-header>` attributes, implement
+:class:`Symfony\\Component\\HttpKernel\\Controller\\SourceValueResolverInterface`.
+Targeting one of them keeps the whole chain behind it, so that the resolver able
+to build the argument type still runs. This is also why more than one resolver
+can be targeted for the same argument, provided that exactly one of them is such
+a source resolver::
+
+    public function dashboard(
+        #[MapQueryParameter] #[MapDateTime(format: 'd/m/Y')] \DateTimeImmutable $to,
+    ): Response
+    {
+        // ...
+    }
+
+.. versionadded:: 8.2
+
+    ``SourceValueResolverInterface`` and the ability to target several resolvers
+    for the same argument were introduced in Symfony 8.2.
+
 A targeted resolver can also be disabled by passing ``ValueResolver``'s ``$disabled``
 argument to ``true``; this is how :ref:`MapEntity allows you to disable the
 EntityValueResolver for a specific controller <doctrine-entity-value-resolver>`.


### PR DESCRIPTION
Documents the feature added in symfony/symfony#65386.

`#[MapQueryParameter]` and `#[MapRequestHeader]` now accept any type another value resolver can build: the raw value is stored in the request attributes under the argument name, so `DateTimeValueResolver`, `UidValueResolver` or `EntityValueResolver` pick it up as if it came from the route. `#[MapDateTime]` can be combined with them to pass a format. The limits are documented too (single scalar values only, arrays rejected with `validationFailedStatusCode`, variadic class-typed arguments unsupported).

`controller/value_resolver.rst` explains `SourceValueResolverInterface`: targeting a source resolver keeps the chain behind it, which is what allows several resolvers to be targeted for the same argument.

Fixes #22724