### PR TITLE
[Clock] Document the DatePoint autodetection by the Doctrine schema tools

### DIFF
--- a/components/clock.rst
+++ b/components/clock.rst
@@ -309,11 +309,16 @@ They convert to/from ``DatePoint`` objects automatically::
     ``DatePoint`` fell back to ``string`` unless the Doctrine type was set
     explicitly.
 
+Only ``date_point`` is autodetected, because it's the Doctrine type matching the
+``DatePoint`` property type. Set the ``type`` option explicitly to store a
+``DatePoint`` as a ``day_point`` or a ``time_point``, as shown above.
+
 .. note::
 
-    A typed field mapper configured in your application (through the
-    ``typed_field_mapper`` option of DoctrineBundle) keeps precedence over this
-    autodetection.
+    The typed field mapper configured in your application (through the
+    ``typed_field_mapper`` option of DoctrineBundle) is asked first for each
+    property, so this autodetection only applies to the properties it leaves
+    without a Doctrine type.
 
 .. _clock_writing-tests:
 

--- a/components/clock.rst
+++ b/components/clock.rst
@@ -301,6 +301,20 @@ They convert to/from ``DatePoint`` objects automatically::
         // ...
     }
 
+.. versionadded:: 8.2
+
+    The autodetection of the ``date_point`` type by the Doctrine schema tools
+    (e.g. when running ``doctrine:migrations:diff`` or ``doctrine:schema:update``)
+    was introduced in Symfony 8.2. In previous versions, columns typed with
+    ``DatePoint`` fell back to ``string`` unless the Doctrine type was set
+    explicitly.
+
+.. note::
+
+    A typed field mapper configured in your application (through the
+    ``typed_field_mapper`` option of DoctrineBundle) keeps precedence over this
+    autodetection.
+
 .. _clock_writing-tests:
 
 Writing Time-Sensitive Tests

--- a/components/clock.rst
+++ b/components/clock.rst
@@ -301,6 +301,25 @@ They convert to/from ``DatePoint`` objects automatically::
         // ...
     }
 
+.. versionadded:: 8.2
+
+    The autodetection of the ``date_point`` type by the Doctrine schema tools
+    (e.g. when running ``doctrine:migrations:diff`` or ``doctrine:schema:update``)
+    was introduced in Symfony 8.2. In previous versions, columns typed with
+    ``DatePoint`` fell back to ``string`` unless the Doctrine type was set
+    explicitly.
+
+Only ``date_point`` is autodetected, because it's the Doctrine type matching the
+``DatePoint`` property type. Set the ``type`` option explicitly to store a
+``DatePoint`` as a ``day_point`` or a ``time_point``, as shown above.
+
+.. note::
+
+    The typed field mapper configured in your application (through the
+    ``typed_field_mapper`` option of DoctrineBundle) is asked first for each
+    property, so this autodetection only applies to the properties it leaves
+    without a Doctrine type.
+
 .. _clock_writing-tests:
 
 Writing Time-Sensitive Tests


### PR DESCRIPTION
The Clock page already promised that a `DatePoint` column needs no explicit Doctrine type, which only became true with symfony/symfony#63772.

This adds a `versionadded` for it (in previous versions the schema tools fell back to `string`), states that only `date_point` is autodetected — `day_point` and `time_point` still need an explicit `type` — and notes that the application's typed field mapper is asked first for each property.

Fixes #22679