### PR TITLE
[AssetMapper] Document the minimum release age for importmap updates

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -293,6 +293,63 @@ You can update your third-party packages to their current versions by running:
     $ php bin/console importmap:update bootstrap lodash
     $ php bin/console importmap:outdated bootstrap lodash
 
+.. _asset-mapper-minimum-release-age:
+
+Delaying Updates to Freshly Published Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``minimum_release_age`` option was introduced in Symfony 8.2.
+
+Supply chain attacks land in freshly published npm versions. Set the
+``minimum_release_age`` option to make ``importmap:update`` ignore the versions
+that are too recent, giving a compromised release the time to be spotted and
+unpublished before your project picks it up:
+
+.. code-block:: yaml
+
+    # config/packages/asset_mapper.yaml
+    framework:
+        asset_mapper:
+            # in seconds; 0 (the default) disables the check
+            minimum_release_age: 604800
+
+A version is then only proposed when it's old enough, it's not a prerelease, and
+it's not above the ``latest`` tag declared by the maintainers. The newest version
+passing these checks is the one ``importmap:update`` pins; when none does, the
+installed version is kept.
+
+``importmap:outdated`` shows the version kept out of reach in a ``Withheld``
+column (also available as a ``withheld`` key when using ``--format=json``):
+
+.. code-block:: terminal
+
+    $ php bin/console importmap:outdated
+
+     ----------- --------- -------- ----------
+      Package     Current   Latest   Withheld
+     ----------- --------- -------- ----------
+      bootstrap   5.3.1     5.3.2    5.3.3
+     ----------- --------- -------- ----------
+
+Both the column and the JSON key only appear when the option is enabled. A
+package whose only newer version is withheld is listed with ``Latest`` equal to
+``Current``, and doesn't make the command fail, as there's nothing to act on.
+
+.. note::
+
+    ``importmap:require`` is not affected by this option. Run
+    ``importmap:require package@latest`` to install a recent version without
+    disabling the check (e.g. to apply an urgent security fix).
+
+.. warning::
+
+    Only the full npm metadata document includes the publication date of each
+    version, so enabling this option makes every update check download it
+    instead of the abbreviated one. The response is much larger for popular
+    packages.
+
 Using Local npm Packages
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -607,6 +607,22 @@ vendor_dir
 
 The directory to store JavaScript vendors.
 
+minimum_release_age
+...................
+
+**type**: ``integer`` **default**: ``0``
+
+The minimum age, in seconds, a package version must have to be considered when
+checking for updates (``0`` disables this check). It protects you from supply
+chain attacks landing in freshly published versions, as explained in
+:ref:`Delaying Updates to Freshly Published Versions <asset-mapper-minimum-release-age>`.
+Enabling it makes update checks download the full npm metadata document, which is
+larger than the abbreviated one.
+
+.. versionadded:: 8.2
+
+    The ``minimum_release_age`` option was introduced in Symfony 8.2.
+
 precompress
 ...........
 


### PR DESCRIPTION
Documents `framework.asset_mapper.minimum_release_age` added in symfony/symfony#65074.

A new section in `frontend/asset_mapper.rst` explains why to delay updates to freshly published versions, which versions are eligible (old enough, stable, not above `dist-tags.latest`), the `Withheld` column of `importmap:outdated` and its `withheld` JSON key, that `importmap:require package@latest` remains the escape hatch, and that enabling the option makes update checks download the full npm metadata document. The option is also added to the framework configuration reference.

Fixes #22723