### PR TITLE
[Form] Document the AsFormType and FormField attributes

### DIFF
--- a/forms.rst
+++ b/forms.rst
@@ -482,10 +482,14 @@ pass a service, use a reference::
     use Symfony\Component\DependencyInjection\Reference;
     // ...
 
-    #[FormField(ChoiceType::class, [
-        'choice_loader' => new Reference(TagChoiceLoader::class),
-    ])]
-    public array $tags = [];
+    #[AsFormType]
+    class PostDto
+    {
+        #[FormField(ChoiceType::class, [
+            'choice_loader' => new Reference(TagChoiceLoader::class),
+        ])]
+        public array $tags = [];
+    }
 
 Literal values stay literal, so a ``%`` sign in an option isn't mistaken for a
 container parameter.

--- a/forms.rst
+++ b/forms.rst
@@ -421,6 +421,97 @@ the ``data_class`` option by adding the following to your form type class::
         }
     }
 
+.. _form-attributes:
+
+Defining Forms with Attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``#[AsFormType]`` and ``#[FormField]`` attributes were introduced in
+    Symfony 8.2.
+
+For a form that only lists fields, you can skip the form type class and declare
+the form on the class that holds the data::
+
+    // src/Dto/UserDto.php
+    namespace App\Dto;
+
+    use Symfony\Component\Form\Attribute\AsFormType;
+    use Symfony\Component\Form\Attribute\FormField;
+    use Symfony\Component\Form\Extension\Core\Type\EmailType;
+    use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+    #[AsFormType(options: ['label' => 'User'])]
+    class UserDto
+    {
+        // the type is guessed, exactly as it is by FormBuilderInterface::add()
+        #[FormField]
+        public ?string $name = null;
+
+        #[FormField(EmailType::class)]
+        public ?string $email = null;
+
+        #[FormField(TextareaType::class, ['label' => 'Bio'])]
+        public ?string $bio = null;
+
+        // the field is named "publicName" in the form and mapped back to
+        // $internalName through the "property_path" option
+        #[FormField(name: 'publicName')]
+        public ?string $internalName = null;
+    }
+
+The class name is then used wherever a form type name is expected::
+
+    $form = $this->createForm(UserDto::class, $user);
+
+The ``data_class`` option is implied by the class itself and cannot be set in
+``#[AsFormType]``. When a class carrying ``#[AsFormType]`` extends another one
+that also carries it, the closest such ancestor becomes the parent type and its
+fields are inherited; otherwise the parent is ``FormType``.
+
+The attributes are read when the container is compiled, so a field type that
+doesn't exist, a duplicate field name, or ``name`` combined with a
+``property_path`` option all fail at compile time rather than on the first
+request. The class must be discovered by the service container: a class living
+in a directory excluded from your service configuration is not seen.
+
+Because options are compiled, their values must be scalars, arrays or enums. To
+pass a service, use a reference::
+
+    use Symfony\Component\DependencyInjection\Reference;
+    // ...
+
+    #[FormField(ChoiceType::class, [
+        'choice_loader' => new Reference(TagChoiceLoader::class),
+    ])]
+    public array $tags = [];
+
+Literal values stay literal, so a ``%`` sign in an option isn't mistaken for a
+container parameter.
+
+This is meant for forms that only describe fields. Anything behavioral, such as
+form events, data transformers or fields computed at runtime, belongs in a
+:doc:`form type extension </form/create_form_type_extension>` targeting the data
+class, which keeps full access to dependency injection::
+
+    class UserDtoExtension extends AbstractTypeExtension
+    {
+        public static function getExtendedTypes(): iterable
+        {
+            yield UserDto::class;
+        }
+
+        public function buildForm(FormBuilderInterface $builder, array $options): void
+        {
+            // ...
+        }
+    }
+
+The derived type keeps the data class as its identity, so type extensions, the
+profiler and ``debug:form`` all refer to it by class name, and ``debug:form``
+lists them in a "Data class form types" section.
+
 .. _form-property-path:
 
 Mapping Fields to Object Properties


### PR DESCRIPTION
Fix #22885

Documents the `#[AsFormType]` and `#[FormField]` attributes added in symfony/symfony#60563.

The section sits right after "Creating Form Classes", since it's the alternative to writing one, and before "Mapping Fields to Object Properties", which the `name` argument leans on.

It follows the list @nicolas-grekas wrote under "For the documentation" in the feature PR: the two attributes and their arguments, type guessing when the type is null, `name` and its interaction with `property_path`, the compile-time restriction on option values with `Reference` as the way out, inheritance through the closest attributed ancestor, and the fact that a class in a directory excluded from the service configuration is never seen.

Two points I made explicit because they are what a reader will trip on rather than what the signatures say:

- **Errors surface when the container is compiled**, not on the first request. A field type that doesn't exist, a duplicate field name or `name` together with `property_path` all fail at compile time.
- **This is for forms that only describe fields.** Anything behavioral belongs in a type extension targeting the data class, which works because the derived type keeps the class as its identity. The section says so and links to the type extension page rather than leaving readers to discover the limit on their own.

I dropped a `:ref:` to `debug:form` I had first written: there is no `debug-forms` anchor in the docs, so it would have broken the build. The command is mentioned in literal instead.

Checked locally: DOCtor-RST reports nothing on `forms.rst` (the two failures it finds on `mailer.rst` and `components/console/events.rst` are already on 8.2), and the docs build with `_build/build.php` renders the section and resolves the link to the type extension page.

---

**About the two red checks.**

`Code Blocks` reported a real mistake of mine, now fixed in 58ab3ce: the `Reference` example showed a property with its attribute but no enclosing class, so the snippet did not parse. All four PHP blocks of the section are checked with `php -l` now.

The two "Missing class" errors it also reports, on `Symfony\Component\Form\Attribute\AsFormType` and `FormField`, are not fixable from here. The checker builds its application from `symfony-tools/symfony-application`, whose `composer.json` asks for `8.2.*` with `prefer-stable: true`; since 8.2 has no stable release yet, the job installs `symfony/form v8.1.6` and cannot see any class introduced in 8.2. Every 8.2 documentation pull request showing a new class hits it, #22881, #22890, #22796 and #22898 among them.

`Lint (DOCtor-RST)` is red on the 8.2 branch itself, from two one-line slips in yesterday's commits. #22910 fixes both, after which the linter reports `[OK] All files are valid!`.