### PR TITLE
[Translation] Document Crowdin pulling every domain when none is configured

### DIFF
--- a/translation.rst
+++ b/translation.rst
@@ -905,6 +905,17 @@ configure the ``providers`` option:
 
 .. tip::
 
+    If you use Crowdin as a provider and you don't define the ``domains``
+    option, translations of every domain found in the project are pulled (each
+    domain matches a ``.xlf`` source file).
+
+.. versionadded:: 8.2
+
+    The support for pulling every domain of a Crowdin project when the
+    ``domains`` option is not defined was introduced in Symfony 8.2.
+
+.. tip::
+
     If you use Lokalise as a provider and a locale format following the `ISO
     639-1`_ (e.g. "en" or "fr"), you have to set the `Custom Language Name setting`_
     in Lokalise for each of your locales, in order to override the


### PR DESCRIPTION
Fixes #22612.

Documents that the Crowdin provider now pulls every domain of the project when
the `domains` option is not defined (symfony/symfony#65269, 8.2).

The `domains` option defaults to an empty array and `translation:pull` falls
back to the provider's configured domains, so leaving it out is what triggers
the new behavior — but nothing in the docs said the option was optional.
