### PR TITLE
[Cache] Mention the marshaller argument in all cache adapters

### DIFF
--- a/components/cache.rst
+++ b/components/cache.rst
@@ -190,6 +190,8 @@ Now you can create, retrieve, update and delete items using this cache pool::
 
 For a list of all of the supported adapters, see :doc:`/components/cache/cache_pools`.
 
+.. _cache-component-marshalling:
+
 Marshalling (Serializing) Data
 ------------------------------
 

--- a/components/cache/adapters/apcu_adapter.rst
+++ b/components/cache/adapters/apcu_adapter.rst
@@ -11,7 +11,8 @@ memory, a component appreciably faster than many others, such as the filesystem.
     this adapter.
 
 The ApcuAdapter can optionally be provided a namespace, default cache lifetime,
-and cache items version string as constructor arguments::
+cache items version string and :ref:`marshaller <cache-component-marshalling>`
+as constructor arguments::
 
     use Symfony\Component\Cache\Adapter\ApcuAdapter;
 
@@ -27,7 +28,10 @@ and cache items version string as constructor arguments::
 
         // when set, all keys prefixed by $namespace can be invalidated by changing
         // this $version string
-        $version = null
+        $version = null,
+
+        // an optional marshaller object used to serialize the cache items before storing them
+        $marshaller = null
     );
 
 .. warning::

--- a/components/cache/adapters/couchbasebucket_adapter.rst
+++ b/components/cache/adapters/couchbasebucket_adapter.rst
@@ -15,8 +15,9 @@ is also available.
     less than 3.0 of the `Couchbase PHP extension`_ is required for this adapter.
 
 This adapter expects a `Couchbase Bucket`_ instance to be passed as the first
-parameter. A namespace and default cache lifetime can optionally be passed as
-the second and third parameters::
+parameter. A namespace, default cache lifetime and
+:ref:`marshaller <cache-component-marshalling>` can optionally be passed as the
+second, third and fourth parameters::
 
     use Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter;
 
@@ -29,7 +30,10 @@ the second and third parameters::
 
         // the default lifetime (in seconds) for cache items that do not define their
         // own lifetime, with a value 0 causing items to be stored indefinitely
-        $defaultLifetime
+        $defaultLifetime,
+
+        // an optional marshaller object used to serialize the cache items before storing them
+        $marshaller = null
     );
 
 Configure the Connection

--- a/components/cache/adapters/couchbasecollection_adapter.rst
+++ b/components/cache/adapters/couchbasecollection_adapter.rst
@@ -15,8 +15,9 @@ is also available.
     greater of the `Couchbase PHP extension`_ is required for this adapter.
 
 This adapter expects a `Couchbase Collection`_ instance to be passed as the first
-parameter. A namespace and default cache lifetime can optionally be passed as
-the second and third parameters::
+parameter. A namespace, default cache lifetime and
+:ref:`marshaller <cache-component-marshalling>` can optionally be passed as the
+second, third and fourth parameters::
 
     use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
 
@@ -29,7 +30,10 @@ the second and third parameters::
 
         // the default lifetime (in seconds) for cache items that do not define their
         // own lifetime, with a value 0 causing items to be stored indefinitely
-        $defaultLifetime
+        $defaultLifetime,
+
+        // an optional marshaller object used to serialize the cache items before storing them
+        $marshaller = null
     );
 
 Configure the Connection

--- a/components/cache/adapters/doctrine_dbal_adapter.rst
+++ b/components/cache/adapters/doctrine_dbal_adapter.rst
@@ -11,8 +11,9 @@ The Doctrine DBAL adapters store the cache items in a table of an SQL database.
 
 The :class:`Symfony\\Component\\Cache\\Adapter\\DoctrineDbalAdapter` requires a
 `Doctrine DBAL Connection`_, or `Doctrine DBAL URL`_ as its first parameter.
-You can pass a namespace, default cache lifetime, and options array as the other
-optional arguments::
+You can pass a namespace, default cache lifetime, options array and
+:ref:`marshaller <cache-component-marshalling>` as the other optional
+arguments::
 
     use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 
@@ -30,7 +31,10 @@ optional arguments::
         $defaultLifetime = 0,
 
         // an array of options for configuring the database table and connection
-        $options = []
+        $options = [],
+
+        // an optional marshaller object used to serialize the cache items before storing them
+        $marshaller = null
     );
 
 .. note::

--- a/components/cache/adapters/filesystem_adapter.rst
+++ b/components/cache/adapters/filesystem_adapter.rst
@@ -13,7 +13,8 @@ a collection of directories on a locally mounted filesystem.
     many other `RAM disk solutions`_ available.
 
 The FilesystemAdapter can optionally be provided a namespace, default cache lifetime,
-and cache root path as constructor parameters::
+cache root path and :ref:`marshaller <cache-component-marshalling>` as
+constructor parameters::
 
     use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
@@ -30,7 +31,10 @@ and cache root path as constructor parameters::
 
         // the main cache directory (the application needs read-write permissions on it)
         // if none is specified, a directory is created inside the system temporary directory
-        $directory = null
+        $directory = null,
+
+        // an optional marshaller object used to serialize the cache items before storing them
+        $marshaller = null
     );
 
 .. warning::

--- a/components/cache/adapters/memcached_adapter.rst
+++ b/components/cache/adapters/memcached_adapter.rst
@@ -15,8 +15,9 @@ is also available.
     greater of the `Memcached PHP extension`_ is required for this adapter.
 
 This adapter expects a `Memcached`_ instance to be passed as the first
-parameter. A namespace and default cache lifetime can optionally be passed as
-the second and third parameters::
+parameter. A namespace, default cache lifetime and
+:ref:`marshaller <cache-component-marshalling>` can optionally be passed as the
+second, third and fourth parameters::
 
     use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 
@@ -30,7 +31,10 @@ the second and third parameters::
         // the default lifetime (in seconds) for cache items that do not define their
         // own lifetime, with a value 0 causing items to be stored indefinitely (i.e.
         // until MemcachedAdapter::clear() is invoked or the server(s) are restarted)
-        $defaultLifetime = 0
+        $defaultLifetime = 0,
+
+        // an optional marshaller object used to serialize the cache items before storing them
+        $marshaller = null
     );
 
 Configure the Connection

--- a/components/cache/adapters/pdo_adapter.rst
+++ b/components/cache/adapters/pdo_adapter.rst
@@ -10,8 +10,9 @@ The PDO adapters store the cache items in a table of an SQL database.
     by calling the ``prune()`` method.
 
 The :class:`Symfony\\Component\\Cache\\Adapter\\PdoAdapter` requires a :phpclass:`PDO`,
-or `DSN`_ as its first parameter. You can pass a namespace,
-default cache lifetime, and options array as the other optional arguments::
+or `DSN`_ as its first parameter. You can pass a namespace, default cache
+lifetime, options array and :ref:`marshaller <cache-component-marshalling>`
+as the other optional arguments::
 
     use Symfony\Component\Cache\Adapter\PdoAdapter;
 
@@ -29,7 +30,10 @@ default cache lifetime, and options array as the other optional arguments::
         $defaultLifetime = 0,
 
         // an array of options for configuring the database table and connection
-        $options = []
+        $options = [],
+
+        // an optional marshaller object used to serialize the cache items before storing them
+        $marshaller = null
     );
 
 The table where values are stored is created automatically on the first call to


### PR DESCRIPTION
This updates #17153 for 6.4 branch and expands the fix to all cache adapters.