### PR TITLE
[HttpKernel] Document the JSON query parameter of #[MapQueryString]

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -471,6 +471,17 @@ set the ``key`` option in the ``#[MapQueryString]`` attribute::
         // ...
     }
 
+That query parameter can also hold a JSON document instead of a nested array,
+which allows passing the whole object in a single parameter:
+``?search={"query":"symfony","page":2}`` (URL-encoded in the actual request).
+Symfony returns a ``400 Bad Request`` response when that string isn't valid
+JSON or when it holds a property the object doesn't define.
+
+.. versionadded:: 8.2
+
+    Deserializing the named query parameter as JSON was introduced in
+    Symfony 8.2.
+
 If you need a valid DTO even when the request query string is empty, set a
 default value for your controller arguments::
 


### PR DESCRIPTION
Fixes #22638.

Documents the JSON deserialization of the parameter named by `#[MapQueryString(key:)]`, from symfony/symfony#64368.