### PR TITLE
[DependencyInjection][EventDispatcher] Document the before/after ordering constraints

### DIFF
--- a/event_dispatcher.rst
+++ b/event_dispatcher.rst
@@ -345,6 +345,115 @@ can also be applied to methods directly::
     Note that the attribute doesn't require its ``event`` parameter to be set
     if the method already type-hints the expected event.
 
+.. _event-dispatcher_ordering-listeners:
+
+Ordering Event Listeners
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``before`` and ``after`` options of event listeners were introduced in
+    Symfony 8.2.
+
+The ``priority`` option orders all the listeners of an event at once, which
+makes it hard to place a listener next to another one when that other listener
+comes from Symfony itself or from a bundle you don't control. The ``before``
+and ``after`` options name that other listener instead. For example, a listener
+that resolves the locale of the current user has to run before
+``LocaleListener`` applies the ``_locale`` request attribute:
+
+.. configuration-block::
+
+    .. code-block:: php-attributes
+
+        // src/EventListener/UserLocaleListener.php
+        namespace App\EventListener;
+
+        use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+        use Symfony\Component\HttpKernel\Event\RequestEvent;
+        use Symfony\Component\HttpKernel\EventListener\LocaleListener;
+
+        #[AsEventListener(before: LocaleListener::class.'::onKernelRequest')]
+        final class UserLocaleListener
+        {
+            public function __invoke(RequestEvent $event): void
+            {
+                // ...
+            }
+        }
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        services:
+            App\EventListener\UserLocaleListener:
+                tags:
+                    - name: kernel.event_listener
+                      event: kernel.request
+                      before: 'locale_listener::onKernelRequest'
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use App\EventListener\UserLocaleListener;
+        use Symfony\Component\HttpKernel\EventListener\LocaleListener;
+
+        return App::config([
+            'services' => [
+                UserLocaleListener::class => [
+                    'tags' => [
+                        ['kernel.event_listener' => [
+                            'event' => 'kernel.request',
+                            'before' => LocaleListener::class.'::onKernelRequest',
+                        ]],
+                    ],
+                ],
+            ],
+        ]);
+
+Both halves of the target accept a service ID or a class name, so
+``locale_listener::onKernelRequest`` and
+``LocaleListener::class.'::onKernelRequest'`` designate the same listener. The
+``debug:event-dispatcher kernel.request`` command lists the class and the
+method of every listener of that event.
+
+Naming the service alone targets every listener that this service registers on
+the event. ``LocaleListener`` listens to ``kernel.request`` twice, once to set
+the default locale and once to apply the ``_locale`` request attribute, so
+``before: LocaleListener::class`` would place your listener ahead of both,
+whereas naming the method places it between them.
+
+Like the :ref:`ordering constraints of tagged services <tags_before-after>`,
+these options apply on top of the priority order, and Symfony ignores a target
+whose service doesn't listen to that event on that dispatcher. A constraint
+pointing at an optional bundle therefore keeps working when that bundle isn't
+installed, while cyclic constraints throw an exception when compiling the
+container.
+
+The method half is the exception: when the target service listens to the event
+but not with the method you named, compiling the container fails, so a typo in
+a method name never turns into a constraint that does nothing.
+
+Listeners run by descending priority and, at equal priority, in registration
+order. Symfony turns the constraints into a registration order when compiling
+the container and raises the priority of the listener that declares them only
+when a constraint places it ahead of a listener with a higher priority. The
+targeted listener always keeps its own priority.
+
+.. note::
+
+    Raising a priority has a side effect: the listener also runs before every
+    other listener with a priority between the old and the new one, including
+    the listeners added at runtime.
+
+:ref:`Event subscribers <events-subscriber>` like ``LocaleListener`` can be the
+target of a constraint, but they can't declare one because
+``getSubscribedEvents()`` has no place to define it. They are also where naming
+a method matters most, because a subscriber often registers several listeners
+on the same event.
+
 .. _events-subscriber:
 .. _event_dispatcher-using-event-subscribers:
 

--- a/service_container/tags.rst
+++ b/service_container/tags.rst
@@ -641,6 +641,82 @@ you can define it in the configuration of the collecting service:
             ],
         ]);
 
