### PR TITLE
[Validator] Document using the ::class constant in GroupSequence

### DIFF
--- a/validation/sequence_provider.rst
+++ b/validation/sequence_provider.rst
@@ -131,6 +131,21 @@ that group are valid, the second group, ``Strict``, will be validated.
     sequence, which will contain the ``Default`` group which references the
     same group sequence, ...).
 
+    You can also use the ``::class`` constant of the annotated class instead
+    of spelling its short name as a string (e.g. ``User::class`` instead of
+    ``'User'``), which is friendlier to IDEs and refactoring tools::
+
+        #[Assert\GroupSequence([User::class, 'Strict'])]
+        class User
+        {
+            // ...
+        }
+
+    .. versionadded:: 8.2
+
+        Support for using the ``::class`` constant of the annotated class in
+        ``GroupSequence`` was introduced in Symfony 8.2.
+
 .. warning::
 
     Calling ``validate()`` with a group in the sequence (``Strict`` in previous


### PR DESCRIPTION
Fix #22781.

Documents symfony/symfony#63557 in the warning of sequence_provider.rst that explains the `{ClassName}` group: the `::class` constant of the annotated class is now accepted instead of spelling the short class name as a string, which is friendlier to IDEs and refactoring tools (the motivation of the feature: renaming the class no longer silently detaches its sequence).
