### PR TITLE
[HttpFoundation] Explain how to use the native PHP session handlers

### DIFF
--- a/session.rst
+++ b/session.rst
@@ -361,12 +361,30 @@ configuration <config-framework-session>` in
         ]);
         $session = new Session($storage);
 
-Setting the ``handler_id`` config option to ``null`` means that Symfony will
-use the native PHP session mechanism. The session metadata files will be stored
-outside of the Symfony application, in a directory controlled by PHP. Although
-this usually simplifies things, some session expiration related options may not
-work as expected if other applications that write to the same directory have
-short max lifetime settings.
+.. _session-native-handlers:
+
+Setting the ``handler_id`` config option to ``null`` (and leaving ``save_path``
+unset) means that Symfony will use the native PHP session mechanism. The
+``session.handler`` service is then a
+:class:`Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\StrictSessionHandler`
+wrapping PHP's own :phpclass:`SessionHandler`, which delegates to the handler
+selected by the ``session.save_handler`` php.ini directive. By default, this is
+the ``files`` handler: the session files are stored outside of the Symfony
+application, in a directory controlled by PHP. Although this usually simplifies
+things, some session expiration related options may not work as expected if
+other applications that write to the same directory have short max lifetime
+settings.
+
+This is also how you can use any other session handler provided by PHP or by
+one of its extensions (``redis`` and ``rediscluster`` from the phpredis
+extension, ``memcached``, etc.) without writing any code: keep
+``handler_id: null`` in Symfony and configure the handler through its own
+php.ini directives (``session.save_handler``, ``session.save_path`` and the
+handler specific settings, such as ``redis.session.*``). Unlike the handlers
+provided by Symfony (``RedisSessionHandler``, ``PdoSessionHandler``, etc.),
+these native handlers implement session locking, which prevents race conditions
+when several requests of the same user write to the session concurrently. See
+:ref:`session-database` for an example with Redis.
 
 If you prefer, you can use the ``session.handler.native_file`` service as
 ``handler_id`` to let Symfony manage the sessions itself. Another useful option
@@ -542,8 +560,10 @@ installed and configured the `phpredis extension`_.
 You have two different options to use Redis to store sessions:
 
 The first option is to configure the Redis session handler directly in the
-server ``php.ini`` file. This approach uses PHP's native session locking,
-which prevents race conditions when multiple requests access the same session:
+server ``php.ini`` file, keeping ``handler_id: null`` in Symfony (see
+:ref:`session-native-handlers`). This approach uses PHP's native session
+locking, which prevents race conditions when multiple requests access the same
+session:
 
 .. code-block:: ini
 


### PR DESCRIPTION
Fix #22627

Documents what @nicolas-grekas explained in symfony/symfony#48588 (comment): the native PHP session handlers are already usable with Symfony, no code needed.

- The "`handler_id: null`" paragraph of `session.rst` now explains what happens under the hood (`session.handler` is a `StrictSessionHandler` wrapping PHP's `SessionHandler`, which delegates to the `session.save_handler` directive), that this is the way to use any handler provided by PHP or an extension (`redis`, `rediscluster`, `memcached`, ...) through their own php.ini directives, and that these native handlers implement session locking, unlike the handlers shipped by Symfony. It gets a `session-native-handlers` anchor.
- The "first option" of the Redis section links to that anchor and mentions keeping `handler_id: null`.

The wiring was checked against `FrameworkExtension::registerSessionConfiguration()` and `Resources/config/session.php` on 6.4 and 8.2 (identical), hence the 6.4 base.

DOCtor-RST and the docs build pass locally.
