### PR TITLE
[FrameworkBundle] Document non-verbose BrowserKit assertions

### DIFF
--- a/testing.rst
+++ b/testing.rst
@@ -1070,13 +1070,24 @@ To use these assertions, your test class must extend
 ``assertResponseIsUnprocessable(string $message = '', bool ?$verbose = null)``
     Asserts the response is unprocessable (HTTP status is 422)
 
-By default, these assert methods provide detailed error messages when they fail.
-You can control the verbosity level using the optional ``verbose`` argument in
-each assert method. To set this verbosity level globally, use the
-``setBrowserKitAssertionsAsVerbose()`` method from the
-:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\BrowserKitAssertionsTrait`::
+When they fail, these assert methods report what was expected and what happened,
+without including the response body. Pass the optional ``verbose`` argument to
+get that body too, which is often what you need to understand a failure::
 
-    BrowserKitAssertionsTrait::setBrowserKitAssertionsAsVerbose(false);
+    $this->assertResponseIsSuccessful(verbose: true);
+
+To get verbose output for an entire test suite instead, call the
+``setBrowserKitAssertionsAsVerbose()`` method from the
+:class:`Symfony\\Bundle\\FrameworkBundle\\Test\\BrowserKitAssertionsTrait`
+(e.g. in your PHPUnit bootstrap file)::
+
+    BrowserKitAssertionsTrait::setBrowserKitAssertionsAsVerbose(true);
+
+.. versionadded:: 8.2
+
+    Response assertions became non-verbose by default in Symfony 8.2. In earlier
+    versions they included the response body and you had to pass ``false`` to
+    ``setBrowserKitAssertionsAsVerbose()`` to leave it out.
 
 Request Assertions
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Updates the response assertions section for symfony/symfony#64222, which flipped
the default verbosity of BrowserKit assertions in 8.2.

The current text is now inverted: it states that these assertions "provide
detailed error messages" by default and shows
`setBrowserKitAssertionsAsVerbose(false)` as the way to control it. Since 8.2 the
default is non-verbose, and `true` is the opt-in.

Rewrites the paragraph accordingly, shows both opt-in paths (`verbose: true` per
assertion, `setBrowserKitAssertionsAsVerbose(true)` for a whole suite) and adds a
`versionadded` directive describing the previous behaviour, as suggested by
@nicolas-grekas in the issue.

Fixes #22643
