### PR TITLE
[FrameworkBundle][HttpKernel] Document the profiler excluded_paths and excluded_http_codes options

### DIFF
--- a/profiler.rst
+++ b/profiler.rst
@@ -223,6 +223,74 @@ In addition to the query parameter, this feature also works when submitting a
 form field with that name (useful to enable the profiler in ``POST`` requests)
 or when including it as a request attribute.
 
+.. _profiler-excluded-requests:
+
+Excluding Requests from the Profiler
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``excluded_paths`` and ``excluded_http_codes`` options were introduced
+    in Symfony 8.2.
+
+Some requests only add noise to the profiler: health checks, monitoring probes,
+``favicon.ico`` requests or the ``/.well-known/`` URLs polled by browser
+developer tools. Use the ``excluded_paths`` and ``excluded_http_codes`` options
+to skip them (nothing is excluded by default):
+
+.. code-block:: yaml
+
+    # config/packages/web_profiler.yaml
+    when@dev:
+        framework:
+            profiler:
+                # regular expressions matched against the path of the request
+                excluded_paths:
+                    - '^/\.well-known/'
+                    - '^/favicon\.ico$'
+                # HTTP status codes of the responses to skip, optionally
+                # restricted to some paths
+                excluded_http_codes:
+                    404: ~                     # every 404 response
+                    400: ['^/foo', '^/bar']    # only under these paths
+                    405: '^/api'               # a single path, as a string
+
+.. code-block:: php
+
+    // config/packages/web_profiler.php
+    namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+    return App::config([
+        'when@dev' => [
+            'framework' => [
+                'profiler' => [
+                    // regular expressions matched against the request path
+                    'excluded_paths' => [
+                        '^/\.well-known/',
+                        '^/favicon\.ico$',
+                    ],
+                    // HTTP status codes of the responses to skip, optionally
+                    // restricted to some paths
+                    'excluded_http_codes' => [
+                        404 => null,                 // every 404 response
+                        400 => ['^/foo', '^/bar'],   // only under these paths
+                        405 => '^/api',              // a single path string
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+The regular expressions are matched against the URL-decoded path info of the
+request (e.g. ``/blog/my-post``, without the query string). They are
+case-sensitive and must not include delimiters. Invalid expressions are
+rejected when the container is compiled.
+
+An excluded request is skipped entirely by the profiler, so it can't be
+profiled on demand with the ``collect_parameter`` option either. Excluding a
+main request doesn't exclude its :ref:`sub-requests <http-kernel-sub-requests>`:
+each one is matched against its own path info.
+
 Updating the Web Debug Toolbar After AJAX Requests
 --------------------------------------------------
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3229,6 +3229,90 @@ and ``test`` environments.
     the :doc:`WebProfilerBundle configuration </reference/configuration/web_profiler>`
     on how to disable/enable the toolbar.
 
+excluded_http_codes
+...................
+
+**type**: ``array`` **default**: ``[]``
+
+A map of HTTP status codes whose responses are not profiled. Each code can be
+restricted to some requests with a list of regular expressions matched against
+the URL-decoded path info of the request (``null`` or an empty list excludes
+every response with that status code):
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/framework.yaml
+        framework:
+            profiler:
+                excluded_http_codes:
+                    404: ~
+                    400: ['^/foo', '^/bar']
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'profiler' => [
+                    'excluded_http_codes' => [
+                        404 => null,
+                        400 => ['^/foo', '^/bar'],
+                    ],
+                ],
+            ],
+        ]);
+
+.. versionadded:: 8.2
+
+    The ``excluded_http_codes`` option was introduced in Symfony 8.2.
+
+excluded_paths
+..............
+
+**type**: ``array`` **default**: ``[]``
+
+A list of regular expressions matched against the URL-decoded path info of the
+requests. Matching requests are not profiled. The expressions are
+case-sensitive and must not include delimiters:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/framework.yaml
+        framework:
+            profiler:
+                excluded_paths:
+                    - '^/\.well-known/'
+                    - '^/favicon\.ico$'
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'profiler' => [
+                    'excluded_paths' => [
+                        '^/\.well-known/',
+                        '^/favicon\.ico$',
+                    ],
+                ],
+            ],
+        ]);
+
+.. versionadded:: 8.2
+
+    The ``excluded_paths`` option was introduced in Symfony 8.2.
+
+See :ref:`how to exclude requests from the profiler
+<profiler-excluded-requests>` for more details.
+
 only_exceptions
 ...............
 


### PR DESCRIPTION
Fix #22801

Documents the `excluded_paths` and `excluded_http_codes` profiler options added in symfony/symfony#65427:

- `profiler.rst`: a new "Excluding Requests from the Profiler" section next to the existing "Enabling the Profiler Conditionally" one, with YAML and PHP examples, the matching rules (regular expressions against the URL-decoded path info, case-sensitive, no delimiters, validated at compile time) and the two behaviors worth knowing (an excluded request cannot be profiled on demand with `collect_parameter`, sub-requests are matched on their own path info).
- `reference/configuration/framework.rst`: both options added to the `profiler` section in alphabetical order, each with its `versionadded` note and a link to the new section.

DOCtor-RST and the docs build pass locally.
