### PR TITLE
 Enable the no_standalone_syntax_element DOCtor-RST rule

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -65,6 +65,7 @@ rules:
     no_php_open_tag_in_code_block_php_directive: ~
     no_relative_doc_path: ~
     no_space_before_self_xml_closing_tag: ~
+    no_standalone_syntax_element: ~
     no_typographic_quotes: ~
     non_static_phpunit_assertions: ~
     only_backslashes_in_namespace_in_php_code_block: ~

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
                     key: ${{ runner.os }}-doctor-rst-${{ steps.extract_base_branch.outputs.branch }}
 
             -   name: "Run DOCtor-RST"
-                uses: docker://oskarstark/doctor-rst:1.78.0
+                uses: docker://oskarstark/doctor-rst:1.83.0
                 with:
                     args: --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache
 

--- a/components/phpunit_bridge.rst
+++ b/components/phpunit_bridge.rst
@@ -908,7 +908,7 @@ You can either:
             </listener>
     </listeners>
 
-::
+Or register the namespaces in the bootstrap file::
 
     // config/bootstrap.php
     use Symfony\Bridge\PhpUnit\ClockMock;

--- a/components/string.rst
+++ b/components/string.rst
@@ -166,7 +166,8 @@ There is also a method to get the bytes stored at some position::
 Methods Related to Length and Whitespace Characters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+These methods measure the contents of the string and deal with its whitespace
+characters::
 
     // returns the number of graphemes, code points or bytes of the given string
     $word = 'नमस्ते';
@@ -200,7 +201,8 @@ Methods Related to Length and Whitespace Characters
 Methods to Change Case
 ~~~~~~~~~~~~~~~~~~~~~~
 
-::
+These methods return a copy of the string with its contents converted to
+another case::
 
     // changes all graphemes/code points to lower case
     u('FOO Bar')->lower();  // 'foo bar'
@@ -235,7 +237,8 @@ case-insensitive operations with the ``ignoreCase()`` method::
 Methods to Append and Prepend
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+These methods add contents at the beginning or the end of the string and
+extract the contents found before or after a given string::
 
     // adds the given content (one or more strings) at the beginning/end of the string
     u('world')->prepend('hello');      // 'helloworld'
@@ -273,7 +276,8 @@ Methods to Append and Prepend
 Methods to Pad and Trim
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+These methods change the length of the string by padding, repeating or
+trimming its contents::
 
     // makes a string as long as the first argument by adding the given
     // string at the beginning, end or both sides of the string
@@ -306,7 +310,7 @@ Methods to Pad and Trim
 Methods to Search and Replace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+These methods look for some contents inside the string and replace them::
 
     // checks if the string starts/ends with the given string
     u('https://symfony.com')->startsWith('https'); // true
@@ -359,7 +363,7 @@ Methods to Search and Replace
 Methods to Join, Split, Truncate and Reverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+These methods merge, break, shorten and reverse the contents of the string::
 
     // uses the string as the "glue" to merge all the given strings
     u(', ')->join(['foo', 'bar']); // 'foo, bar'
@@ -385,8 +389,6 @@ Methods to Join, Split, Truncate and Reverse
     // if the third argument is false, the last word before the cut is kept
     // even if that generates a string longer than the desired length
     u('Lorem Ipsum')->truncate(8, '…', cut: false); // 'Lorem Ipsum'
-
-::
 
     // breaks the string into lines of the given length
     u('Lorem Ipsum')->wordwrap(4);                  // 'Lorem\nIpsum'

--- a/webhook.rst
+++ b/webhook.rst
@@ -217,7 +217,7 @@ you need to implement two methods:
 * :method:`Symfony\\Component\\Webhook\\Client\\AbstractRequestParser::doParse`
   to verify the webhook and parse it into a RemoteEvent.
 
-::
+The resulting parser looks like this::
 
     // src/Webhook/AcmeWebhookRequestParser.php
     namespace App\Webhook;


### PR DESCRIPTION
A `::` alone on a line opens a literal block without saying what it holds, which is what the review on #22480 asked to catch. The rule landed in DOCtor-RST as `no_standalone_syntax_element` (OskarStark/doctor-rst#2372), so this enables it and moves the CI to the release that ships it.

Nine places were doing it, all introducing PHP, and none of them needs an explicit `.. code-block:: php`:

- six of them open a section in `components/string.rst`, and get a short sentence saying what the example shows, ending with `::`;
- the seventh, in the same file, was two consecutive literal blocks inside a single section (`truncate` then `wordwrap`) with nothing in between, so they are merged into one block;
- the two others, in `webhook.rst` and `components/phpunit_bridge.rst`, follow a bullet list and get an introducing sentence as well.

Targeted at 6.4 so it merges up. DOCtor-RST 1.83.0 is green on the whole tree with the rule on.

/cc @OskarStark @MrYamous
