### PR TITLE
[Config][Configuration] Document the APP_RUNTIME_ENV env var

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -600,6 +600,28 @@ and environment (e.g. ``prod``) but change its behavior thanks to the
 configuration based on environment variables (e.g. to run the application in
 different scenarios: staging, quality assurance, client review, etc.)
 
+.. _configuration-runtime-environment:
+
+The ``APP_RUNTIME_ENV`` env var is dedicated to this. It names the place where
+you deploy the application, which is unrelated to the configuration environment
+that the application runs with:
+
+.. code-block:: bash
+
+    # .env (or .env.local)
+
+    # the application runs with the "prod" configuration ...
+    APP_ENV=prod
+
+    # ... but it's deployed on the staging servers
+    APP_RUNTIME_ENV=staging
+
+The :ref:`kernel.runtime_environment <configuration-kernel-runtime-environment>`
+container parameter holds this value. Unlike ``kernel.environment``, Symfony
+resolves it at runtime, so you can deploy the same built application in several
+places. It selects for example which vault to read when
+:doc:`storing sensitive information </configuration/secrets>`.
+
 .. _config-env-vars:
 
 Configuration Based on Environment Variables

--- a/configuration/secrets.rst
+++ b/configuration/secrets.rst
@@ -38,7 +38,9 @@ you're coding locally in the ``dev`` environment, this will create:
     but the ``prod`` decryption key should *never* be committed.
 
 You can generate a pair of cryptographic keys for the ``prod`` environment by
-running:
+running the following command, where the
+:ref:`APP_RUNTIME_ENV <configuration-runtime-environment>` env var selects the
+vault to store the keys in:
 
 .. code-block:: terminal
 

--- a/reference/configuration/kernel.rst
+++ b/reference/configuration/kernel.rst
@@ -301,14 +301,18 @@ have deleted it entirely (for example in the production servers), override the
 
 **type**: ``string`` **default**: ``%env(default:kernel.environment:APP_RUNTIME_ENV)%``
 
-This parameter stores the name of the current :doc:`runtime environment </components/runtime>`
-used by the application.
+This parameter stores the name of the current runtime environment used by the
+application. Define it with the ``APP_RUNTIME_ENV`` env var; when that env var
+is not set, this parameter falls back to the value of ``kernel.environment``.
 
 This value defines the place where the application is deployed, whereas the
 :ref:`kernel.environment <configuration-kernel-environment>` option defines
 the configuration options used to run the application. This allows for example
 to run an application with the ``prod`` config (``kernel.environment``) in different
 scenarios like ``staging`` or ``production`` (``kernel.runtime_environment``).
+Unlike ``kernel.environment``, Symfony resolves this parameter at runtime, so
+you can deploy the same built application in several places. Read more about
+:ref:`selecting the runtime environment <configuration-runtime-environment>`.
 
 ``kernel.runtime_mode``
 -----------------------


### PR DESCRIPTION
`APP_RUNTIME_ENV` and `kernel.runtime_environment` exist since 5.3 but the docs never explain how to set them. The only mentions are the default value of the parameter in the kernel reference, and three command examples in the secrets article that use `APP_RUNTIME_ENV=prod` without saying what it does.

This is the feature that answers "where do I put staging?", which is the very question that makes people create a `staging` configuration environment and then wonder why Symfony environments do not match their deployments (see symfony/symfony#60943).

Changes:

* document the env var in `configuration.rst`, right after the paragraph that already suggests not creating a new environment for that purpose;
* link to it from the secrets article, where the env var first shows up unexplained;
* in the kernel reference, replace the link to the Runtime component, which documents an unrelated concept and says nothing about `APP_RUNTIME_ENV`, and state that the parameter is resolved at runtime.