### PR TITLE
[AssetMapper] Document the minimum_release_age option

### DIFF
--- a/frontend/asset_mapper.rst
+++ b/frontend/asset_mapper.rst
@@ -293,6 +293,68 @@ You can update your third-party packages to their current versions by running:
     $ php bin/console importmap:update bootstrap lodash
     $ php bin/console importmap:outdated bootstrap lodash
 
+.. _importmap-minimum-release-age:
+
+Delaying Updates to Freshly Published Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``minimum_release_age`` option was introduced in Symfony 8.2.
+
+A compromised npm release is usually spotted and unpublished within hours. The
+``minimum_release_age`` option makes ``importmap:update`` ignore versions that
+are more recent than the given age, so your project never picks up a release
+during that window:
+
+.. code-block:: yaml
+
+    # config/packages/asset_mapper.yaml
+    framework:
+        asset_mapper:
+            # in seconds; 0 (the default) disables the check
+            minimum_release_age: 604800
+
+The value is expressed in seconds, like every other duration option of
+FrameworkBundle, so six hours is ``21600``.
+
+When the option is enabled, the newest version that is old enough is pinned,
+provided it is also stable (no prerelease suffix) and not above the version
+published as ``latest`` by the package maintainers. Updates only ever move
+forward: if no eligible version is newer than the installed one, the installed
+version is kept.
+
+``importmap:outdated`` reports the versions being held back in a ``Withheld``
+column, so you can see what the check is keeping out of reach:
+
+.. code-block:: terminal
+
+    $ php bin/console importmap:outdated
+
+     ----------- --------- -------- ----------
+      Package     Current   Latest   Withheld
+     ----------- --------- -------- ----------
+      bootstrap   5.3.1     5.3.2    5.3.3
+     ----------- --------- -------- ----------
+
+A package whose only newer version is withheld is listed too, with ``Latest``
+equal to ``Current``. Such rows don't make the command fail, as there's nothing
+to act upon. The column, and the matching ``withheld`` key of ``--format=json``,
+only appear when the option is enabled.
+
+The check applies to ``importmap:update`` only, so an urgent upgrade never
+requires turning the option off:
+
+.. code-block:: terminal
+
+    $ php bin/console importmap:require bootstrap@latest
+
+.. note::
+
+    Publication dates are only available in the full npm metadata document, so
+    enabling this option makes each update check download it instead of the
+    abbreviated one. For popular packages, that response is significantly larger.
+
 Using Local npm Packages
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -600,6 +600,19 @@ this feature.
 
     The ``importmap_integrity_algorithms`` option was introduced in Symfony 8.2.
 
+minimum_release_age
+...................
+
+**type**: ``integer`` **default**: ``0``
+
+The minimum age, in seconds, that a package version must have before
+``importmap:update`` is allowed to pin it. The default ``0`` disables the check.
+See :ref:`delaying updates to freshly published versions <importmap-minimum-release-age>`.
+
+.. versionadded:: 8.2
+
+    The ``minimum_release_age`` option was introduced in Symfony 8.2.
+
 vendor_dir
 ..........
 


### PR DESCRIPTION
Documents `framework.asset_mapper.minimum_release_age`, added in symfony/symfony#65074.

Covers the option itself in the configuration reference, and a section in the
AssetMapper guide explaining what the check does: which version gets pinned
(newest one that is old enough, stable, and not above `dist-tags.latest`), the
`Withheld` column `importmap:outdated` grows when the option is on, and the fact
that `importmap:require pkg@latest` stays unaffected so an urgent upgrade never
requires turning the option off.

Also notes the trade-off worth knowing before enabling it: publication dates only
exist in the full npm metadata document, so each update check downloads that
instead of the abbreviated one.

Fixes #22723
