### PR TITLE
[Security] Document the deprecation of access control rules voting on many attributes

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -2361,9 +2361,6 @@ start with ``/admin``, you can:
                     // require ROLE_ADMIN for /admin*
                     ['path' => '^/admin', 'roles' => 'ROLE_ADMIN'],
 
-                    // or require ROLE_ADMIN or IS_AUTHENTICATED_FULLY for /admin*
-                    ['path' => '^/admin', 'roles' => ['IS_AUTHENTICATED_FULLY', 'ROLE_ADMIN']],
-
                     // the 'path' value can be any valid regular expression
                     // (this one will match URLs like /api/post/7298 and /api/comment/528491)
                     ['path' => '^/api/(post|comment)/\d+$', 'roles' => 'ROLE_USER'],

--- a/security/access_control.rst
+++ b/security/access_control.rst
@@ -264,7 +264,9 @@ Securing by an Expression
 
 Once an ``access_control`` entry is matched, you can deny access via the
 ``roles`` key or use more complex logic with an expression in the ``allow_if``
-key:
+key. Use one or the other: a rule holding both is deprecated since Symfony 8.2,
+so a condition on the roles belongs inside the expression, through
+``is_granted()``:
 
 .. configuration-block::
 
@@ -276,10 +278,8 @@ key:
             access_control:
                 -
                     path: ^/_internal/secure
-                    # the 'roles' and 'allow_if' options work like an OR expression, so
-                    # access is granted if the expression is TRUE or the user has ROLE_ADMIN
-                    roles: 'ROLE_ADMIN'
-                    allow_if: "'127.0.0.1' == request.getClientIp() or request.headers.has('X-Secure-Access')"
+                    # access is granted if the expression is TRUE
+                    allow_if: "is_granted('ROLE_ADMIN') or '127.0.0.1' == request.getClientIp() or request.headers.has('X-Secure-Access')"
 
     .. code-block:: php
 
@@ -291,10 +291,8 @@ key:
                 'access_control' => [
                     [
                         'path' => '^/_internal/secure',
-                        // the 'roles' and 'allow_if' options work like an OR expression, so
-                        // access is granted if the expression is TRUE or the user has ROLE_ADMIN
-                        'roles' => 'ROLE_ADMIN',
-                        'allow_if' => '"127.0.0.1" == request.getClientIp() or request.headers.has("X-Secure-Access")',
+                        // access is granted if the expression is TRUE
+                        'allow_if' => 'is_granted("ROLE_ADMIN") or "127.0.0.1" == request.getClientIp() or request.headers.has("X-Secure-Access")',
                     ],
                 ],
             ],


### PR DESCRIPTION
Fix #22618
Fix #22921

symfony/symfony#65056 and symfony/symfony#65827 deprecated two shapes of an `access_control` rule: giving it more than one role, and combining `roles` with `allow_if`. Both make the rule vote on several attributes at once, which the default `affirmative` strategy grants on the first one that passes, while the configuration reads as an `AND` to most people. Since #65827, such a rule also triggers a deprecation on every matched request.

This is scoped to what #22624 by @MatTheCat does not cover, as agreed with @MrYamous above. It should go in first.

- The "Securing by an Expression" section had `roles` and `allow_if` side by side in the same rule, with a comment explaining they behave like an `OR`, which is exactly the shape the notices added by #22624 declare deprecated. The example now carries the role check inside the expression through `is_granted()`.
- `security.rst` showed the same deprecated shape as a list of roles, in **both** halves of its configuration block. #22624 removes the YAML one and leaves the PHP one, so that block would end up out of sync; this removes the PHP one.

Nothing else to change for #22921: `$allowMultipleAttributes` is not documented anywhere, and the three `AccessDecisionManager::decide()` examples in the docs (`security/voters.rst`, and `security/impersonating_user.rst` twice) all pass a single attribute, so none of them deprecates.

DOCtor-RST is clean.
