### PR TITLE
[Mailer] Fix the global S/MIME encrypter configuration

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1680,8 +1680,13 @@ and it will select the appropriate certificate depending on the ``To`` option::
 Encrypting Messages Globally
 ............................
 
-Instead of creating a new encrypter for each email, you can configure a global S/MIME
-encrypter that automatically applies to all outgoing messages:
+Instead of creating a new encrypter for each email, you can configure a global
+S/MIME encrypter that applies to the messages having the ``X-SMime-Encrypt``
+header::
+
+    $email->getHeaders()->addTextHeader('X-SMime-Encrypt', 'true');
+
+Enable it and define where the certificates of the recipients come from:
 
 .. configuration-block::
 
@@ -1691,6 +1696,7 @@ encrypter that automatically applies to all outgoing messages:
         framework:
             mailer:
                 smime_encrypter:
+                    enabled: true
                     repository: App\Security\LocalFileCertificateRepository
 
     .. code-block:: xml
@@ -1707,7 +1713,7 @@ encrypter that automatically applies to all outgoing messages:
             <!-- ... -->
             <framework:config>
                 <framework:mailer>
-                    <framework:smime-encrypter>
+                    <framework:smime-encrypter enabled="true">
                         <framework:repository>App\Security\LocalFileCertificateRepository</framework:repository>
                     </framework:smime-encrypter>
                 </framework:mailer>
@@ -1723,6 +1729,7 @@ encrypter that automatically applies to all outgoing messages:
         return static function (FrameworkConfig $framework): void {
             $mailer = $framework->mailer();
             $mailer->smimeEncrypter()
+                    ->enabled(true)
                     ->repository(LocalFileCertificateRepository::class)
             ;
         };


### PR DESCRIPTION
Two fixes in the "Encrypting Messages Globally" section:

* `SmimeEncryptedMessageListener` returns early unless the message carries the `X-SMime-Encrypt` header, so the encrypter does not "automatically apply to all outgoing messages";
* `framework.mailer.smime_encrypter` is declared with `canBeEnabled()`, so without `enabled: true` the listener definition is removed and the documented example does nothing.