### PR TITLE
[Validator] Document BcMath\Number support in Range and comparison constraints

### DIFF
--- a/reference/constraints/EqualTo.rst
+++ b/reference/constraints/EqualTo.rst
@@ -98,6 +98,8 @@ and that the ``age`` is ``20``, you could do the following:
             }
         }
 
+.. include:: /reference/constraints/_comparison-bcmath-number.rst.inc
+
 Options
 -------
 

--- a/reference/constraints/GreaterThan.rst
+++ b/reference/constraints/GreaterThan.rst
@@ -296,6 +296,8 @@ as a service, comparison validators automatically use it to resolve relative dat
 strings (e.g. ``today``, ``+5 hours``). This makes date comparisons deterministic
 and testable by using :ref:`MockClock <clock-mockclock>`.
 
+.. include:: /reference/constraints/_comparison-bcmath-number.rst.inc
+
 Options
 -------
 

--- a/reference/constraints/GreaterThanOrEqual.rst
+++ b/reference/constraints/GreaterThanOrEqual.rst
@@ -298,6 +298,8 @@ as a service, comparison validators automatically use it to resolve relative dat
 strings (e.g. ``today``, ``+5 hours``). This makes date comparisons deterministic
 and testable by using :ref:`MockClock <clock-mockclock>`.
 
+.. include:: /reference/constraints/_comparison-bcmath-number.rst.inc
+
 Options
 -------
 

--- a/reference/constraints/LessThan.rst
+++ b/reference/constraints/LessThan.rst
@@ -298,6 +298,8 @@ as a service, comparison validators automatically use it to resolve relative dat
 strings (e.g. ``today``, ``-18 years``). This makes date comparisons deterministic
 and testable by using :ref:`MockClock <clock-mockclock>`.
 
+.. include:: /reference/constraints/_comparison-bcmath-number.rst.inc
+
 Options
 -------
 

--- a/reference/constraints/LessThanOrEqual.rst
+++ b/reference/constraints/LessThanOrEqual.rst
@@ -297,6 +297,8 @@ as a service, comparison validators automatically use it to resolve relative dat
 strings (e.g. ``today``, ``-18 years``). This makes date comparisons deterministic
 and testable by using :ref:`MockClock <clock-mockclock>`.
 
+.. include:: /reference/constraints/_comparison-bcmath-number.rst.inc
+
 Options
 -------
 

--- a/reference/constraints/NotEqualTo.rst
+++ b/reference/constraints/NotEqualTo.rst
@@ -100,6 +100,8 @@ the following:
             }
         }
 
+.. include:: /reference/constraints/_comparison-bcmath-number.rst.inc
+
 Options
 -------
 

--- a/reference/constraints/Range.rst
+++ b/reference/constraints/Range.rst
@@ -1,7 +1,8 @@
 Range
 =====
 
-Validates that a given number or ``DateTime`` object is *between* some minimum and maximum.
+Validates that a given number, :phpclass:`BcMath\\Number` or ``DateTime``
+object is *between* some minimum and maximum.
 
 ==========  ===================================================================
 Applies to  :ref:`property or method <validation-property-target>`
@@ -313,6 +314,48 @@ as a service, the Range validator automatically uses it to resolve relative date
 strings (e.g. ``now``, ``+5 hours``). This makes date range comparisons
 deterministic and testable by using :ref:`MockClock <clock-mockclock>`.
 
+Arbitrary Precision Number Ranges
+---------------------------------
+
+.. versionadded:: 8.2
+
+    Support for :phpclass:`BcMath\\Number` values in the ``Range`` constraint
+    was introduced in Symfony 8.2.
+
+This constraint can also be applied to :phpclass:`BcMath\\Number` objects,
+the arbitrary precision numbers provided by the PHP ``bcmath`` extension. The
+``min`` and ``max`` limits can be given as integers, floats or numeric
+strings::
+
+    // src/Entity/Order.php
+    namespace App\Entity;
+
+    use Symfony\Component\Validator\Constraints as Assert;
+
+    class Order
+    {
+        #[Assert\Range(min: 0.01, max: 10000)]
+        protected \BcMath\Number $amount;
+    }
+
+When the validated value is a ``BcMath\Number``, the limits are converted to
+``BcMath\Number`` objects too, so the comparison keeps its arbitrary precision.
+This matters because PHP truncates the other operand to an integer when
+comparing it with a ``BcMath\Number``, which makes ``10.2`` greater than
+``10.5`` in plain PHP::
+
+    new \BcMath\Number('10.2') > 10.5; // true in plain PHP
+    // with the constraint, 10.2 is correctly considered lower than 10.5
+
+Floats written in exponent notation (e.g. ``1.0E-7``) are supported as well.
+The ``INF`` and ``NAN`` limits have no ``BcMath\Number`` representation, so
+they keep the native PHP comparison.
+
+.. seealso::
+
+    The same support is available in the comparison constraints, such as
+    :doc:`GreaterThanOrEqual </reference/constraints/GreaterThanOrEqual>`.
+
 Options
 -------
 
