### PR TITLE
[FrameworkBundle][Mailer] Document the TrackingHeader and the mailer.tracking option

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -1917,6 +1917,124 @@ The following transports only support metadata:
 * Amazon SES (note that Amazon refers to this feature as "tags", but Symfony
   calls it "metadata" because it contains a key and a value)
 
+.. _mailer-tracking:
+
+Controlling Open and Click Tracking
+-----------------------------------
+
+.. versionadded:: 8.2
+
+    The ``TrackingHeader`` class and the ``framework.mailer.tracking`` option
+    were introduced in Symfony 8.2.
+
+Most third-party providers can track when an email is opened and when its links
+are clicked. This is usually a global setting of the provider account, but
+privacy regulations may require to let each user refuse it. The
+:class:`Symfony\\Component\\Mailer\\Header\\TrackingHeader` class controls
+both kinds of tracking per message, in a provider-agnostic way::
+
+    use Symfony\Component\Mailer\Header\TrackingHeader;
+
+    // disables both open and click tracking for this email
+    $email->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
+
+    // enables click tracking and keeps the provider default for opens
+    $email->getHeaders()->add(new TrackingHeader(clicks: true));
+
+Both flags are nullable and default to ``null``, which keeps the default of the
+provider (or of your account) for that kind of tracking. The transports listed
+below convert the header into the native mechanism of their provider. Any
+provider-specific header or setting that you set explicitly on the message
+always wins over this generic header. On all other transports, the header is
+sent as a regular ``X-Track`` header and has no effect:
+
+.. code-block:: text
+
+    X-Track: opens=false; clicks=false
+
+Setting a Default for All Emails
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When tracking depends on the consent of the users, the safest default is to
+disable it for every email, and to opt in per message. Use the
+``framework.mailer.tracking`` option to define that default:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/mailer.yaml
+        framework:
+            mailer:
+                tracking:
+                    opens: false
+                    clicks: false
+
+    .. code-block:: php
+
+        // config/packages/mailer.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'tracking' => [
+                        'opens' => false,
+                        'clicks' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+This option only applies to the emails that don't define their own ``X-Track``
+header. From the strongest to the weakest, the effective setting comes from: the
+``TrackingHeader`` added to the message itself, then an ``X-Track`` entry in the
+``framework.mailer.headers`` option (see
+:ref:`mailer-configure-email-globally`), then the ``tracking`` option, and
+finally the default of the provider.
+
+When using the Mailer component without the framework, register a
+:class:`Symfony\\Component\\Mailer\\EventListener\\MessageListener` with an
+``X-Track`` header to get the same default::
+
+    use Symfony\Component\Mailer\EventListener\MessageListener;
+    use Symfony\Component\Mime\Header\Headers;
+
+    $headers = new Headers()
+        ->addTextHeader('X-Track', 'opens=false; clicks=false');
+    $dispatcher->addSubscriber(new MessageListener($headers));
+
+Supported Transports
+~~~~~~~~~~~~~~~~~~~~
+
+=============  ===  ====
+Transport      API  SMTP
+=============  ===  ====
+AhaSend        yes  yes
+Azure          yes  n/a
+Brevo          yes  no
+Infobip        yes  yes
+Mailchimp      yes  yes
+MailerSend     yes  no
+Mailgun        yes  yes
+Mailjet        yes  yes
+Postmark       yes  yes
+Sendgrid       yes  yes
+=============  ===  ====
+
+Some providers have specific behaviors:
+
+* **Azure** only has a single toggle: setting either flag to ``false``
+  disables both kinds of tracking;
+* **Brevo** exposes a per-recipient consent flag, so disabling tracking
+  anonymizes the events instead of disabling them;
+* **Mailchimp** (Mandrill) over SMTP expects the list of tracking aspects to
+  enable, so a ``null`` flag is disabled when the other one is set explicitly.
+
+Other providers don't support per-message tracking settings: Resend and
+Mailtrap configure tracking per domain, Amazon SES through configuration sets
+(the ``X-SES-CONFIGURATION-SET`` header) and MailPace doesn't track emails.
+
 Draft Emails
 ------------
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -2702,6 +2702,51 @@ message_bus
 Service identifier of the message bus to use when using the
 :doc:`Messenger component </messenger>` (e.g. ``messenger.default_bus``).
 
+tracking
+........
+
+**type**: ``array``
+
+The default open (``opens`` key) and click (``clicks`` key) tracking settings
+for every email that doesn't define its own ``X-Track`` header. Each key accepts
+``true``, ``false`` or ``null`` (the default, which keeps the provider's own
+setting):
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/mailer.yaml
+        framework:
+            mailer:
+                tracking:
+                    opens: false
+                    clicks: false
+
+    .. code-block:: php
+
+        // config/packages/mailer.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'mailer' => [
+                    'tracking' => [
+                        'opens' => false,
+                        'clicks' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+An ``X-Track`` entry in the ``headers`` option takes precedence over this
+option. See :ref:`Controlling Open and Click Tracking <mailer-tracking>` for
+more details and the list of supported transports.
+
+.. versionadded:: 8.2
+
+    The ``tracking`` option was introduced in Symfony 8.2.
+
 transports
 ..........
 


### PR DESCRIPTION
Fix #22807

Documents symfony/symfony#65451, following the "for the documentation" list of the feature PR:

- `mailer.rst`: a new "Controlling Open and Click Tracking" section after "Adding Tags and Metadata to Emails", covering the `TrackingHeader` and its two nullable flags, the `null` semantics, the literal `X-Track` form used on transports without support, the fact that explicit provider headers and settings always win, the `framework.mailer.tracking` application-wide default with its precedence chain (message header, `X-Track` entry in `framework.mailer.headers`, `tracking` option, provider default), the standalone `MessageListener` equivalent, and the transport support matrix with the Azure, Brevo and Mandrill SMTP caveats plus the providers that have no per-message setting.
- `reference/configuration/framework.rst`: the `tracking` option in the `mailer` section, with a link to the new section.

DOCtor-RST and the docs build pass locally.
