### PR TITLE
[Form] Document when passwords are hashed with hash_property_path

### DIFF
--- a/reference/forms/types/password.rst
+++ b/reference/forms/types/password.rst
@@ -43,6 +43,19 @@ Data passed to the form must be a
 :class:`Symfony\\Component\\Security\\Core\\User\\PasswordAuthenticatedUserInterface`
 object.
 
+The password is hashed after the validation of the form, and only when the
+whole form is valid. This requires the integration with the Validator
+component, which is enabled by default in Symfony applications. In
+:ref:`standalone applications <forms-standalone-setup>`, add the
+``ValidatorExtension`` to the form factory, otherwise the password is never
+hashed.
+
+.. versionadded:: 8.2
+
+    Hashing the password after the validation was introduced in Symfony 8.2.
+    In previous versions, it was hashed right after the submission of the form,
+    without the Validator component being required.
+
 .. warning::
 
     To minimize the risk of leaking the plain password, this option can


### PR DESCRIPTION
Documents the behavior change from symfony/symfony#65794: passwords are now hashed during the `\form.post_validate` event.
Fixes #22874.