### PR TITLE
[Mailer] Document the MailKite bridge

### DIFF
--- a/mailer.rst
+++ b/mailer.rst
@@ -98,6 +98,7 @@ Service               Install with                                        Webhoo
 `Infobip`_            ``composer require symfony/infobip-mailer``
 `Mailgun`_            ``composer require symfony/mailgun-mailer``         yes
 `Mailjet`_            ``composer require symfony/mailjet-mailer``         yes
+`MailKite`_           ``composer require symfony/mail-kite-mailer``
 `Mailomat`_           ``composer require symfony/mailomat-mailer``        yes
 `MailPace`_           ``composer require symfony/mail-pace-mailer``
 `MailerSend`_         ``composer require symfony/mailer-send-mailer``     yes
@@ -115,7 +116,7 @@ Service               Install with                                        Webhoo
 
 .. versionadded:: 8.2
 
-    The ``TurboSMTP`` and ``Cloudflare`` integrations were introduced in Symfony 8.2.
+    The ``MailKite``, ``TurboSMTP`` and ``Cloudflare`` integrations were introduced in Symfony 8.2.
     Webhook support for ``Scaleway`` was also introduced in Symfony 8.2.
 
 .. note::
@@ -210,6 +211,10 @@ party provider:
 | `Mailjet`_             | - SMTP ``mailjet+smtp://ACCESS_KEY:SECRET_KEY@default``                                   |
 |                        | - HTTP n/a                                                                                |
 |                        | - API ``mailjet+api://ACCESS_KEY:SECRET_KEY@default``                                     |
++------------------------+-------------------------------------------------------------------------------------------+
+| `MailKite`_            | - SMTP ``mailkite+smtp://KEY@default``                                                    |
+|                        | - HTTP n/a                                                                                |
+|                        | - API ``mailkite+api://KEY@default``                                                      |
 +------------------------+-------------------------------------------------------------------------------------------+
 | `Mailomat`_            | - SMTP ``mailomat+smtp://USERNAME:PASSWORD@default``                                      |
 |                        | - HTTP n/a                                                                                |
@@ -335,6 +340,14 @@ party provider:
     the non-EU endpoints (``pro.turbo-smtp.com`` for SMTP and
     ``api.turbo-smtp.com`` for the API). To use the EU endpoints, set the host
     explicitly, such as ``turbosmtp+api://KEY:SECRET@api.eu.turbo-smtp.com``.
+
+.. note::
+
+    ``mailkite`` is an alias for ``mailkite+smtp``. The SMTP transport
+    authenticates on the API key alone: the username is a fixed placeholder
+    (``mailkite``) and is not checked, so the DSN is simply
+    ``mailkite+smtp://KEY@default``. Use ``mailkite+smtps`` for implicit TLS
+    on port 465.
 
 .. tip::
 
@@ -2338,6 +2351,7 @@ the :class:`Symfony\\Bundle\\FrameworkBundle\\Test\\MailerAssertionsTrait`::
 .. _`Mandrill`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Mailchimp/README.md
 .. _`Mailgun`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Mailgun/README.md
 .. _`Mailjet`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Mailjet/README.md
+.. _`MailKite`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/MailKite/README.md
 .. _`Markdown syntax`: https://commonmark.org/
 .. _`Mailomat`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/Mailomat/README.md
 .. _`MailPace`: https://github.com/symfony/symfony/blob/{version}/src/Symfony/Component/Mailer/Bridge/MailPace/README.md


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | —
| License       | MIT

Documents the new MailKite Mailer bridge added in
`symfony/symfony#65672 <https://github.com/symfony/symfony/pull/65672>`_.

Adds the service-table row, the DSN table entry (`mailkite+smtp` / `mailkite` alias /
`mailkite+smtps` / `mailkite+api`), a note on the `mailkite` alias and SMTP auth, the
8.2 `versionadded` mention, and the bottom link target.
