### PR TITLE
[Messenger] Document RedispatchMessage falling back to configured senders

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -4445,7 +4445,20 @@ it through your bus. Reusing the same ``SmsNotification`` example shown earlier:
 The built-in :class:`Symfony\\Component\\Messenger\\Handler\\RedispatchMessageHandler`
 will take care of this message to redispatch it through the same bus it was
 dispatched at first. You can also use the second argument of the ``RedispatchMessage``
-constructor to provide transports to use when redispatching the message.
+constructor to force the transports to use when redispatching the message::
+
+    $this->bus->dispatch(new RedispatchMessage($message, 'async'));
+
+When you don't pass any transport name, the message is sent to the senders
+:ref:`configured for its class <messenger-routing>`, whether they come from the
+``framework.messenger.routing`` option or from the ``#[AsMessage]`` attribute.
+If the message class has no configured sender, it is handled in process.
+
+.. versionadded:: 8.2
+
+    Falling back to the senders configured for the message was introduced in
+    Symfony 8.2. In previous versions, omitting the transport names sent the
+    message to no sender at all.
 
 Learn more
 ----------

--- a/scheduler.rst
+++ b/scheduler.rst
@@ -1051,6 +1051,17 @@ before being further redispatched to its corresponding handler::
         }
     }
 
+The transport name is optional: leave it out and the message is redispatched to
+the senders configured for its class, in the ``framework.messenger.routing``
+option or in its ``#[AsMessage]`` attribute::
+
+    RecurringMessage::every('5 seconds', new RedispatchMessage(new Message()));
+
+.. versionadded:: 8.2
+
+    Redispatching to the senders configured for the message was introduced in
+    Symfony 8.2.
+
 When using the ``RedispatchMessage``, Symfony will attach a
 :class:`Symfony\\Component\\Scheduler\\Messenger\\ScheduledStamp` to the message,
 helping you identify those messages when needed.


### PR DESCRIPTION
Fixes #22570.

Since symfony/symfony#65143, a `RedispatchMessage` without transport names is sent
to the senders configured for the message class instead of to no sender at all.

The existing `new RedispatchMessage($message)` example in messenger.rst therefore
changed meaning, so both it and the Scheduler section needed the new behavior spelled
out. UPGRADE-8.2.md covers restoring the previous behavior with an empty
`TransportNamesStamp`.
