### PR TITLE
Ignore the DOCtor-RST cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /_build/vendor
 /_build/output
+/.doctor-rst.cache


### PR DESCRIPTION
Running DOCtor-RST locally, the same way the CI workflow invokes it but without its `--cache-file` argument, drops a `.doctor-rst.cache` at the repository root. It is not ignored, so a `git add -A` stages a 140 KB binary. I managed to push one into a PR before noticing, which is what prompted this.

Targeting 6.4 so it merges up rather than needing a commit per branch.

The workflow itself writes to `.cache/doctor-rst.cache`, so that path is not affected. I left it out because local linting is not documented in `contributing/`, so the root file is the one people actually get. Happy to add `/.cache` as well if you prefer to cover both.
