### PR TITLE
[Messenger] Complete the SQS FIFO deduplication note

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2685,7 +2685,10 @@ The transport has a number of options:
     ``Message group ID`` for every message, so the queue processes them one at a
     time, and a unique ``Message deduplication ID`` for every message, so the
     queue delivers every message you send. Set the ``Message deduplication ID``
-    yourself when you want the queue to discard duplicates.
+    yourself, with the stamp or the interface described above, when you want
+    the queue to discard duplicates: the ``ContentBasedDeduplication``
+    attribute of the queue alone is not enough, as the default ID overrides
+    it.
 
     .. versionadded:: 8.2
 


### PR DESCRIPTION
Fix #22836

Reduced to a small completion after 43e780806 documented the new default directly: this adds the pointer to the stamp/interface for setting the ID explicitly, and the caveat that the queue's `ContentBasedDeduplication` attribute alone is not enough since the default ID overrides it (matching the UPGRADE note of symfony/symfony#65605).