@@ -340,7 +383,8 @@ Parameter        Description
 **type**: ``string`` **default**: ``This value should be a valid number.``
 
 The message displayed when the ``min`` and ``max`` values are numeric (per
-the :phpfunction:`is_numeric` PHP function) but the given value is not.
+the :phpfunction:`is_numeric` PHP function) but the given value is neither
+numeric nor a :phpclass:`BcMath\\Number` object.
 
 You can use the following parameters in this message:
 

--- a/reference/constraints/_comparison-bcmath-number.rst.inc
+++ b/reference/constraints/_comparison-bcmath-number.rst.inc
@@ -1,0 +1,50 @@
+Comparing Arbitrary Precision Numbers
+-------------------------------------
+
+.. versionadded:: 8.2
+
+    Support for :phpclass:`BcMath\\Number` values in comparison constraints was
+    introduced in Symfony 8.2.
+
+This constraint can also be applied to :phpclass:`BcMath\\Number` objects,
+the arbitrary precision numbers provided by the PHP ``bcmath`` extension. The
+comparison value can be given as an integer, a float or a numeric string::
+
+    // src/Entity/Order.php
+    namespace App\Entity;
+
+    use Symfony\Component\Validator\Constraints as Assert;
+
+    class Order
+    {
+        #[Assert\GreaterThanOrEqual(0.01)]
+        protected \BcMath\Number $amount;
+    }
+
+When the validated value is a ``BcMath\Number``, the comparison value is
+converted to a ``BcMath\Number`` too, so the comparison keeps its arbitrary
+precision. This matters because PHP truncates the other operand to an integer
+when comparing it with a ``BcMath\Number``, which makes ``10.2`` greater than
+``10.5`` in plain PHP::
+
+    new \BcMath\Number('10.2') > 10.5; // true in plain PHP
+    // with the constraint, 10.2 is correctly considered lower than 10.5
+
+Floats written in exponent notation (e.g. ``1.0E-7``) are supported as well.
+The ``INF`` and ``NAN`` values have no ``BcMath\Number`` representation, so
+they keep the native PHP comparison.
+
+.. note::
+
+    This applies to the :doc:`EqualTo </reference/constraints/EqualTo>`,
+    :doc:`NotEqualTo </reference/constraints/NotEqualTo>`,
+    :doc:`GreaterThan </reference/constraints/GreaterThan>`,
+    :doc:`GreaterThanOrEqual </reference/constraints/GreaterThanOrEqual>`,
+    :doc:`LessThan </reference/constraints/LessThan>`,
+    :doc:`LessThanOrEqual </reference/constraints/LessThanOrEqual>` and
+    :doc:`Range </reference/constraints/Range>` constraints.
+    :doc:`IdenticalTo </reference/constraints/IdenticalTo>` and
+    :doc:`NotIdenticalTo </reference/constraints/NotIdenticalTo>` compare
+    object identity, so a ``BcMath\Number`` is never identical to a scalar, and
+    :doc:`DivisibleBy </reference/constraints/DivisibleBy>` doesn't accept
+    ``BcMath\Number`` values.


### PR DESCRIPTION
Fix #22800

Documents symfony/symfony#65110, which adds `BcMath\Number` support to the `Range` constraint and to the comparison constraints (`EqualTo`, `NotEqualTo`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`).

- A new shared `_comparison-bcmath-number.rst.inc` section, included in the six comparison constraint pages right before their `Options`: the limit keeps its arbitrary precision (with the `10.2` vs `10.5` example of what PHP does otherwise), exponent notation is accepted, `INF` and `NAN` fall back to the native comparison, and a note lists the constraints involved as well as the ones left out (`IdenticalTo`, `NotIdenticalTo`, `DivisibleBy`), as described in the feature PR.
- `Range.rst` gets its own "Arbitrary Precision Number Ranges" section with the same content adapted to `min`/`max`, and the `invalidMessage` description now mentions `BcMath\Number`.

DOCtor-RST and the docs build pass locally.
