### PR TITLE
[Cache] Document the PdoTagAwareAdapter and its "cache.adapter.pdo_tag_aware" service

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -252,6 +252,7 @@ you can use them when defining your cache pools:
 * :doc:`cache.adapter.filesystem </cache/adapters/filesystem_adapter>`
 * :doc:`cache.adapter.memcached </cache/adapters/memcached_adapter>`
 * :doc:`cache.adapter.pdo </cache/adapters/pdo_adapter>`
+* :ref:`cache.adapter.pdo_tag_aware <pdo-tag-aware-adapter>` (PDO adapter optimized to work with tags)
 * :doc:`cache.adapter.psr6 </cache/adapters/proxy_adapter>`
 * :doc:`cache.adapter.redis </cache/adapters/redis_adapter>`
 * :ref:`cache.adapter.redis_tag_aware <redis-tag-aware-adapter>` (Redis adapter optimized to work with tags)

--- a/cache/adapters/pdo_adapter.rst
+++ b/cache/adapters/pdo_adapter.rst
@@ -43,5 +43,65 @@ your code.
     When passed a `Data Source Name (DSN)`_ string (instead of a database connection
     class instance), the connection will be lazy-loaded when needed.
 
+.. _pdo-tag-aware-adapter:
+
+Working with Tags
+-----------------
+
+.. versionadded:: 8.2
+
+    The ``PdoTagAwareAdapter`` and the ``cache.adapter.pdo_tag_aware`` service
+    were introduced in Symfony 8.2.
+
+In order to use tag-based invalidation, you can wrap the adapter in
+:class:`Symfony\\Component\\Cache\\Adapter\\TagAwareAdapter`. However, the
+dedicated :class:`Symfony\\Component\\Cache\\Adapter\\PdoTagAwareAdapter`
+stores the tags in the same database, so the tag invalidation logic runs in the
+database itself::
+
+    use Symfony\Component\Cache\Adapter\PdoTagAwareAdapter;
+
+    $cache = new PdoTagAwareAdapter($databaseConnectionOrDSN);
+
+Tags are stored in their own table, created on the first save like the table of
+the cache items. Use the ``db_tags_table``, ``db_tags_col`` and
+``db_tags_tag_index_name`` options to change the name of that table, of its tag
+column and of its index.
+
+In Symfony applications, use the ``cache.adapter.pdo_tag_aware`` adapter. Pools
+based on it are tag aware on their own, so Symfony doesn't wrap them in a
+``TagAwareAdapter``. Their ``provider`` option is optional and defaults to the
+``framework.cache.default_pdo_provider`` value:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/cache.yaml
+        framework:
+            cache:
+                pools:
+                    my_cache_pool:
+                        adapter: cache.adapter.pdo_tag_aware
+                        provider: 'pgsql:host=localhost'
+
+    .. code-block:: php
+
+        // config/packages/cache.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'cache' => [
+                    'pools' => [
+                        'my_cache_pool' => [
+                            'adapter' => 'cache.adapter.pdo_tag_aware',
+                            'provider' => 'pgsql:host=localhost',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
 .. _`DSN`: https://php.net/manual/pdo.drivers.php
 .. _`Data Source Name (DSN)`: https://en.wikipedia.org/wiki/Data_source_name


### PR DESCRIPTION
Fixes #22670.

Documents the `cache.adapter.pdo_tag_aware` wiring from symfony/symfony#65351, along with the `PdoTagAwareAdapter` it exposes (symfony/symfony#58296), which had no documentation yet.