### PR TITLE
[Form] Fix `choice_value` typo about placeholder use

### DIFF
--- a/reference/forms/types/options/choice_value.rst.inc
+++ b/reference/forms/types/options/choice_value.rst.inc
@@ -13,7 +13,7 @@ can be cast to strings. Otherwise an incrementing integer is used (starting at `
 
 If you pass a callable, it will receive one argument: the choice itself. When using
 the :doc:`/reference/forms/types/entity`, the argument will be the entity object
-for each choice or ``null`` in a placeholder is used, which you need to handle::
+for each choice or ``null`` if a placeholder is used, which you need to handle::
 
     'choice_value' => function (?MyOptionEntity $entity): string {
         return $entity ? $entity->getId() : '';


### PR DESCRIPTION
> `null` **in** a placeholder is used

corrected to 

> `null` **if** a placeholder is used

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `7.x` for features of unreleased versions).

-->
