### PR TITLE
[Messenger] Fix the documented defaults of the SQS FIFO message IDs

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2196,7 +2196,11 @@ The transport has a number of options:
     Additionally, if your message implements the
     :class:`Symfony\\Component\\Messenger\\Bridge\\AmazonSqs\\MessageGroupAwareInterface`,
     the middleware will automatically set the ``Message group ID`` of the stamp.
-    The default value of this group ID is a hash of the SQS message's headers and body.
+
+    When you don't set these IDs, the transport sends its own defaults: the same
+    ``Message group ID`` for every message, so the queue processes them one at a
+    time, and a ``Message deduplication ID`` built from a hash of the message
+    headers and body, so the queue treats two identical messages as duplicates.
 
     You can learn more about middlewares in
     :ref:`the dedicated section <messenger_middleware>`.


### PR DESCRIPTION
The FIFO section of the SQS transport documentation says:

> The default value of this group ID is a hash of the SQS message's headers and body.

That sentence describes the wrong ID, and it leaves the real defaults undocumented. `Connection::send()` sets both parameters when the queue name ends in `.fifo`:

```php
$parameters['MessageGroupId'] = $messageGroupId ?? __METHOD__;
$parameters['MessageDeduplicationId'] = $messageDeduplicationId ?? sha1(json_encode(['body' => $body, 'headers' => $headers]));
```

So the `Message group ID` defaults to a constant, not to a hash: every message without an explicit group lands in the same group and the queue processes them one at a time. It is the `Message deduplication ID` that defaults to a hash of the headers and body, which is why sending the same message twice delivers it once.

Both defaults matter to anyone using a FIFO queue, so this replaces the sentence with a paragraph covering the two of them. Same code on 6.4, 7.4, 8.1 and 8.2, so this targets the oldest maintained branch.
