### PR TITLE
[Messenger] Document the reject_redelivered_messages option

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -3720,6 +3720,17 @@ for each bus looks like this:
 #. ``add_bus_name_stamp_middleware`` - adds a stamp to record which bus this
    message was dispatched into;
 
+#. ``reject_redelivered_message_middleware`` - throws a
+   ``RejectRedeliveredMessageException`` when AMQP redelivers a message, so the
+   worker republishes it through the retry logic instead of handling it
+   directly. Remove it with the
+   :ref:`reject_redelivered_messages <reference-messenger-reject-redelivered-messages>`
+   option;
+
+   .. versionadded:: 8.2
+
+       The ``reject_redelivered_messages`` option was introduced in Symfony 8.2.
+
 #. ``dispatch_after_current_bus``- see :ref:`messenger-transactional-messages`;
 
 #. ``failed_message_processing_middleware`` - processes messages that are being

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2849,6 +2849,28 @@ failure_transport
 
 The transport name to send failed messages to (after all retries have failed).
 
+.. _reference-messenger-reject-redelivered-messages:
+
+reject_redelivered_messages
+...........................
+
+**type**: ``boolean`` **default**: ``true``
+
+Whether to add the ``reject_redelivered_message_middleware`` to the default
+middleware of every bus. AMQP redelivers a message that was neither acknowledged
+nor rejected (e.g. after a connection timeout); this middleware rejects such a
+message so the retry mechanism republishes it, which bounds it by the retry
+limit instead of letting it be redelivered forever.
+
+Set this option to ``false`` to handle redeliveries directly instead. This
+avoids losing a message when the retry or the failure transport is unreachable,
+at the risk of the redelivery loop the middleware prevents. You can still list
+the middleware in the ``middleware`` option of a specific bus.
+
+.. versionadded:: 8.2
+
+    The ``reject_redelivered_messages`` option was introduced in Symfony 8.2.
+
 routing
 .......
 


### PR DESCRIPTION
Fixes #22572.

Documents `framework.messenger.reject_redelivered_messages`, added in
symfony/symfony#64866 to make the `RejectRedeliveredMessageMiddleware` opt-out.

The middleware itself was missing from the default middleware list in
messenger.rst, so it is added there as well: the option cannot be explained
without it.
