### PR TITLE
[Security] Fix a standalone "::" breaking the DOCtor-RST job

### DIFF
--- a/security/custom_authenticator.rst
+++ b/security/custom_authenticator.rst
@@ -317,7 +317,7 @@ ASCII-only, lowercase format::
         }
     }
 
-::
+Then, use this badge in your authenticator::
 
     // src/Security/PasswordAuthenticator.php
     namespace App\Security;


### PR DESCRIPTION
The `Lint (DOCtor-RST)` job currently fails on the `7.4`, `8.1` and `8.2` branches themselves, so every pull request opened against them starts red:

```
security/custom_authenticator.rst ✘
Please do not use "::" alone on a line, prefer the full declaration.
```

#22847 enabled the `no_standalone_syntax_element` rule on `6.4` and fixed the occurrences visible from there (`components/phpunit_bridge.rst`, `components/string.rst` and `webhook.rst`). The one in `security/custom_authenticator.rst` was added later, in 8f5409ff0, on a branch `6.4` never saw, so the rule reached `7.4` and above without its fix. `6.4` is green, the three others are not.

As asked in the review of #22847, this introduces the second code block with a sentence instead of adding an explicit `.. code-block:: php` directive, which `no_explicit_use_of_code_block_php` forbids anyway.

DOCtor-RST 1.83.0 reports `All files are valid!` with this change.