### PR TITLE
[FrameworkBundle] Complete the verbose parameter in the BrowserKit assertion signatures

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -1063,11 +1063,11 @@ To use these assertions, your test class must extend
     checking for a specific cookie path or domain).
 ``assertResponseCookieValueSame(string $name, string $expectedValue, string $path = '/', ?string $domain = null, string $message = '')``
     Asserts the given cookie is present and set to the expected value.
-``assertResponseFormatSame(?string $expectedFormat, string $message = '')``
+``assertResponseFormatSame(?string $expectedFormat, string $message = '', ?bool $verbose = null)``
     Asserts the response format returned by the
     :method:`Symfony\\Component\\HttpFoundation\\Response::getFormat` method
     is the same as the expected value.
-``assertResponseIsUnprocessable(string $message = '', bool ?$verbose = null)``
+``assertResponseIsUnprocessable(string $message = '', ?bool $verbose = null)``
     Asserts the response is unprocessable (HTTP status is 422)
 
 When they fail, these assert methods report what was expected and what happened,


### PR DESCRIPTION
The prose was covered by #22828; this keeps only the leftover: `assertResponseFormatSame` was missing its `?bool $verbose` in the documented signature, and `assertResponseIsUnprocessable` had `bool ?$verbose` instead of `?bool $verbose` (both match `BrowserKitAssertionsTrait` on 8.2).
