### PR TITLE
[Messenger] Document raw Redis stream messages

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -2382,6 +2382,34 @@ under the transport in ``messenger.yaml``:
             ],
         ]);
 
+Adding Messages from External Producers
+.......................................
+
+.. versionadded:: 8.2
+
+    Symfony 8.2 added support for Redis stream entries that define ``body`` and
+    ``headers`` fields directly.
+
+When Messenger sends a message to Redis, it writes a stream entry with a
+``message`` field. That field contains a JSON object with the serialized message
+``body`` and its ``headers``.
+
+External producers can either write that same ``message`` field or write
+``body`` and ``headers`` as separate stream fields:
+
+.. code-block:: terminal
+
+    $ redis-cli XADD messages '*' \
+        body '{"subject":"Hello"}' \
+        headers '{"type":"App\\Message\\Mail"}'
+
+The ``headers`` field is optional, but the default Messenger serializer needs a
+``type`` header to know which message class it should create. If an external
+producer cannot send that header, use a custom serializer for the transport.
+
+When a stream entry contains both formats, the ``message`` field takes
+precedence and Messenger ignores the separate ``body`` and ``headers`` fields.
+
 .. warning::
 
     There should never be more than one ``messenger:consume`` command running with the same


### PR DESCRIPTION
This documents the Redis stream layout accepted by Messenger when messages are produced outside Symfony. It covers the existing `message` field format, the new direct `body` and `headers` fields, the precedence rule and the default serializer's `type` header requirement.

Fixes #22861.
Refs symfony/symfony#65760.

Validation:
- `git diff --check`
- `docker run --rm -v "/home/ousama/repos/symfony-docs":/github/workspace -w /github/workspace oskarstark/doctor-rst:1.78.0 --short --error-format=github --cache-file=/github/workspace/.cache/doctor-rst.cache`