### PR TITLE
[Console] Document callables for the description and help of the console attributes

### DIFF
--- a/console.rst
+++ b/console.rst
@@ -173,6 +173,36 @@ longer help text for the command::
         }
     }
 
+The ``description`` and ``help`` options also accept a callable returning the
+string. Attribute arguments must be constant expressions, so this is the way to
+build a text that can't be written as a literal::
+
+    #[AsCommand(
+        name: 'app:create-user',
+        description: [CreateUserCommand::class, 'describeCommand'],
+    )]
+    class CreateUserCommand
+    {
+        public static function describeCommand(): string
+        {
+            return 'Creates a new user with one of these roles: '
+                .implode(', ', Role::names());
+        }
+
+        public function __invoke(): int
+        {
+            // ...
+        }
+    }
+
+The callable runs when the attribute is instantiated, so the returned string is
+computed once and then used as any other description.
+
+.. versionadded:: 8.2
+
+    Support for callables in the ``description`` and ``help`` options was
+    introduced in Symfony 8.2.
+
 Additionally, you can extend the :class:`Symfony\\Component\\Console\\Command\\Command` class to
 leverage advanced features like lifecycle hooks (e.g. :method:`Symfony\\Component\\Console\\Command\\Command::initialize`
 and :method:`Symfony\\Component\\Console\\Command\\Command::interact`)::

--- a/console/input.rst
+++ b/console/input.rst
@@ -45,7 +45,14 @@ The ``Argument`` attribute accepts the following parameters:
 
 ``description``
     A description of the argument shown when displaying the command help.
-    For example: ``#[Argument(description: 'Your username')]``.
+    For example: ``#[Argument(description: 'Your username')]``. It also accepts
+    a callable returning the string, such as
+    ``#[Argument(description: [self::class, 'describeUsername'])]``.
+
+    .. versionadded:: 8.2
+
+        Support for callables in the ``description`` parameter was introduced
+        in Symfony 8.2.
 
 ``name``
     The name displayed for the argument in the command help and used to retrieve
@@ -262,7 +269,14 @@ The ``Option`` attribute accepts the following parameters:
 
 ``description``
     A description of the option shown when displaying the command help.
-    For example: ``#[Option(description: 'Number of iterations')]``.
+    For example: ``#[Option(description: 'Number of iterations')]``. It also
+    accepts a callable returning the string, such as
+    ``#[Option(description: [self::class, 'describeIterations'])]``.
+
+    .. versionadded:: 8.2
+
+        Support for callables in the ``description`` parameter was introduced
+        in Symfony 8.2.
 
 ``name``
     The name used when passing the option to the command (e.g. ``--max-retries=5``)


### PR DESCRIPTION
Fixes #22634.

Documents the callable `description`/`help` options of `#[AsCommand]`, `#[Argument]` and `#[Option]`, from symfony/symfony#61677.