+.. _tags_before-after:
+
+Tagged Services with Ordering Constraints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 8.2
+
+    The ``before`` and ``after`` tag attributes were introduced in Symfony 8.2.
+
+Priorities can't express "place this service between those two" when both of
+them share the same priority and come from a bundle you don't control. The
+``before`` and ``after`` attributes name the other services instead, and
+Symfony works out the resulting order when compiling the container:
+
+.. configuration-block::
+
+    .. code-block:: php-attributes
+
+        // src/Handler/TsvHandler.php
+        namespace App\Handler;
+
+        use Acme\ImportBundle\Handler\CsvHandler;
+        use Acme\ImportBundle\Handler\XlsxHandler;
+        use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+        #[AsTaggedItem(after: CsvHandler::class, before: XlsxHandler::class)]
+        class TsvHandler
+        {
+            // ...
+        }
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+        services:
+            App\Handler\TsvHandler:
+                tags:
+                    - name: 'app.handler'
+                      after: 'Acme\ImportBundle\Handler\CsvHandler'
+                      before: 'Acme\ImportBundle\Handler\XlsxHandler'
+
+    .. code-block:: php
+
+        // config/services.php
+        namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+        use Acme\ImportBundle\Handler\CsvHandler;
+        use Acme\ImportBundle\Handler\XlsxHandler;
+        use App\Handler\TsvHandler;
+
+        return App::config([
+            'services' => [
+                TsvHandler::class => [
+                    'tags' => [
+                        ['app.handler' => [
+                            'after' => CsvHandler::class,
+                            'before' => XlsxHandler::class,
+                        ]],
+                    ],
+                ],
+            ],
+        ]);
+
+Both attributes accept a single service or a list of services. They don't
+replace the ``priority`` attribute: the priority order is the starting point
+and each service moves only as far as its constraints require. ``A before B``
+and ``B after A`` describe the same relation, so declare it on whichever side
+you control.
+
+Symfony matches each target against the service IDs of the collection first
+and against their class names next, which is why ``SomeClass::class`` works for
+services registered through :ref:`autoconfiguration <services-autoconfigure>`.
+Symfony ignores targets that are not part of the collection, so a constraint
+pointing at an optional bundle keeps working when that bundle isn't installed.
+Constraints that form a cycle throw an exception when compiling the container.
+
 .. _tags_index-by:
 
 Tagged Services with Index
@@ -819,9 +895,10 @@ will process them in the following order:
 The ``#[AsTaggedItem]`` Attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is possible to define both the priority and the index of a tagged
-item thanks to the ``#[AsTaggedItem]`` attribute. This attribute must
-be used directly on the class of the service you want to configure::
+It is possible to define the index, the priority and the
+:ref:`ordering constraints <tags_before-after>` of a tagged item thanks to the
+``#[AsTaggedItem]`` attribute. This attribute must be used directly on the
+class of the service you want to configure::
 
     // src/Handler/One.php
     namespace App\Handler;

--- a/translation.rst
+++ b/translation.rst
@@ -1041,9 +1041,9 @@ it::
 .. note::
 
     The custom listener must be called **before** ``LocaleListener``, which
-    initializes the locale based on the current request. To do so, set your
-    listener priority to a higher value than ``LocaleListener`` priority (which
-    you can obtain by running the ``debug:event kernel.request`` command).
+    initializes the locale based on the current request. Use the ``before``
+    option to place it there, as explained in
+    :ref:`Ordering Event Listeners <event-dispatcher_ordering-listeners>`.
 
 Read :ref:`locale-sticky-session` for more information on making the user's
 locale "sticky" to their session.


### PR DESCRIPTION
Documents symfony/symfony#66012, which adds `before` and `after` ordering
constraints for tagged services and for event listeners, resolved at compile
time.

* `service_container/tags.rst`: a new "Tagged Services with Ordering
  Constraints" section next to the priority one, and a pointer to it from the
  `#[AsTaggedItem]` section;
* `event_dispatcher.rst`: a new "Ordering Event Listeners" section next to the
  `#[AsEventListener]` one, covering the `Service::method` form for targeting a
  single registration, when a priority is raised and what that implies for
  listeners added at runtime and for subscribers;
* `translation.rst`: the note about running before `LocaleListener` told readers
  to outrank it by picking a higher priority. Since `LocaleListener` listens to
  `kernel.request` twice, `before: LocaleListener::class.'::onKernelRequest'` is
  now the exact way to land between its two listeners, so the note points at the
  new section instead of the priority hunt.

Thanks @aboks for opening symfony/symfony#64580, the issue the feature comes from.
