### PR TITLE
[Cache] Document pruning of RedisTagAwareAdapter

### DIFF
--- a/cache.rst
+++ b/cache.rst
@@ -1268,8 +1268,10 @@ all the expired items from the storage. The adapters that need this feature
 implement it: :doc:`ChainAdapter </cache/adapters/chain_adapter>`,
 :doc:`DoctrineDbalAdapter </cache/adapters/doctrine_dbal_adapter>`,
 :doc:`FilesystemAdapter </cache/adapters/filesystem_adapter>`,
-:doc:`PdoAdapter </cache/adapters/pdo_adapter>` and
-:doc:`PhpFilesAdapter </cache/adapters/php_files_adapter>`, as well as the
+:doc:`PdoAdapter </cache/adapters/pdo_adapter>`,
+:doc:`PdoTagAwareAdapter </cache/adapters/pdo_adapter>`,
+:doc:`PhpFilesAdapter </cache/adapters/php_files_adapter>` and
+:doc:`RedisTagAwareAdapter </cache/adapters/redis_adapter>`, as well as the
 adapters that wrap other adapters (such as ``TagAwareAdapter``, ``ProxyAdapter``
 and ``Psr16Adapter``), which delegate the pruning to the wrapped adapter::
 
@@ -1278,6 +1280,18 @@ and ``Psr16Adapter``), which delegate the pruning to the wrapped adapter::
     $cache = new FilesystemAdapter('app.cache');
     // ... do some set and get operations
     $cache->prune();
+
+.. note::
+
+    Redis removes the expired items on its own, but the Sets that
+    :doc:`RedisTagAwareAdapter </cache/adapters/redis_adapter>` uses to relate
+    tags and items keep referencing them. Pruning that adapter removes those
+    stale references and deletes the Sets that don't reference any existing
+    item anymore.
+
+.. versionadded:: 8.2
+
+    Support for pruning ``RedisTagAwareAdapter`` was introduced in Symfony 8.2.
 
 The :doc:`ChainAdapter </cache/adapters/chain_adapter>` implementation does not directly
 contain any pruning logic itself. Instead, when calling the chain adapter's

--- a/cache/adapters/redis_adapter.rst
+++ b/cache/adapters/redis_adapter.rst
@@ -326,6 +326,16 @@ performance when using tag-based invalidation::
 
 Read more about this topic in the official `Redis LRU Cache Documentation`_.
 
+The Sets that relate tags and cache items keep referencing the items that Redis
+expired or evicted. Call
+:method:`Symfony\\Component\\Cache\\PruneableInterface::prune` to
+:ref:`remove those stale references <component-cache-cache-pool-prune>` and the
+Sets that don't reference any existing item anymore.
+
+.. versionadded:: 8.2
+
+    Support for pruning ``RedisTagAwareAdapter`` was introduced in Symfony 8.2.
+
 Working with Marshaller
 -----------------------
 


### PR DESCRIPTION
Fixes #22672.

Documents `PruneableInterface` on `RedisTagAwareAdapter`, from symfony/symfony#65353.

While rewriting that list, I also added `PdoTagAwareAdapter` to it: it implements `PruneableInterface` too and was missing. It is documented by #22763; keeping both edits here avoids two PRs rewriting the same sentence.