### PR TITLE
Move the classes that left FrameworkBundle to their new namespaces

### DIFF
--- a/controller/service.rst
+++ b/controller/service.rst
@@ -291,7 +291,6 @@ The following controllers are automatically allowed:
 
 * Classes using the ``#[AsController]`` attribute;
 * Classes extending ``AbstractController``;
-* The built-in ``TemplateController``;
 * All services tagged with ``controller.service_arguments``.
 
 If you use the ``#[Route]`` attribute on a class, Symfony already registers it

--- a/reference/attributes.rst
+++ b/reference/attributes.rst
@@ -59,11 +59,6 @@ EventDispatcher
 
 * :ref:`AsEventListener <event-dispatcher_event-listener-attributes>`
 
-FrameworkBundle
-~~~~~~~~~~~~~~~
-
-* :ref:`AsRoutingConditionService <routing-matching-expressions>`
-
 HttpKernel
 ~~~~~~~~~~
 
@@ -115,6 +110,8 @@ RemoteEvent
 Routing
 ~~~~~~~
 
+* :ref:`AsRouteLoader <routing-service-route-loaders>`
+* :ref:`AsRoutingConditionService <routing-matching-expressions>`
 * :ref:`DeprecatedAlias <routing-alias-deprecation>`
 * :doc:`Route </routing>`
 

--- a/routing.rst
+++ b/routing.rst
@@ -383,7 +383,7 @@ You can also use these functions:
     First, add the ``#[AsRoutingConditionService]`` attribute or ``routing.condition_service``
     tag to the services that you want to use in route conditions::
 
-        use Symfony\Bundle\FrameworkBundle\Routing\Attribute\AsRoutingConditionService;
+        use Symfony\Component\Routing\Attribute\AsRoutingConditionService;
         use Symfony\Component\HttpFoundation\Request;
 
         #[AsRoutingConditionService(alias: 'route_checker')]
@@ -1675,7 +1675,7 @@ Use the ``RedirectController`` to redirect to other routes and URLs:
         # config/routes.yaml
         doc_shortcut:
             path: /doc
-            controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
+            controller: Symfony\Component\Routing\Controller\RedirectController
             defaults:
                 route: 'doc_page'
                 # optionally you can define some arguments passed to the route
@@ -1696,7 +1696,7 @@ Use the ``RedirectController`` to redirect to other routes and URLs:
 
         legacy_doc:
             path: /legacy/doc
-            controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
+            controller: Symfony\Component\Routing\Controller\RedirectController
             defaults:
                 # this value can be an absolute path or an absolute URL
                 path: 'https://legacy.example.com/doc'
@@ -1707,7 +1707,7 @@ Use the ``RedirectController`` to redirect to other routes and URLs:
         // config/routes.php
         namespace Symfony\Component\Routing\Loader\Configurator;
 
