### PR TITLE
[Console] Document the temporary bind

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -25,7 +25,8 @@ The ``ConsoleEvents::COMMAND`` Event
 
 **Typical Purposes**: Doing something before any command is run (like logging
 which command is going to be executed), or displaying something about the event
-to be executed.
+to be executed. Note any changes to the input are discarded before the command
+is executed.
 
 Just before executing any command, the ``ConsoleEvents::COMMAND`` event is
 dispatched. Listeners receive a


### PR DESCRIPTION
Application::doRunCommand() has "bind before the console.command event, so the listeners have access to input options/arguments" but that binding is temporary and any changes will be discarded because Application::doRun() runs bind _again_. 

I thought documenting this would be useful.