### PR TITLE
[Messenger] Document exiting immediately on a second SIGINT

### DIFF
--- a/messenger.rst
+++ b/messenger.rst
@@ -1053,6 +1053,18 @@ If you install the `PCNTL`_ PHP extension in your project, workers will handle
 the ``SIGTERM`` or ``SIGINT`` POSIX signals to finish processing their current
 message before terminating.
 
+Sending ``SIGINT`` a second time, by pressing ``Ctrl+C`` again, stops
+``messenger:consume`` and ``messenger:failed:retry`` immediately instead of
+waiting for the current message. The command then exits with code ``130``,
+unless something else already set an exit code. This is useful while developing,
+when a handler takes long enough that waiting for it is not worth it; in
+production, let the first signal do its work so the message is not left
+half-processed.
+
+.. versionadded:: 8.2
+
+    Exiting immediately on a second ``SIGINT`` was introduced in Symfony 8.2.
+
 However, you might prefer to use different POSIX signals for graceful shutdown.
 You can override default ones by setting the ``framework.messenger.stop_worker_on_signals``
 configuration option:


### PR DESCRIPTION
Fix #22899

Documents the second-`SIGINT` behaviour added in symfony/symfony#65633, in the "Graceful Shutdown" section right after the paragraph it qualifies.

Two details taken from the implementation rather than the feature description, because they are what a reader needs:

- the exit code is `130` (`128 + SIGINT`), unless a previous handler already set one;
- it covers `messenger:failed:retry` as well as `messenger:consume`, since both commands got the change.

I also spelled out when *not* to use it: the second signal skips the graceful stop, so a message can be left half-processed. That is fine while developing and is exactly what you don't want in production.
