### PR TITLE
[Cache][HttpCache] Replace the forbidden caution directive with a warning

### DIFF
--- a/http_cache/expiration.rst
+++ b/http_cache/expiration.rst
@@ -109,7 +109,7 @@ any other directive, use the ``set()``, ``get()``, ``has()``, ``remove()`` and
     is optional, so a cache that doesn't support it would get no freshness
     information at all.
 
-.. caution::
+.. warning::
 
     The ``#[Cache]`` attribute doesn't provide any option to set targeted
     directives, so you must set them on the ``Response`` object. Also,


### PR DESCRIPTION
The ``caution`` directive is forbidden by ``.doctor-rst.yaml``, so the lint job currently fails on every pull request opened against 8.2.