### PR TITLE
[Security] Document checking a guest's permissions with isGrantedForUser()

### DIFF
--- a/reference/twig_reference.rst
+++ b/reference/twig_reference.rst
@@ -449,16 +449,21 @@ is_granted_for_user
     {{ is_granted_for_user(user, attribute, subject = null) }}
 
 ``user``
-    **type**: ``object``
+    **type**: ``object`` | ``null``
 ``attribute``
     **type**: ``string``
 ``subject`` *(optional)*
     **type**: ``object``
 
-Returns ``true`` if the user is authorized for the specified attribute.
+Returns ``true`` if the user is authorized for the specified attribute. Pass
+``null`` as the user to check a guest's permissions.
 
 Optionally, an object can be passed to be used by the voter. More information
 can be found in :ref:`security-template`.
+
+.. versionadded:: 8.2
+
+    Support for passing ``null`` as the user was introduced in Symfony 8.2.
 
 link
 ~~~~

--- a/security.rst
+++ b/security.rst
@@ -2600,6 +2600,20 @@ the built-in ``is_granted_for_user()`` helper function:
         <a href="...">Delete</a>
     {% endif %}
 
+Pass ``null`` instead of a user to check what a guest is allowed to do. The
+attribute is voted on with no user and no roles, which is what your voters see
+for a visitor who is not logged in:
+
+.. code-block:: twig
+
+    {% if is_granted_for_user(null, 'view', post) %}
+        {# this post is public #}
+    {% endif %}
+
+.. versionadded:: 8.2
+
+    Support for passing ``null`` as the user was introduced in Symfony 8.2.
+
 Symfony also provides the ``access_decision()`` and ``access_decision_for_user()``
 Twig functions to check authorization and to retrieve the reasons for denying
 permission in :ref:`your custom security voters <creating-the-custom-voter>`:
@@ -2668,6 +2682,18 @@ want to include extra details only for users that have a ``ROLE_SALES_ADMIN`` ro
     If you need to check authorization for a different user or when the user session
     is unavailable (e.g., in a CLI context such as a message queue or cron job), you
     can use the ``isGrantedForUser()`` method to explicitly set the target user.
+
+    Passing ``null`` as the user checks a guest's permissions instead. This
+    differs from ``isGranted()`` with nobody logged in: ``isGrantedForUser()``
+    never reads the token storage, so it answers the same way in a CLI context
+    as it does during a request::
+
+        // is this post readable by someone who is not logged in?
+        $this->security->isGrantedForUser(null, 'view', $post);
+
+    .. versionadded:: 8.2
+
+        Support for passing ``null`` as the user was introduced in Symfony 8.2.
 
 You can also use the ``getAccessDecision()`` and ``getAccessDecisionForUser()``
 methods to check authorization and retrieve the reasons for denying


### PR DESCRIPTION
Fix #22900

Documents the guest support added to `isGrantedForUser()` in symfony/symfony#61938.

Three places, since the feature spans both APIs: the Twig section of `security.rst`, the `isGrantedForUser()` tip in the same page, and the `is_granted_for_user` entry of the Twig reference where the `user` argument was typed `object`.

The PHP note says what the feature actually buys, which is not obvious from the signature alone: passing `null` is not the same as calling `isGranted()` with nobody logged in. `isGrantedForUser()` builds an offline token and never touches the token storage, so it answers identically in a CLI context and during a request. That is the reason the method exists, and it now covers guests too.

The new Twig block is `twig` rather than `html+twig`, since it contains no HTML; DOCtor-RST flags the opposite. The two failures it reports on `mailer.rst` and `components/console/events.rst` are already there on 8.2, I checked against the branch without this change.
