### PR TITLE
[Scheduler] Stop using the deprecated Schedule::with()

### DIFF
--- a/scheduler.rst
+++ b/scheduler.rst
@@ -380,7 +380,7 @@ Finally, the recurring message has to be attached to a schedule::
         public function getSchedule(): Schedule
         {
             return $this->schedule ??= new Schedule()
-                ->with(
+                ->add(
                     RecurringMessage::trigger(
                         new ExcludeHolidaysTrigger(
                             CronExpressionTrigger::fromSpec('@daily'),
@@ -424,7 +424,7 @@ checks for messages to be generated::
         public function getSchedule(): Schedule
         {
             return $this->schedule ??= new Schedule()
-                ->with(
+                ->add(
                     RecurringMessage::trigger(
                         new ExcludeHolidaysTrigger(
                             CronExpressionTrigger::fromSpec('@daily'),
@@ -599,9 +599,9 @@ In your handler, you can check a condition and, if affirmative, access the
             $this->removeOldReports = RecurringMessage::cron('3 8 * * 1', new CleanUpOldSalesReport());
 
             return $this->schedule ??= new Schedule()
-                ->with(
+                ->add(
                     // ...
-                    $this->removeOldReports;
+                    $this->removeOldReports,
                 );
         }
 
@@ -686,7 +686,7 @@ being transferred and processed by its handler::
             $this->removeOldReports = RecurringMessage::cron('3 8 * * 1', new CleanUpOldSalesReport());
 
             return $this->schedule ??= new Schedule($this->dispatcher)
-                ->with(
+                ->add(
                     // ...
                 )
                 ->before(function(PreRunEvent $event) {
@@ -851,7 +851,7 @@ code::
     use Symfony\Component\Scheduler\Scheduler;
 
     $schedule = new Schedule()
-        ->with(
+        ->add(
             RecurringMessage::trigger(
                 new ExcludeHolidaysTrigger(
                     CronExpressionTrigger::fromSpec('@daily'),
@@ -897,7 +897,7 @@ This enables dynamic control of scheduled tasks at runtime::
         public function getSchedule(): Schedule
         {
             return $this->schedule ??= new Schedule()
-                ->with(
+                ->add(
                     // ...
                 )
             ;
@@ -974,7 +974,7 @@ worker is restarted, it resumes from the point it left off::
             $this->removeOldReports = RecurringMessage::cron('3 8 * * 1', new CleanUpOldSalesReport());
 
             return $this->schedule ??= new Schedule()
-                ->with(
+                ->add(
                     // ...
                 )
                 ->stateful($this->cache)
@@ -995,7 +995,7 @@ handle a message only once, you can use the ``processOnlyLastMissedRun`` option:
             $this->removeOldReports = RecurringMessage::cron('3 8 * * 1', new CleanUpOldSalesReport());
 
             return $this->schedule ??= new Schedule()
-                ->with(
+                ->add(
                     // ...
                 )
                 ->stateful($this->cache)
@@ -1018,7 +1018,7 @@ same task running more than once::
             $this->removeOldReports = RecurringMessage::cron('3 8 * * 1', new CleanUpOldSalesReport());
 
             return $this->schedule ??= new Schedule()
-                ->with(
+                ->add(
                     // ...
                 )
                 ->lock($this->lockFactory->createLock('my-lock'));
@@ -1045,7 +1045,7 @@ before being further redispatched to its corresponding handler::
         public function getSchedule(): Schedule
         {
             return $this->schedule ??= new Schedule()
-                ->with(
+                ->add(
                     RecurringMessage::every('5 seconds', new RedispatchMessage(new Message(), 'async'))
                 );
         }


### PR DESCRIPTION
Fix #22743.

symfony/symfony#65383 deprecates `Schedule::with()`: it silently drops the lock and the state of the original schedule. Every example in scheduler.rst calls it on a fresh instance, where the recommended `add()` is a drop-in replacement, so this simply switches them all. Also fixes a stray `;` inside one of the touched calls (it made the example invalid PHP).
