### PR TITLE
[Webhook] Document that the routing secret must be set in production

### DIFF
--- a/reference/configuration/framework.rst
+++ b/reference/configuration/framework.rst
@@ -3954,8 +3954,15 @@ secret
 
 **type**: ``string`` **default**: ``''``
 
-The secret used to verify the webhook signature. The value depends on the
-third-party service sending the webhook.
+The value used to authenticate incoming webhook requests. What it holds
+depends on the third-party service: the signing key it gives you, or the HTTP
+Basic credentials configured on the webhook URL.
+
+Always set it in production. Parsers for services that sign their requests
+reject an empty value and throw. The others cannot do that: a service that
+does not sign, or that makes signing optional, leaves its parser with nothing
+to check, and the endpoint then accepts requests from any sender without
+warning.
 
 workflows
 ~~~~~~~~~

--- a/webhook.rst
+++ b/webhook.rst
@@ -88,7 +88,7 @@ controller uses a routing mechanism to map incoming requests to the appropriate 
                 routing:
                     acme_webhook:  # routing name, maps to /webhook/acme_webhook
                         service: App\Webhook\AcmeWebhookRequestParser
-                        secret: '%env(WEBHOOK_SECRET)%'  # optional
+                        secret: '%env(WEBHOOK_SECRET)%'
 
     .. code-block:: xml
 
@@ -125,6 +125,19 @@ controller uses a routing mechanism to map incoming requests to the appropriate 
 The routing name becomes part of the webhook URL (e.g.,
 ``https://example.com/webhook/acme_webhook``). Each routing name must be
 unique as it connects the webhook source to your consumer code.
+
+.. warning::
+
+    Always set ``secret`` in production. Parsers for services that sign their
+    requests reject an empty value and throw, so a missing secret fails
+    loudly. The others cannot do that: a service that does not sign, or that
+    makes signing optional, leaves its parser with nothing to check, and the
+    endpoint then accepts requests from any sender without warning. What the
+    value holds depends on the service, either the signing key it gives you
+    or the HTTP Basic credentials you set on the webhook URL in its
+    dashboard. Store it using the
+    :doc:`secrets management system </configuration/secrets>` or a ``.env``
+    file.
 
 All parsers are automatically injected into the WebhookController.
 


### PR DESCRIPTION
The `secret` of `framework.webhook.routing.*` defaults to an empty string, and the example in `webhook.rst` labelled it `# optional`. An empty secret raises no error, so nothing signals the problem at runtime.

What actually happens with an empty secret depends on the parser. Nine of them (Brevo, Mailjet, Postmark, Mailtrap, MailerSend, Sendgrid, Sweego, Twilio, Lox24) gate the whole verification on a non-empty secret and skip it. Three others (AhaSend, Mailchimp, Sweego for Notifier) verify with an empty HMAC key, which anyone can reproduce. Five fail closed and throw.

Keeping the empty default is fine, it is what makes local development work without credentials, but then the documentation is the only thing standing between a user and an endpoint that accepts forged requests. This drops the `# optional` comment and says so in the two places the option is documented.