-        use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+        use Symfony\Component\Routing\Controller\RedirectController;
 
         return Routes::config([
             'doc_shortcut' => [

--- a/routing/custom_route_loader.rst
+++ b/routing/custom_route_loader.rst
@@ -109,7 +109,7 @@ Loading Routes
 --------------
 
 The routes in a Symfony application are loaded by the
-:class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\DelegatingLoader`.
+:class:`Symfony\\Component\\Routing\\Loader\\DelegatingLoader`.
 This loader uses several other loaders (delegates) to load resources of
 different types, for instance YAML files or ``#[Route]`` attributes in controller
 files. The specialized loaders implement
@@ -154,6 +154,8 @@ containing :class:`Symfony\\Component\\Routing\\Route` objects.
     Routes loaded this way will be cached by the Router the same way as
     when they are defined in one of the default formats (e.g. YAML, PHP files).
 
+.. _routing-service-route-loaders:
+
 Loading Routes with a Custom Service
 ------------------------------------
 
@@ -190,10 +192,18 @@ of the service whose ID is ``admin_route_loader``. Your service doesn't have to
 extend or implement any special class, but the called method must return a
 :class:`Symfony\\Component\\Routing\\RouteCollection` object.
 
-If you're using :ref:`autoconfigure <services-autoconfigure>`, your class should
-implement the :class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\RouteLoaderInterface`
-interface to be tagged automatically. If you're **not using autoconfigure**,
-tag it manually with ``routing.route_loader``.
+If you're using :ref:`autoconfigure <services-autoconfigure>`, add the
+:class:`Symfony\\Component\\Routing\\Attribute\\AsRouteLoader` attribute to your class
+to have it tagged automatically. If you're **not using autoconfigure**, tag it
+manually with ``routing.route_loader``.
+
+.. versionadded:: 8.2
+
+    The ``#[AsRouteLoader]`` attribute was introduced in Symfony 8.2. In previous
+    versions, classes implemented the
+    ``Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface`` interface
+    instead. Unlike the interface, the attribute is not inherited: a class extending
+    an annotated one must carry it too.
 
 .. note::
 
@@ -313,7 +323,7 @@ Now define a service for the ``ExtraLoader``:
 Notice the tag ``routing.loader``. All services with this *tag* will be marked
 as potential route loaders and added as specialized route loaders to the
 ``routing.loader`` *service*, which is an instance of
-:class:`Symfony\\Bundle\\FrameworkBundle\\Routing\\DelegatingLoader`.
+:class:`Symfony\\Component\\Routing\\Loader\\DelegatingLoader`.
 
 Using the Custom Loader
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/templates.rst
+++ b/templates.rst
@@ -1056,7 +1056,7 @@ Rendering a Template Directly from a Route
 
 Although templates are usually rendered in controllers and services, you can
 render static pages that don't need any variables directly from the route
-definition. Use the special :class:`Symfony\\Bundle\\FrameworkBundle\\Controller\\TemplateController`
+definition. Use the special :class:`Symfony\\Bundle\\TwigBundle\\Controller\\TemplateController`
 provided by Symfony:
 
 .. configuration-block::
@@ -1066,7 +1066,7 @@ provided by Symfony:
         # config/routes.yaml
         acme_privacy:
             path:          /privacy
-            controller:    Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+            controller:    Symfony\Bundle\TwigBundle\Controller\TemplateController
             defaults:
                 # the path of the template to render
                 template:  'static/privacy.html.twig'
@@ -1096,7 +1096,7 @@ provided by Symfony:
         // config/routes.php
         namespace Symfony\Component\Routing\Loader\Configurator;
 
-        use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
+        use Symfony\Bundle\TwigBundle\Controller\TemplateController;
 
         return Routes::config([
             'acme_privacy' => [

--- a/translation.rst
+++ b/translation.rst
@@ -1526,7 +1526,7 @@ Debug Command Exit Codes
 The exit code of the ``debug:translation`` command changes depending on the
 status of the translations. Use the following public constants to check it::
 
-    use Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand;
+    use Symfony\Component\Translation\Command\TranslationDebugCommand;
 
     // generic failure (e.g. there are no translations)
     TranslationDebugCommand::EXIT_CODE_GENERAL_ERROR;


### PR DESCRIPTION
Follows symfony/symfony#65948, which finishes moving out of FrameworkBundle the classes that belong to the components shipping the services that use them. Five of the moved classes are named by applications themselves, so the pages that describe them need the new names.

| page | change |
| --- | --- |
| `templates.rst` | `TemplateController` is now `Symfony\Bundle\TwigBundle\Controller\TemplateController` |
| `routing.rst` | `RedirectController` is now `Symfony\Component\Routing\Controller\RedirectController`, and `AsRoutingConditionService` now lives in `Symfony\Component\Routing\Attribute` |
| `routing/custom_route_loader.rst` | route loaders use the new `#[AsRouteLoader]` attribute instead of implementing `RouteLoaderInterface`; `DelegatingLoader` is now `Symfony\Component\Routing\Loader\DelegatingLoader` |
| `translation.rst` | the `debug:translation` exit-code constants come from `Symfony\Component\Translation\Command\TranslationDebugCommand` |
| `reference/attributes.rst` | `AsRoutingConditionService` moves from the FrameworkBundle group to Routing, and `AsRouteLoader` is added |
| `controller/service.rst` | drops the `TemplateController` bullet from the allowed-controller list |

Two of these are more than a rename.

**`#[AsRouteLoader]` replaces `RouteLoaderInterface`**, so the page gains a `versionadded` note. It also spells out the one behaviour difference: an attribute is not inherited where the interface was, so a class extending an annotated one has to carry it too.

**`TemplateController` now carries `#[AsController]`**, which the controller resolver allows by default. That makes its bullet in the allowed-controller list redundant with the `#[AsController]` bullet directly above it, so the bullet goes.

The old service ids that route definitions reference, `Symfony\Bundle\FrameworkBundle\Controller\RedirectController` and `...\TemplateController`, keep working as deprecated aliases, so nothing here is urgent for readers on 8.2.

I also added a `routing-service-route-loaders` label to `custom_route_loader.rst`, since the attribute reference needed something to point at.
