### PR TITLE
[DependencyInjection] Document the AutowireClassMap attribute

### DIFF
--- a/reference/attributes.rst
+++ b/reference/attributes.rst
@@ -40,6 +40,7 @@ Dependency Injection
 * :ref:`AutoconfigureTag <di-instanceof>`
 * :ref:`Autowire <autowire-attribute>`
 * :ref:`AutowireCallable <autowiring_closures>`
+* :ref:`AutowireClassMap <service-tags-resource-tags-class-map>`
 * :doc:`AutowireDecorated </service_container/decoration>`
 * :ref:`AutowireInline <autowiring-anonymous-services-inline>`
 * :ref:`AutowireIterator <service-locator_autowire-iterator>`

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -979,6 +979,43 @@ using :method:`Symfony\\Component\\DependencyInjection\\ContainerBuilder::findTa
         }
     }
 
+.. _service-tags-resource-tags-class-map:
+
+Injecting a Class Map of Tagged Classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the most common use case (injecting the map of tagged classes into a
+service) you don't need a compiler pass: use the ``#[AutowireClassMap]``
+attribute to inject an array that maps an index to each tagged class name::
+
+    // src/Report/ReportGenerator.php
+    namespace App\Report;
+
+    use Symfony\Component\DependencyInjection\Attribute\AutowireClassMap;
+
+    class ReportGenerator
+    {
+        public function __construct(
+            // e.g. ['invoice' => Invoice::class, 'order' => Order::class]
+            #[AutowireClassMap('app.report_item', indexAttribute: 'type')]
+            private array $reportItemClasses,
+        ) {
+        }
+    }
+
+The ``indexAttribute`` argument defines which tag attribute provides the key
+of each class in the map. When not passed, it defaults to the last dot-segment
+of the tag name (``report_item`` for the ``app.report_item`` tag). Classes
+whose tag doesn't define the index attribute are keyed by the index of their
+``#[AsTaggedItem]`` attribute if they have one, or by their own fully-qualified
+class name; a ``priority`` tag attribute (or the priority of ``#[AsTaggedItem]``)
+decides which class wins when several of them share the same index. Use the
+``exclude`` argument to leave some class names out of the map.
+
+.. versionadded:: 8.2
+
+    The ``#[AutowireClassMap]`` attribute was introduced in Symfony 8.2.
+
 Creating Custom Tags and Processing Them with Compiler Passes
 -------------------------------------------------------------
 


### PR DESCRIPTION
Fix #22788.

Documents symfony/symfony#65370 as a new subsection of the resource tags documentation in tags.rst, right after the compiler-pass example it replaces for the common case, reusing the section's running `app.report_item` example. Covers the `indexAttribute` default (the last dot-segment of the tag name, per `TaggedClassMapArgument`), the `#[AsTaggedItem]` / FQCN fallbacks and the priority semantics (from `ResolveTaggedClassMapArgumentPass`), and the `exclude` argument. Also adds the attribute to the list in reference/attributes.rst.
