### PR TITLE
[Security] Document the current_user() expression function

### DIFF
--- a/reference/constraints/Expression.rst
+++ b/reference/constraints/Expression.rst
@@ -243,6 +243,39 @@ in your expression:
 You also have access to the ``is_valid()`` function in your expression. This function
 checks that the data passed to the function doesn't raise any validation violations.
 
+When the :doc:`Security component </security>` is available, you can also use the
+``is_granted()``, ``is_authenticated()``, ``is_fully_authenticated()``,
+``is_remember_me()`` and ``current_user()`` functions to condition the validation
+on the current authorization state, like in :ref:`Twig templates <security-template>`::
+
+    // src/Entity/BlogPost.php
+    namespace App\Entity;
+
+    use Symfony\Component\Validator\Constraints as Assert;
+
+    #[Assert\Expression(
+        'is_granted("ROLE_ADMIN") or this.getAuthor() == current_user()',
+        message: 'Only an admin can edit somebody else\'s post.',
+    )]
+    class BlogPost
+    {
+        // ...
+    }
+
+.. note::
+
+    Outside of an authorization check there is no ``token`` variable to read, so
+    these functions use the security services instead. They therefore throw a
+    ``LogicException`` when the expression is evaluated outside of a request, such
+    as in a console command or a message worker, rather than silently reporting
+    that nobody is authenticated. For the same reason they cannot be used in an
+    expression that is compiled rather than evaluated.
+
+.. versionadded:: 8.2
+
+    The security functions were made available in validator expressions in Symfony 8.2.
+    The ``current_user()`` function was added to them in the same version.
+
 .. include:: /reference/constraints/_groups-option.rst.inc
 
 ``message``

--- a/reference/constraints/When.rst
+++ b/reference/constraints/When.rst
@@ -198,6 +198,27 @@ applied but the constraints defined in ``otherwise`` option (if provided) will b
     object that provides information such as the currently validated class, the
     name of the currently validated property, the list of violations, etc.
 
+The expression can also call the
+:ref:`security functions <reference-constraint-expression-option>` that the
+``Expression`` constraint documents, which is how a constraint is made to apply only
+to some users::
+
+    class Discount
+    {
+        #[Assert\When(
+            expression: 'not is_granted("ROLE_ADMIN")',
+            constraints: [new Assert\LessThan(100)],
+        )]
+        private ?int $value;
+
+        // ...
+    }
+
+.. versionadded:: 8.2
+
+    The security functions were made available in validator expressions in Symfony 8.2.
+    The ``current_user()`` function was added to them in the same version.
+
 **When using a closure**, the first argument is the object being validated.
 
 .. note::

--- a/security/expressions.rst
+++ b/security/expressions.rst
@@ -110,6 +110,13 @@ Additionally, you have access to a number of functions inside the expression:
     second argument with the object where permission is checked on. It's
     equivalent to using the :ref:`isGranted() method <security-isgranted>`
     from the security service.
+``current_user()``
+    Returns the user object of the current token, or ``null`` when nobody is
+    authenticated.
+
+.. versionadded:: 8.2
+
+    The ``current_user()`` function was introduced in Symfony 8.2.
 
 .. sidebar:: ``is_remember_me()`` is different from checking ``IS_AUTHENTICATED_REMEMBERED``
 


### PR DESCRIPTION
Fixes #22924.
Fixes #22706.

Documents `current_user()` from symfony/symfony#65821, plus the part of that PR the ticket title does not mention: the security functions are now registered in the validator expression language, so `Expression` and `When` can call them.

**This supersedes my own #22714.** That PR documents the same functions in the same two files, for the earlier symfony/symfony#63719 which registered them. I did not notice the overlap when I opened this one, sorry about that. Rather than leave you two conflicting PRs, I folded #22714 in here: its `.. note::` framing, its parallel with Twig templates and its link to the Security component are all kept, and this one adds `current_user()` on top. #22714 can be closed.

The behaviour worth spelling out is the fallback: outside an authorization check there is no `token` variable, so the functions read the security services instead. They throw outside a request rather than quietly reporting that nobody is authenticated, and they cannot be used in a compiled expression.
