### PR TITLE
[PropertyInfo][Serializer] Use the constructor extractor when building a PropertyInfoExtractor

### DIFF
--- a/components/property_info.rst
+++ b/components/property_info.rst
@@ -546,6 +546,13 @@ on the constructor arguments::
     $constructorExtractor = new ConstructorExtractor([new ReflectionExtractor()]);
     $constructorExtractor->getTypes(Foo::class, 'bar')[0]->getBuiltinType(); // returns 'string'
 
+When you combine extractors inside a
+:class:`Symfony\\Component\\PropertyInfo\\PropertyInfoExtractor`, put the
+``ConstructorExtractor`` before the other type extractors. Otherwise the
+property docblock also answers for constructor arguments, which changes the
+result whenever the ``@param`` and the ``@var`` of a class declare different
+types.
+
 .. _`components-property-information-extractors-creation`:
 
 Creating Your Own Extractors

--- a/serializer.rst
+++ b/serializer.rst
@@ -1364,6 +1364,7 @@ normalizers (in order of priority):
 
         .. code-block:: php-standalone
 
+            use Symfony\Component\PropertyInfo\Extractor\ConstructorExtractor;
             use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
             use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
             use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
@@ -1374,10 +1375,21 @@ normalizers (in order of priority):
             use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
             use Symfony\Component\Serializer\Serializer;
 
-            $propertyInfo = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+            $phpDocExtractor = new PhpDocExtractor();
+            $reflectionExtractor = new ReflectionExtractor();
+            $propertyInfo = new PropertyInfoExtractor([], [
+                new ConstructorExtractor([$phpDocExtractor, $reflectionExtractor]),
+                $phpDocExtractor,
+                $reflectionExtractor,
+            ]);
             $normalizers = [new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()), null, null, $propertyInfo), new ArrayDenormalizer()];
 
             $this->serializer = new Serializer($normalizers, [new JsonEncoder()]);
+
+    The :class:`Symfony\\Component\\PropertyInfo\\Extractor\\ConstructorExtractor`
+    comes first, so a constructor argument takes its type from the constructor
+    docblock. Without it, the property docblock wins for that argument too, even
+    when the ``@param`` and the ``@var`` of a class declare different types.
 
 :class:`Symfony\\Component\\Serializer\\Normalizer\\ObjectNormalizer`
     This is the most powerful default normalizer and used for any object


### PR DESCRIPTION
The standalone example that builds a `PropertyInfoExtractor` for the Serializer leaves out the `ConstructorExtractor`, so it does not behave like a full stack application, where FrameworkBundle registers that extractor ahead of the others.

Without it, a constructor argument takes its type from the doc block of the property rather than from the one of the constructor, and the two differ whenever a class documents them separately:

```php
class Foo
{
    /** @var array<int> */
    public readonly array $values;

    /** @param array<int|string> $values */
    public function __construct(array $values)
    {
        $this->values = array_map(intval(...), $values);
    }
}
```

This adds the extractor to the example, with the same composition FrameworkBundle uses, and a short note on why it comes first. It also records the ordering rule in the `ConstructorExtractor` section of the PropertyInfo component page.

Reported in symfony/symfony#65661.
