### PR TITLE
[Validator] Document that an uncaught ValidationFailedException renders as a 422 response

### DIFF
--- a/validation.rst
+++ b/validation.rst
@@ -272,6 +272,20 @@ when :ref:`validating OptionsResolver values <optionsresolver-validate-value>`):
 :method:`Symfony\\Component\\Validator\\Validation::createIsValidCallable`
     This returns a closure that returns ``false`` when the constraints aren't matched.
 
+When a ``ValidationFailedException`` is thrown while handling a request and
+nothing catches it, for example when one of these closures fails in a
+controller, Symfony turns it into a 422 Unprocessable Content response, like it
+does for :ref:`the mapped request payload <controller-mapping-request-payload>`.
+When the error is rendered in a format supported by the Serializer, such as
+JSON, the response also lists the constraint violations. Use the
+:ref:`framework.exceptions <framework_exceptions>` option to return another
+status code.
+
+.. versionadded:: 8.2
+
+    Turning an uncaught ``ValidationFailedException`` into a 422 response was
+    introduced in Symfony 8.2.
+
 Validating Properties
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fix #22980

Documents symfony/symfony#66000: an uncaught `ValidationFailedException` thrown while handling a request now renders as a 422 response instead of a 500 one, with the violations listed when the error is rendered by the Serializer (JSON, XML...). The `framework.exceptions` option still wins over the attribute. `Messenger\Exception\ValidationFailedException` is a separate class and is not affected, so the Messenger docs are left untouched.
