### PR TITLE
[HttpClient] Fixing `Accept-Encoding` error

### DIFF
--- a/http_client.rst
+++ b/http_client.rst
@@ -1095,7 +1095,7 @@ the remote server support it.
 
 .. warning::
 
-    If you set ``Accept-Encoding`` to e.g. ``gzip``, you will need to handle the
+    If you set ``Accept-Encoding`` to e.g. ``zstd``, you will need to handle the
     decompression yourself.
 
 HTTP/2 Support


### PR DESCRIPTION
Page: https://symfony.com/doc/6.4/http_client.html#http-compression

The current text is certainly wrong, since the paragraph right above it explains the opposite.

I don't know if `zstd` is an appropriate example though.

