### PR TITLE
[FrameworkBundle][HttpKernel] Document the cache_status option

### DIFF
--- a/http_cache.rst
+++ b/http_cache.rst
@@ -121,6 +121,82 @@ cache efficiency of your routes.
     You can change the name of the header used for the trace
     information using the ``trace_header`` config option.
 
+.. _http-cache-status:
+
+Reporting the Cache Status
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``cache_status`` option was introduced in Symfony 8.2.
+
+The traces above are meant for development. In production, the reverse proxy can
+report how it handled the request in the standard `RFC 9211`_ ``Cache-Status``
+response header, which is understood by other caches and by monitoring tools.
+Set the :ref:`cache_status <reference-http-cache-cache-status>` option to the
+name identifying this cache:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/framework.yaml
+        framework:
+            http_cache:
+                cache_status: 'Symfony'
+
+    .. code-block:: php
+
+        // config/packages/framework.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        return App::config([
+            'framework' => [
+                'http_cache' => [
+                    'cache_status' => 'Symfony',
+                ],
+            ],
+        ]);
+
+Responses then carry a header such as ``Cache-Status: Symfony; hit; ttl=58``.
+The name can be anything identifying the cache: a product name, a hostname or a
+generated string. The option is ``null`` by default and no header is emitted
+then.
+
+The status reported for the main request is one of the following:
+
+===================  =========================================================
+Reported as          When
+===================  =========================================================
+``hit``              the response was served from the cache
+``fwd=method``       the request method is not cacheable
+``fwd=bypass``       the cache was bypassed
+``fwd=request``      the client forced a reload
+``fwd=stale``        a stored response was revalidated, invalidated or served
+                     stale because the backend failed
+``fwd=miss``         nothing matching was stored
+===================  =========================================================
+
+A ``hit`` carries a ``ttl`` parameter: the remaining freshness lifetime of the
+served response, in seconds. It is negative when a stale response is served, as
+the RFC uses that to signal staleness, so ``ttl=-12`` and ``ttl=0`` do not mean
+the same thing.
+
+A forward carries ``stored`` when the response coming back was stored, and
+``fwd-status`` when the backend answered with a different status than the one
+sent to the client. A successful revalidation therefore reports
+``Cache-Status: Symfony; fwd=stale; fwd-status=304; stored``.
+
+As the RFC requires, the member is appended to any ``Cache-Status`` header
+received from the backend instead of replacing it, so in a chain of caches each
+one adds its own member and the reader sees the origin first.
+
+.. warning::
+
+    This option is disabled by default because it changes the responses of an
+    existing application, and because section 6 of `RFC 9211`_ notes that
+    exposing the behavior of a cache helps an attacker probe it.
+
 .. _http-cache-symfony-versus-varnish:
 
 .. sidebar:: Changing from one Reverse Proxy to another
@@ -387,3 +463,4 @@ Learn more
 .. _`RFC 7232 - Conditional Requests`: https://tools.ietf.org/html/rfc7232
 .. _`FOSHttpCacheBundle`: https://foshttpcachebundle.readthedocs.org/
 .. _`they can be cached`: https://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-20#section-2.3.4
+.. _`RFC 9211`: https://www.rfc-editor.org/rfc/rfc9211.html

--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -1586,6 +1586,22 @@ Specifies whether the client can force a cache revalidate by including a
 Cache-Control "max-age=0" directive in the request. Set it to ``true``
 for compliance with RFC 2616.
 
+.. _reference-http-cache-cache-status:
+
+cache_status
+............
+
+**type**: ``string`` **default**: ``null``
+
+.. versionadded:: 8.2
+
+    The ``cache_status`` option was introduced in Symfony 8.2.
+
+Enables the `RFC 9211`_ ``Cache-Status`` response header and names this cache
+in it. No header is added when this option is ``null``. Read
+:ref:`Reporting the cache status <http-cache-status>` for the details of what
+the header reports.
+
 debug
 .....
 
@@ -5435,3 +5451,4 @@ to know their differences.
 .. _`shared cache`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#shared_cache
 .. _`private cache`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#private_caches
 .. _`W3C Sanitizer API standard`: https://wicg.github.io/sanitizer-api/#default-configuration
+.. _`RFC 9211`: https://www.rfc-editor.org/rfc/rfc9211.html


### PR DESCRIPTION
Fix #22853.

Documents the `framework.http_cache.cache_status` option added in symfony/symfony#65573.

Two places, following how `trace_level` and `trace_header` are already split:

- a new "Reporting the Cache Status" section in `http_cache.rst`, right after the traces, since it is the production counterpart of a development tool;
- the option itself in the `http_cache` configuration reference, alphabetically between `allow_revalidate` and `debug`.

The section carries the four things a reader cannot guess from the option name:

- the mapping from what the cache did to what the header says, as a table, so a `Cache-Status` line can be read without opening the RFC;
- `ttl` is negative when a stale response is served, so `ttl=-12` and `ttl=0` do not mean the same thing;
- the member is appended to any header received from the backend rather than replacing it, which is what makes a chain of caches readable;
- why the option is off by default, including the note from section 6 of the RFC about exposing cache behavior to an attacker.

DOCtor-RST is green and the docs build cleanly, with both new cross-references resolving in the rendered output.
