### PR TITLE
[Tui] Fix the 8.1 docs where they describe API the component does not have

### DIFF
--- a/tui/cheat_sheet.rst
+++ b/tui/cheat_sheet.rst
@@ -62,8 +62,8 @@ Ctrl+K                        Delete to end of line
 EditorWidget
 ------------
 
-Multi-line text editor with word wrap, scrolling, undo/redo, kill
-ring and autocomplete.
+Multi-line text editor with word wrap, scrolling, undo/redo and a
+kill ring.
 
 **Keyboard:**
 
@@ -73,7 +73,6 @@ Key                           Action
 Enter                         Submit
 Shift+Enter                   Insert newline
 Escape, Ctrl+C                Cancel (or close autocomplete)
-Tab                           Trigger autocomplete
 Shift+Space                   Insert a space
 Up                            Move up (start of first line)
 Down                          Move down (end of last line)
@@ -99,19 +98,6 @@ Ctrl+Shift+Z                  Redo
 Ctrl+Y                        Yank (paste from kill ring)
 Alt+Y                         Yank pop (cycle kill ring)
 ============================  ==============================
-
-**Autocomplete (when the dropdown is open):**
-
-====================  ==============================
-Key                   Action
-====================  ==============================
-Up                    Previous suggestion
-Down                  Next suggestion
-Page Up               Page up through suggestions
-Page Down             Page down through suggestions
-Enter                 Accept suggestion
-Escape                Close dropdown
-====================  ==============================
 
 **Paste:**
 

--- a/tui/cheat_sheet.rst
+++ b/tui/cheat_sheet.rst
@@ -72,7 +72,8 @@ Key                           Action
 ============================  ==============================
 Enter                         Submit
 Shift+Enter                   Insert newline
-Escape, Ctrl+C                Cancel (or close autocomplete)
+Escape                        Cancel
+Ctrl+C                        Left to the application
 Shift+Space                   Insert a space
 Up                            Move up (start of first line)
 Down                          Move down (end of last line)

--- a/tui/getting_started.rst
+++ b/tui/getting_started.rst
@@ -10,11 +10,10 @@ Creating a Tui
 The ``Tui`` class is the entry point for every application. Create
 one, add widgets and run the event loop::
 
-    use Symfony\Component\Tui\Tui;
-    use Symfony\Component\Tui\Widget\TextWidget;
-
     use Symfony\Component\Tui\Event\InputEvent;
     use Symfony\Component\Tui\Input\Keybindings;
+    use Symfony\Component\Tui\Tui;
+    use Symfony\Component\Tui\Widget\TextWidget;
 
     $tui = new Tui();
     $tui->add(new TextWidget('Hello, terminal!'));

--- a/tui/style/style.rst
+++ b/tui/style/style.rst
@@ -143,7 +143,7 @@ Three shortcuts simplify common operations:
 * ``scale($percentage)``: Positive values darken, negative values
   lighten.
 
-::
+For example::
 
     $lighter = Color::named('blue')->tint(40);
     $darker = Color::named('blue')->shade(40);
@@ -275,7 +275,7 @@ Property               Description
 ``flex``               Flex grow (``0`` = intrinsic, ``1+`` = proportional)
 =====================  ===================================================
 
-::
+.. code-block:: php
 
     use Symfony\Component\Tui\Style\Direction;
 

--- a/tui/topics/events.rst
+++ b/tui/topics/events.rst
@@ -96,7 +96,5 @@ Event Types
   keys, scroll).
 * ``SettingChangeEvent``: a setting value changed. Carries the
   setting id and new value.
-* ``TabChangeEvent``: the active tab changed. Carries previous
-  and new indices/ids.
 * ``FocusEvent``: focus moved between widgets. Carries the new
   and previous widget.

--- a/tui/widgets/basics.rst
+++ b/tui/widgets/basics.rst
@@ -99,8 +99,6 @@ The following widgets support vertical expansion:
   automatically; if any child is vertically expanded, the container
   reports itself as expanded too.
 * ``EditorWidget``: grows the editing area to fill available space.
