### PR TITLE
Fix the two DOCtor-RST failures on 8.2

### DIFF
--- a/components/console/events.rst
+++ b/components/console/events.rst
@@ -1,4 +1,4 @@
-fUsing Events
+Using Events
 ============
 
 The Application class of the Console component allows you to optionally hook

--- a/mailer.rst
+++ b/mailer.rst
@@ -2011,7 +2011,7 @@ The following transports only support tags:
 * MailPace
 * Resend
 
-.. versionadded::
+.. versionadded:: 8.2
 
     Tag support for ``MailerSend`` was introduced in Symfony 8.2.
 


### PR DESCRIPTION
`DOCtor-RST` currently fails on 8.2, so every open pull request shows a red lint. Two one-line slips, both from yesterday's commits:

- `mailer.rst`: the `.. versionadded::` added in 92c6937c6 carries no version, which trips three rules at once (`versionadded_directive_should_have_version`, the numeric check, and the minimum-version check). The version is in the sentence right below it, so it is simply `8.2`.
- `components/console/events.rst`: the title became `fUsing Events` in cae3ca2a0, so it no longer matches its underline.

With both fixed, `DOCtor-RST` reports `[OK] All files are valid!` on the branch. Checked with the same image the CI uses, against `.doctor-rst.yaml`.

I came across the first one while looking at #22866, which asks to document tag support for MailerSend: that is already done on 8.2 by the commit above, only the directive was malformed. Leaving the issue for you to close, since the documentation came from your commit rather than this one.
