### PR TITLE
[Translation] Describe the `trans_default_domain` `for _self` modifier added in 8.2

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -1674,11 +1674,29 @@ trans_default_domain
 .. code-block:: twig
 
     {% trans_default_domain domain %}
+    {% trans_default_domain domain for _self %}
 
 ``domain``
     **type**: ``string``
 
-This will set the default domain in the current template.
+This will set the default domain for translations made after this tag, within
+the current Twig scope (e.g. it does not apply to the body of an ``embed``
+tag).
+
+.. versionadded:: 8.2
+
+    The ``for _self`` modifier was introduced in Symfony 8.2. When added,
+    ``domain`` must be a constant value and the tag must be used only once
+    per template, before any ``embed`` tag. The domain then applies to the
+    whole template instead: It also reaches macros, blocks inherited by
+    child templates, ``embed`` bodies, and ``trans`` calls written above the
+    declaration. A scoped ``trans_default_domain`` (without ``for _self``)
+    still takes precedence where it applies.
+
+    This is especially useful for :ref:`Twig Components <templates-twig-components>`,
+    which are built on top of ``embed`` under the hood: without ``for _self``,
+    the domain would have to be redeclared within each and every Twig
+    Component used in the same file, instead of being set once at the top.
 
 .. _reference-twig-tests:
 

--- a/translation.rst
+++ b/translation.rst
@@ -514,7 +514,28 @@ The ``trans`` filter can be used to translate *variable texts* and complex expre
        {% trans_default_domain 'app' %}
 
     Note that this only influences the current template, not any "included"
-    template (in order to avoid side effects).
+    template (in order to avoid side effects). It also does not apply to the
+    body of an ``embed`` tag.
+
+    .. versionadded:: 8.2
+
+        Add ``for _self`` to make the domain apply to the whole
+        template, including ``embed`` bodies:
+
+        .. code-block:: twig
+
+           {% trans_default_domain 'app' for _self %}
+
+        This requires a constant domain and the tag can only be declared
+        once per template, before any ``embed`` tag. It still does not reach
+        ``include``, ``use`` or the parent of an ``extends``. A scoped
+        ``trans_default_domain`` takes precedence over it where it applies.
+
+        This is especially useful for :ref:`Twig Components <templates-twig-components>`,
+        which are built on top of ``embed`` under the hood: without
+        ``for _self``, the domain would have to be redeclared within each
+        and every Twig Component used in the same file, instead of being
+        set once at the top.
 
 By default, the translated messages are output escaped; apply the ``raw``
 filter after the translation filter to avoid the automatic escaping:


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Feature PR   | symfony/symfony#63986
| PR author(s) | @nicolas-grekas, @mpdude
| Merged in    | 8.2

This only describes the new modifier, not the deprecation path or changes planned for 9.0.

Closes #22805.