-* ``AnimatedImageWidget``: grows the animation area to fill
-  available space (except in ``ImageScaling::None`` mode).
 
 This is useful for layouts where one section should grow to fill
 the terminal height while others stay at their natural size.
@@ -108,16 +106,16 @@ the terminal height while others stay at their natural size.
 Labels
 ------
 
-Widgets have an optional label, used by container widgets like
-``TabsWidget`` to display a title::
+Widgets have an optional label, which parent widgets can read with
+``getLabel()`` to display a title::
 
     $widget->setLabel('Overview');
 
 Widget Tree
 -----------
 
-Widgets form a tree. Container widgets (``ContainerWidget``,
-``TabsWidget``, etc.) hold child widgets. You can walk up the tree
-with ``getParent()``::
+Widgets form a tree. ``ContainerWidget`` holds the widgets added to
+it, and ``SettingsListWidget`` holds its open submenu. You can walk
+up the tree with ``getParent()``::
 
     $parent = $widget->getParent();

--- a/tui/widgets/editor.rst
+++ b/tui/widgets/editor.rst
@@ -2,7 +2,7 @@ EditorWidget
 ============
 
 ``EditorWidget`` is a full-featured multi-line text editor with word
-wrapping, scrolling, undo/redo, a kill ring and autocomplete support.
+wrapping, scrolling, undo/redo and a kill ring.
 
 When to Use
 -----------
@@ -39,20 +39,6 @@ counts::
 To make the editor fill all remaining vertical space, call::
 
     $editor->expandVertically(true);
