### PR TITLE
[Mime] Document AbstractPart::setContentTypeParameter()

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -909,6 +909,21 @@ unchanged::
 
     The ``binary`` content transfer encoding was introduced in Symfony 8.2.
 
+Some media types define additional ``Content-Type`` parameters, such as the
+``method`` of a ``text/calendar`` part. Use ``setContentTypeParameter()`` to
+define them on any part::
+
+    use Symfony\Component\Mime\Part\TextPart;
+
+    $invitation = new TextPart($icalContent, 'utf-8', 'calendar', '8bit')
+        ->setContentTypeParameter('method', 'REQUEST');
+    // the part is now sent with the following header:
+    // Content-Type: text/calendar; method=REQUEST; charset=utf-8
+
+.. versionadded:: 8.2
+
+    The ``setContentTypeParameter()`` method was introduced in Symfony 8.2.
+
 .. _mailer-configure-email-globally:
 
 Configuring Emails Globally


### PR DESCRIPTION
Fix #22744.

Documents the new `AbstractPart::setContentTypeParameter()` from symfony/symfony#65381, in the raw-message section of mailer.rst where the parts API already lives. The example is the canonical use case from the feature PR (a `text/calendar` part with `method=REQUEST`), with the resulting header taken from its tests.
