### PR TITLE
[Security] Document that login links need trusted_hosts configured

### DIFF
--- a/security/login_link.rst
+++ b/security/login_link.rst
@@ -202,6 +202,19 @@ link is created using
     Or use the :doc:`notifier </notifier>` component to send an SMS to the
     user's device.
 
+.. warning::
+
+    The login link is an absolute URL, so its host comes from the incoming
+    request unless you tell the application which hosts it may answer to.
+    An attacker who requests a login link with a forged ``Host`` header makes
+    the application send the victim a link that points at the attacker's host.
+    Following that link hands the attacker a valid login link for the victim.
+
+    Configure :ref:`trusted_hosts <configuration-framework-trusted-hosts>` to
+    close this. Setting ``framework.router.default_uri`` is not enough: it only
+    applies when a link is generated outside a request, such as from a command,
+    and the incoming request overrides it for every web request.
+
 3) Send the Login Link to the User
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
`LoginLinkHandler::createLoginLink()` generates an `ABSOLUTE_URL`, so the host of the emailed link comes from the incoming request unless `trusted_hosts` is configured. A request carrying a forged `Host` header therefore produces a link pointing at that host, and the user who follows it hands over a working login link.

The `trusted_hosts` reference already covers the general shape of these attacks and even mentions password reset emails, but nothing in the login link guide points there, which is where someone building a "send me a login link" flow is reading.

The note also rules out `framework.router.default_uri`, because it looks like the fix and is not: it sets the `router.request_context.base_url` parameter, which only applies outside a request, and `RouterListener` seeds the routing context from the request on every web request. The same holds for the older `router.request_context.host` parameter, which is deprecated since 8.1 in favour of `default_uri`, so naming `default_uri` here keeps the note accurate on every branch it merges up into.