-
-Autocomplete
-------------
-
-Attach an autocomplete provider to get context-aware suggestions when
-the user presses **Tab**::
-
-    use Symfony\Component\Tui\Autocomplete\FilePathProvider;
-
-    $editor->setAutocompleteProvider(new FilePathProvider());
-
-The autocomplete dropdown appears inline and can be navigated with
-**Up**/**Down** and confirmed with **Enter**. Press **Escape** to
-dismiss it.
 
 Events
 ------
@@ -93,7 +79,6 @@ Key                           Action
 Enter                         Submit
 Shift+Enter                   Insert newline
 Escape, Ctrl+C                Cancel / close autocomplete
-Tab                           Trigger autocomplete
 Up / Down                     Move cursor or navigate autocomplete
 Left, Ctrl+B                  Move cursor left
 Right, Ctrl+F                 Move cursor right

--- a/tui/widgets/editor.rst
+++ b/tui/widgets/editor.rst
@@ -55,8 +55,7 @@ Events
           $text = $event->getValue();
       });
 
-* ``CancelEvent``: Fired when the user presses **Escape** or
-  **Ctrl+C** (if no autocomplete dropdown is open)::
+* ``CancelEvent``: Fired when the user presses **Escape**::
 
       $editor->onCancel(function () {
           // discard changes or close the editor
@@ -78,17 +77,19 @@ Key                           Action
 ============================  ==============================
 Enter                         Submit
 Shift+Enter                   Insert newline
-Escape, Ctrl+C                Cancel / close autocomplete
-Up / Down                     Move cursor or navigate autocomplete
+Escape                        Cancel
+Ctrl+C                        Left to the application
+Shift+Space                   Insert a space
+Up / Down                     Move cursor up / down
 Left, Ctrl+B                  Move cursor left
 Right, Ctrl+F                 Move cursor right
-Alt+Left, Ctrl+Left           Move word left
-Alt+Right, Ctrl+Right         Move word right
+Alt+Left, Ctrl+Left, Alt+B    Move word left
+Alt+Right, Ctrl+Right, Alt+F  Move word right
 Home, Ctrl+A                  Move to line start
 End, Ctrl+E                   Move to line end
 Page Up / Page Down           Scroll by page
-Backspace                     Delete character backward
-Delete, Ctrl+D                Delete character forward
+Backspace, Shift+Backspace    Delete character backward
+Delete, Ctrl+D, Shift+Delete  Delete character forward
 Ctrl+W, Alt+Backspace         Delete word backward
 Alt+D, Alt+Delete             Delete word forward
 Ctrl+Shift+K                  Delete entire line

--- a/tui/widgets/select_list.rst
+++ b/tui/widgets/select_list.rst
@@ -47,9 +47,10 @@ than the visible window.
 Filtering
 ---------
 
-Call ``setFilter()`` to narrow the list to items whose value starts
-with the given string. This is useful when combining a
-``SelectListWidget`` with an :doc:`/tui/widgets/input` for fuzzy search::
+Call ``setFilter()`` to narrow the list to items whose ``value``
+starts with the given string, ignoring case. The match is done on
+``value``, not on the ``label`` shown on screen. This is useful when
+combining a ``SelectListWidget`` with an :doc:`/tui/widgets/input`::
 
     $list->setFilter('ban'); // shows only "Banana"
 


### PR DESCRIPTION
Javier asked for this in #22569 back on 12 August: merge #22201 first, then one follow-up to fix things in 8.1 and a separate one to add the 8.2 features. This is the first of the two, and nothing here touches 8.2.

#22201 landed as it was written, so several pages still describe things this branch does not have. I went through each of them against `symfony/symfony` 8.1 (`49b2223`) and 8.2 (`084d243`):

* the editor's autocomplete. There is no `Autocomplete/` directory in the component, and `grep -ri autocomplete` over it minus `Tests/` returns nothing in either branch, so `Tui\Autocomplete\FilePathProvider`, `EditorWidget::setAutocompleteProvider()`, the `Tab` binding and the dropdown key table in the cheat sheet all document something that was never released.
* `TabsWidget`, `TabItem`, `TabPosition` and `TabChangeEvent`. These do exist, but only in 8.2, so `basics.rst` and the event list in `events.rst` name them one branch too early. I only removed the mentions: documenting the widget belongs to the 8.2 follow-up, and @lacatoire already has #22963 open for it.
* `AnimatedImageWidget` and `ImageScaling::None` in the vertical expansion list. Neither is in 8.1 or in 8.2.

While removing the `Tab` row I compared the rest of the `editor.rst` table with `EditorWidget::getDefaultKeybindings()`, and it disagreed in a few more places. `ctrl+c` is bound to `copy` there and `handleInput()` returns without doing anything with it, so `Escape, Ctrl+C` for cancel is wrong: `select_cancel` is Escape alone. `alt+b`, `alt+f`, `shift+backspace`, `shift+delete` and `shift+space` are bound but were missing from the table. The cheat sheet already listed all five, so the two tables in the same page set disagreed with each other; both now describe the same bindings.

`select_list.rst` calls `setFilter()` useful for fuzzy search. It is `str_starts_with(strtolower($item['value']), strtolower($filter))`: a case-insensitive prefix match, and it only looks at `value` while the list displays `label`. The second half is what I would have wanted documented: an item with `value` `fruit-1` and `label` `Apple` does not match `App`.

The first commit is unrelated to the rest. `8.1` is currently red on DOCtor-RST and both files it reports are in `tui/`: `getting_started.rst` has a `use` block split by a blank line, which the linter reads as one unsorted block, and `style.rst` has two bare `::` markers. Every run on the branch has failed since #22201 was merged. It is three violations in two files, so I put the fix first here instead of opening a separate PR, though I am happy to split it out. One side effect worth naming: reordering that `use` block changes the hash the code block checker keys its baseline on, so that job now reports two of its pre-existing `Missing class` errors as new. Both are about Tui classes the test application does not ship, and the job does not block the merge.

Part of this @lacatoire had already fixed in #22569, commit efc82f9. That PR was closed as a duplicate once #22201 landed, so none of it reached 8.1. The base and the file contents differ enough that cherry-picking was not practical, so the diff here is written from scratch.

One thing I could not settle: autocomplete is missing from 8.2 as well, so I removed it instead of leaving it for the 8.2 follow-up. The only trace of the feature left in the component is a docblock in `Tests/Widget/EditorTest.php` describing an autocomplete regression, and it now sits above a test for undo, which reads like the feature was dropped shortly before the merge. If it is still planned, a stub would be better than a deletion, but I cannot tell that from the outside.
