### PR TITLE
 Fix PHP preloading link

### DIFF
--- a/performance.rst
+++ b/performance.rst
@@ -394,4 +394,4 @@ Learn more
 .. _`full-featured demo`: https://demo.blackfire.io?utm_source=symfony&utm_medium=symfonycom_docs&utm_campaign=performance
 .. _`Stopwatch component`: https://symfony.com/components/Stopwatch
 .. _`real-world stopwatch`: https://en.wikipedia.org/wiki/Stopwatch
-.. _`class preloading`: https://php.net/opcache.preloading.php
+.. _`class preloading`: https://www.php.net/manual/en/opcache.preloading.php


### PR DESCRIPTION
The shortened PHP manual URL redirects to a failed lookup and returns a 404 response.

This replaces it with the canonical PHP manual URL for preloading.