### PR TITLE
[Console][HttpKernel] Document union and intersection types as controller and command arguments

### DIFF
--- a/console/value_resolver.rst
+++ b/console/value_resolver.rst
@@ -184,8 +184,9 @@ section :ref:`Automatically Fetching Objects <doctrine-entity-value-resolver>`.
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 :class:`Symfony\\Component\\Console\\ArgumentResolver\\ValueResolver\\ServiceValueResolver`
-injects a service if type-hinted with a valid service class or interface. This
-works like :doc:`autowiring </service_container/autowiring>`::
+injects a service if type-hinted with a valid service class or interface, as
+well as with a union or intersection of them. This works like
+:doc:`autowiring </service_container/autowiring>`::
 
     use App\Service\UserManager;
     use Psr\Log\LoggerInterface;
@@ -206,6 +207,11 @@ works like :doc:`autowiring </service_container/autowiring>`::
             return Command::SUCCESS;
         }
     }
+
+.. versionadded:: 8.2
+
+    Support for union and intersection types in command arguments was
+    introduced in Symfony 8.2.
 
 ``UidValueResolver``
 ~~~~~~~~~~~~~~~~~~~~

--- a/controller.rst
+++ b/controller.rst
@@ -192,6 +192,19 @@ your :doc:`controller to be registered as a service </controller/service>`::
         // ...
     }
 
+Union and intersection types are supported too, and behave like they do for
+:doc:`constructor arguments </service_container/autowiring>`::
+
+    public function number(DecoderInterface&DenormalizerInterface $serializer): Response
+    {
+        // ...
+    }
+
+.. versionadded:: 8.2
+
+    Support for union and intersection types in controller arguments was
+    introduced in Symfony 8.2.
+
 Awesome!
 
 What other services can you type-hint? To see them, use the ``debug:autowiring`` console


### PR DESCRIPTION
Fix #22791.

Documents symfony/symfony#65368 in the two places where service injection into method arguments is explained: the "Fetching Services" example of controller.rst (with the intersection-type example from the feature PR) and the `ServiceValueResolver` section of console/value_resolver.rst, each with a `versionadded` directive.
