### PR TITLE
[Messenger] Document the unique MessageDeduplicationId sent by default on SQS FIFO queues

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2683,8 +2683,16 @@ The transport has a number of options:
 
     When you don't set these IDs, the transport sends its own defaults: the same
     ``Message group ID`` for every message, so the queue processes them one at a
-    time, and a ``Message deduplication ID`` built from a hash of the message
-    headers and body, so the queue treats two identical messages as duplicates.
+    time, and a unique ``Message deduplication ID`` for every message, so the
+    queue delivers every message you send. Set the ``Message deduplication ID``
+    yourself when you want the queue to discard duplicates.
+
+    .. versionadded:: 8.2
+
+        Sending a unique ``Message deduplication ID`` by default was introduced
+        in Symfony 8.2. In previous versions, the transport sent a hash of the
+        message headers and body, so the queue discarded the same message when
+        you sent it twice within the deduplication window.
 
     You can learn more about middlewares in
     :ref:`the dedicated section <messenger_middleware>`.


### PR DESCRIPTION
Documents the new default introduced by symfony/symfony#65605: on a FIFO queue the transport now sends a unique `MessageDeduplicationId` per `send()` call instead of a hash of the message body and headers, so a message dispatched twice is delivered twice.

Depends on symfony/symfony#65605 and should be merged after it.

It also carries the fix from #22830, which corrects the same sentence on 6.4: the `Message group ID` defaults to a constant, not to a hash. Whichever lands first, the other needs a trivial conflict resolution on this paragraph.
