### PR TITLE
[Console] Document dropping multiple files

### DIFF
--- a/components/console/helpers/questionhelper.rst
+++ b/components/console/helpers/questionhelper.rst
@@ -648,6 +648,30 @@ methods:
 * ``isTempFile()``: returns ``true`` if the file was created from pasted data
   (temporary files are cleaned up automatically at shutdown)
 
+Asking for Multiple Files
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``multiple`` option of ``FileQuestion`` was introduced in Symfony 8.2.
+
+Set the ``multiple`` option to ``true`` to collect several files with a single
+question. The answer is then an array of ``InputFile`` instances instead of a
+single one::
+
+    $question = new FileQuestion('Provide images:', multiple: true);
+
+    $files = $helper->ask($input, $output, $question);
+
+    foreach ($files as $file) {
+        $output->writeln($file->getFilename().': '.$file->getHumanReadableSize());
+    }
+
+A single answer can carry several files at once (e.g. by dragging and dropping
+them together or by pasting whitespace separated paths) and the question keeps
+asking for more files until the user submits an empty answer. Validation
+constraints, if any, are applied to each collected file individually.
+
 Testing a Command that Expects Input
 ------------------------------------
 

--- a/console/input.rst
+++ b/console/input.rst
@@ -1082,6 +1082,85 @@ mode, file paths are accepted as regular arguments.
     size), see the ``FileQuestion`` class in the
     :doc:`QuestionHelper documentation </components/console/helpers/questionhelper>`.
 
+Asking for Multiple Files
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    Support for multiple files was introduced in Symfony 8.2.
+
+A command can also accept several files at once. Type-hint the parameter as
+variadic to collect them all::
+
+    use Symfony\Component\Console\Attribute\Argument;
+    use Symfony\Component\Console\Attribute\AsCommand;
+    use Symfony\Component\Console\Attribute\Ask;
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Input\File\InputFile;
+    use Symfony\Component\Console\Style\SymfonyStyle;
+
+    // ...
+
+    #[AsCommand(name: 'app:analyze')]
+    class AnalyzeCommand
+    {
+        public function __invoke(
+            SymfonyStyle $io,
+            #[Argument(description: 'The images to analyze')]
+            #[Ask('Provide images (paste or enter paths):')]
+            InputFile ...$images,
+        ): int {
+            foreach ($images as $image) {
+                $io->writeln($image->getFilename().': '.$image->getHumanReadableSize());
+            }
+
+            return Command::SUCCESS;
+        }
+    }
+
+Interactively, a single drag & drop can carry several files at once, and the
+question keeps asking for more until you submit an empty answer (by hitting
+``Enter``). In non-interactive mode, the files are read from the whitespace
+separated paths passed as regular arguments.
+
+If a variadic parameter doesn't fit (for example because you need other
+parameters after it), use an ``array`` parameter narrowed to ``InputFile`` with
+a PHPDoc. The console reads the item type from the ``@param`` tag to know that a
+list of files is expected::
+
+    /**
+     * @param InputFile[] $images
+     */
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Argument(description: 'The images to analyze')]
+        #[Ask('Provide images (paste or enter paths):')]
+        array $images,
+    ): int {
+        // ...
+    }
+
+The PHPDoc form is also the one to use on the properties of a
+:ref:`#[MapInput] <console-input-map-input>` object, where a variadic can't be
+used::
+
+    use Symfony\Component\Console\Attribute\Argument;
+    use Symfony\Component\Console\Attribute\Ask;
+    use Symfony\Component\Console\Input\File\InputFile;
+
+    final class UploadInput
+    {
+        /**
+         * @var InputFile[]
+         */
+        #[Argument(description: 'The images to analyze')]
+        #[Ask('Provide images (paste or enter paths):')]
+        public array $images;
+    }
+
+The behavior is the same in all cases, and matches
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::askFiles`.
+
 Options with optional arguments
 -------------------------------
 

--- a/console/style.rst
+++ b/console/style.rst
@@ -413,6 +413,20 @@ User Input Methods
 
         The ``askFile()`` method was introduced in Symfony 8.1.
 
+:method:`Symfony\\Component\\Console\\Style\\SymfonyStyle::askFiles`
+    It asks the user to provide one or more files and returns an array of
+    ``InputFile`` instances::
+
+        $files = $io->askFiles('Provide images:');
+
+    A single answer can carry several files at once (e.g. by dragging and
+    dropping them together or by pasting whitespace separated paths) and the
+    question keeps asking for more until the user submits an empty answer.
+
+    .. versionadded:: 8.2
+
+        The ``askFiles()`` method was introduced in Symfony 8.2.
+
 .. _symfony-style-blocks:
 
 Result Methods


### PR DESCRIPTION
Fixes #22838.

Documents the multiple-files support added in symfony/symfony#65616:

* `console/input.rst`: new "Asking for Multiple Files" subsection under *File Input*, covering the three forms — variadic `InputFile ...$files`, `array` narrowed with a `@param InputFile[]` PHPDoc, and the same PHPDoc form on `#[MapInput]` DTO properties (where a variadic can't be used).
* `console/style.rst`: `SymfonyStyle::askFiles()`.
* `components/console/helpers/questionhelper.rst`: the `multiple` option of `FileQuestion`.
